### PR TITLE
New version: LucasHenriqueDiniz.SoundDeck version 0.3.0

### DIFF
--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.installer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.3.0
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-19
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.3.0/SoundDeck_0.3.0_x64-setup.exe
+    InstallerSha256: 4EDED259DC3A8CD83EA9F471371EF71FA240257833B58326E6F5CB37A2E8C86F
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.3.0/SoundDeck_0.3.0_x64_en-US.msi
+    InstallerSha256: 0A0E2E6AD12E9B1BB35AD5BCF1F440CF19C8D9C3167F329F32772213C0D57153
+    ProductCode: '{3BB94FBA-6AB3-4A10-B83B-D19E45AE0016}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Lucas Henrique Diniz Ostroski
+PublisherUrl: https://github.com/LucasHenriqueDiniz
+PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/sounddeck/issues
+PackageName: SoundDeck
+PackageUrl: https://sounddeck.lucashdo.com
+License: MIT
+LicenseUrl: https://github.com/LucasHenriqueDiniz/sounddeck/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski
+ShortDescription: A sound scheme picker for Windows 10 and 11.
+Description: |-
+  SoundDeck replaces the Windows sound scheme editor with a modern app. Browse a
+  library of sound packs, preview every event before committing, and apply a whole
+  scheme in one click. Includes real recreations of the Windows XP, Vista, 7, 8, 98
+  and 10 default schemes, the official Windows 7 bonus themes, Microsoft Plus!
+  packs, two originals, a per-event editor, and local custom pack creation.
+
+  The current scheme is backed up before every change, so any apply is reversible.
+  SoundDeck runs without administrator privileges, never modifies system files, and
+  writes only to the current user's registry hive (HKCU) — the same place the
+  official Control Panel applet uses.
+Moniker: sounddeck
+Tags:
+  - sound
+  - audio
+  - customization
+  - windows
+  - theme
+  - sound-scheme
+  - personalization
+ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.locale.en-US.yaml
@@ -15,9 +15,10 @@ ShortDescription: A sound scheme picker for Windows 10 and 11.
 Description: |-
   SoundDeck replaces the Windows sound scheme editor with a modern app. Browse a
   library of sound packs, preview every event before committing, and apply a whole
-  scheme in one click. Includes real recreations of the Windows XP, Vista, 7, 8, 98
-  and 10 default schemes, the official Windows 7 bonus themes, Microsoft Plus!
-  packs, two originals, a per-event editor, and local custom pack creation.
+  scheme in one click. Thirty packs are available: the Windows 98, XP, Vista, 7, 8
+  and 10 default schemes, the thirteen Windows 7 bonus themes, the Vista themes and
+  the Microsoft Plus! packs. You can also build your own pack from your own .wav
+  files, and a per-event editor swaps individual sounds.
 
   The current scheme is backed up before every change, so any apply is reversible.
   SoundDeck runs without administrator privileges, never modifies system files, and

--- a/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.yaml
+++ b/manifests/l/LucasHenriqueDiniz/SoundDeck/0.3.0/LucasHenriqueDiniz.SoundDeck.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.SoundDeck
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been verified against the [manifest specification](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

New version: **SoundDeck 0.3.0**

Supersedes #420519 (0.2.1), which I closed — this is the only open
submission for the package.

- Homepage: https://sounddeck.lucashdo.com
- Source: https://github.com/LucasHenriqueDiniz/sounddeck
- License: MIT
- Release: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.3.0

Both installers produced by the release build are included:

| Installer | Type | Scope |
|---|---|---|
| `SoundDeck_0.3.0_x64-setup.exe` | nullsoft | user |
| `SoundDeck_0.3.0_x64_en-US.msi` | wix | machine |

The MSI `ProductCode` was read from the package itself. Both `InstallerSha256`
values were computed from the downloaded release artifacts. The `UpgradeCode`
is pinned and unchanged since 0.1.0, so this installs as an in-place upgrade.

The app requires no administrator privileges, modifies no system files, and
writes only to `HKCU\AppEvents\Schemes\Apps`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420566)