### PR TITLE
New package: Videoclinic.DMSDesktop version 0.1.0

### DIFF
--- a/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.installer.yaml
+++ b/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Videoclinic.DMSDesktop
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallModes:
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/videoclinic/dms/releases/download/v0.1.0/DMS_Desktop_0.1.0_x64-setup.exe
+  InstallerSha256: d78de0ca7d5f3e720b550f83499c48fb1af151f56fb42c83daafb111969e8690
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.locale.en-US.yaml
+++ b/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Videoclinic.DMSDesktop
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Videoclinic
+PublisherUrl: https://videoclinic.de/
+PrivacyUrl: https://github.com/videoclinic/dms/blob/main/docs/privacy.md
+PackageName: DMS Desktop
+PackageUrl: https://github.com/videoclinic/dms
+License: MIT
+LicenseUrl: https://github.com/videoclinic/dms/blob/main/LICENSE
+ShortDescription: Operator-controlled document control for ISO 27001-style workflows.
+Moniker: dms-desktop
+Tags:
+- document-management
+- iso-27001
+- compliance
+- tauri
+ReleaseNotesUrl: https://github.com/videoclinic/dms/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.yaml
+++ b/manifests/v/Videoclinic/DMSDesktop/0.1.0/Videoclinic.DMSDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Videoclinic.DMSDesktop
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the initial multi-file manifest set for `Videoclinic.DMSDesktop` version `0.1.0`.

- Release installer: https://github.com/videoclinic/dms/releases/download/v0.1.0/DMS_Desktop_0.1.0_x64-setup.exe
- Installer SHA-256: `d78de0ca7d5f3e720b550f83499c48fb1af151f56fb42c83daafb111969e8690`
- Installer type: NSIS (`nullsoft`), x64

## Verification

- [x] Searched upstream for an existing `Videoclinic.DMSDesktop` PR.
- [x] This PR contains exactly one package version and only its three manifests.
- [x] Validated all manifests against the official winget 1.12 JSON schemas.
- [x] Confirmed the manifest hash against the live GitHub Release asset and its `.sha256` sidecar.
- [x] Publisher tested the NSIS installer on Windows before release.
- [ ] `winget validate` is unavailable in this WSL submission environment; upstream validation is requested.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420554)