### PR TITLE
Add Win-CodexBar 0.53.0

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.53.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+AppsAndFeaturesEntries:
+- DisplayName: CodexBar 0.53.0
+  Publisher: CodexBar Contributors
+  DisplayVersion: 0.53.0
+  ProductCode: WinCodexBar_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.53.0/CodexBar-0.53.0-Setup.exe
+  InstallerSha256: 5B135C24445A33200C1D57D4C29967F0C8FBD36010256E5B3ABC7A2A4355FA75
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-19

--- a/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.53.0
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Windows port of upstream CodexBar 0.52.0 to 0.53.0.
+
+  Ported upstream 0.52.0-0.53.0 cost contracts, provider billing, and spend contract modules onto the Windows tray/desktop shell.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.53.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.53.0/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.53.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version bump for Win-CodexBar from 0.48.0 to 0.53.0.

Installer SHA-256: `5b135c24445a33200c1d57d4c29967f0c8fbd36010256e5b3abc7a2a4355fa75`
Release notes: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.53.0

This is a routine version bump. Only version-specific fields changed: PackageVersion, InstallerUrl, InstallerSha256, DisplayName, DisplayVersion, ReleaseNotes, ReleaseNotesUrl. Package identity and installer behavior remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420587)