### PR TITLE
New version: rulssss.CloudCostTree version 0.1.58

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.58
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.58/cloudcosttree-windows-amd64.exe
+    InstallerSha256: 15F8E3BFF2C4F1601B2F87B4F14B8FDCD7199F583D9446712563F8149AF80A76
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.1.58/cloudcosttree-windows-arm64.exe
+    InstallerSha256: 38EF174FBF66C8F04464ED0B757CC85EF8F50C3C7C7F0F75F0175C91BE7DFAD9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.58
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.1.58/rulssss.CloudCostTree.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.1.58
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update to 0.1.58. Installer URLs verified reachable; InstallerSha256 computed locally against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420675)