### PR TITLE
New package: Slohmaier.StarTooth version 1.0.0

### DIFF
--- a/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.installer.yaml
+++ b/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Slohmaier.StarTooth
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/slohmaier/StarTooth/releases/download/1.0.0/StarTooth-Setup-1.0.0.exe
+  InstallerSha256: 7426A0F17134D2EE1C4A851601B41D5C492B0D0DF77F589F4D384F262FE1647B
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.locale.en-US.yaml
+++ b/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Slohmaier.StarTooth
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Stefan Lohmaier
+PublisherUrl: https://github.com/slohmaier
+PublisherSupportUrl: https://github.com/slohmaier/StarTooth/issues
+Author: Stefan Lohmaier
+PackageName: StarTooth
+PackageUrl: https://github.com/slohmaier/StarTooth
+License: MIT
+LicenseUrl: https://github.com/slohmaier/StarTooth/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Stefan Lohmaier
+ShortDescription: System tray Bluetooth device list and manager with starred favourites.
+Description: StarTooth is a Windows system tray tool that lists every paired Bluetooth device and connects or disconnects it with a click. The device list shows connected and available devices; starred favourites sit at the top, with everything else grouped below under "Other devices". Settings cover language, colour mode and autostart.
+Moniker: startooth
+Tags:
+- bluetooth
+- system-tray
+- tray
+- bluetooth-devices
+- device-list
+- devices
+- connect
+- disconnect
+- favourite
+- favorites
+- pair
+- wireless
+ReleaseNotesUrl: https://github.com/slohmaier/StarTooth/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.yaml
+++ b/manifests/s/Slohmaier/StarTooth/1.0.0/Slohmaier.StarTooth.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Slohmaier.StarTooth
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adding the initial version of **Slohmaier.StarTooth** (1.0.0) to the Windows Package Manager repository.

- **Publisher:** Stefan Lohmaier
- **App:** StarTooth, a Windows system tray Bluetooth device list and manager with starred favourites
- **Installer:** Inno Setup, per-machine (machine scope), silent install supported
- **Signed:** Authenticode-signed (Certum cloud cert)
- **x64** only, Windows 10 build 19041+

- [x] User-facing metadata applied (description, tags, logos)
- [x] Has been verified with \winget validate\ (validation passed)
- [x] Has been tested in a sandbox / local environment

URL of the installer: https://github.com/slohmaier/StarTooth/releases/download/1.0.0/StarTooth-Setup-1.0.0.exe
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420565)