### PR TITLE
Update version: V2Free.ClashVergeForV2free version 2.5.21

### DIFF
--- a/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.installer.yaml
+++ b/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: V2Free.ClashVergeForV2free
+PackageVersion: 2.5.21
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+UpgradeBehavior: install
+FileExtensions:
+- clash
+ProductCode: Clash Verge
+AppsAndFeaturesEntries:
+- ProductCode: Clash Verge
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\Clash Verge"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/fqfqgo/clash-verge-rev/releases/download/v2.5.21/Clash.Verge_2.5.21_x64-setup.exe
+  InstallerSha256: FEC2D75C80CBBDA315BA6283FA6FFF4F4ADC8E6182DC17E8EEBF259FC2E336BD
+- Architecture: arm64
+  InstallerUrl: https://github.com/fqfqgo/clash-verge-rev/releases/download/v2.5.21/Clash.Verge_2.5.21_arm64-setup.exe
+  InstallerSha256: B1E720B6305546AABB25A5EF1AB9D56A16BC2591F1A7E91192BDC4E509B98C99
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.locale.en-US.yaml
+++ b/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: V2Free.ClashVergeForV2free
+PackageVersion: 2.5.21
+PackageLocale: en-US
+Publisher: v2free
+PublisherUrl: https://github.com/fqfqgo/clash-verge-rev
+PublisherSupportUrl: https://github.com/fqfqgo/clash-verge-rev/issues
+PackageName: Clash Verge for v2free
+PackageUrl: https://github.com/fqfqgo/clash-verge-rev
+License: GPL-3.0
+LicenseUrl: https://github.com/fqfqgo/clash-verge-rev/blob/dev/LICENSE
+Copyright: Copyright © 2026 fqfqgo
+ShortDescription: A Clash Meta GUI based on Tauri for v2free
+Description: Clash Verge for v2free - A Clash Meta GUI based on Tauri (Windows, macOS, Linux)
+Tags:
+- clash
+- clash-meta
+- mihomo
+- network
+- proxy
+- vpn
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.locale.zh-CN.yaml
+++ b/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: V2Free.ClashVergeForV2free
+PackageVersion: 2.5.21
+PackageLocale: zh-CN
+Publisher: v2free
+PublisherUrl: https://github.com/fqfqgo/clash-verge-rev
+PublisherSupportUrl: https://github.com/fqfqgo/clash-verge-rev/issues
+PackageName: Clash Verge for v2free
+PackageUrl: https://github.com/fqfqgo/clash-verge-rev
+License: GPL-3.0
+LicenseUrl: https://github.com/fqfqgo/clash-verge-rev/blob/dev/LICENSE
+Copyright: Copyright © 2026 fqfqgo
+ShortDescription: 基于 Tauri 的 Clash Meta GUI（v2free 定制版）
+Description: Clash Verge for v2free - 基于 Tauri 的 Clash Meta GUI（Windows、macOS、Linux）
+Tags:
+- clash
+- clash-meta
+- mihomo
+- vpn
+- 代理
+- 网络
+ReleaseNotesUrl: https://github.com/fqfqgo/clash-verge-rev/releases/tag/v2.5.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.yaml
+++ b/manifests/v/V2Free/ClashVergeForV2free/2.5.21/V2Free.ClashVergeForV2free.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: V2Free.ClashVergeForV2free
+PackageVersion: 2.5.21
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update V2Free.ClashVergeForV2free to version 2.5.21.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420577)