### PR TITLE
New package: LucasHenriqueDiniz.Chimer version 0.4.0

### DIFF
--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.installer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.Chimer
+PackageVersion: 0.4.0
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-19
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    Scope: user
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.4.0/Chimer_0.4.0_x64-setup.exe
+    InstallerSha256: 7A84D654883D02EFF208A96D2AF75D861B3E22CDA0D332BFEE2DBB2E80D7E7A2
+  - Architecture: x64
+    InstallerType: wix
+    Scope: machine
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.4.0/Chimer_0.4.0_x64_en-US.msi
+    InstallerSha256: FD1431BEFED26A63EB49CA2FBA23F3468788DDA766383527A8AC6AE58B72DCE7
+    ProductCode: '{CFBAE8A7-33FA-431A-90A8-64BE6CB51EAD}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.installer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.installer.yaml
@@ -12,12 +12,12 @@ Installers:
   - Architecture: x64
     InstallerType: nullsoft
     Scope: user
-    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.4.0/Chimer_0.4.0_x64-setup.exe
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/chimer/releases/download/v0.4.0/Chimer_0.4.0_x64-setup.exe
     InstallerSha256: 7A84D654883D02EFF208A96D2AF75D861B3E22CDA0D332BFEE2DBB2E80D7E7A2
   - Architecture: x64
     InstallerType: wix
     Scope: machine
-    InstallerUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/download/v0.4.0/Chimer_0.4.0_x64_en-US.msi
+    InstallerUrl: https://github.com/LucasHenriqueDiniz/chimer/releases/download/v0.4.0/Chimer_0.4.0_x64_en-US.msi
     InstallerSha256: FD1431BEFED26A63EB49CA2FBA23F3468788DDA766383527A8AC6AE58B72DCE7
     ProductCode: '{CFBAE8A7-33FA-431A-90A8-64BE6CB51EAD}'
 ManifestType: installer

--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
@@ -5,11 +5,11 @@ PackageVersion: 0.4.0
 PackageLocale: en-US
 Publisher: Lucas Henrique Diniz Ostroski
 PublisherUrl: https://github.com/LucasHenriqueDiniz
-PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/sounddeck/issues
+PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/chimer/issues
 PackageName: Chimer
 PackageUrl: https://sounddeck.lucashdo.com
 License: MIT
-LicenseUrl: https://github.com/LucasHenriqueDiniz/sounddeck/blob/master/LICENSE
+LicenseUrl: https://github.com/LucasHenriqueDiniz/chimer/blob/master/LICENSE
 Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski
 ShortDescription: A sound scheme picker for Windows 10 and 11.
 Description: |-
@@ -33,6 +33,6 @@ Tags:
   - theme
   - sound-scheme
   - personalization
-ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.4.0
+ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/chimer/releases/tag/v0.4.0
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
@@ -7,7 +7,7 @@ Publisher: Lucas Henrique Diniz Ostroski
 PublisherUrl: https://github.com/LucasHenriqueDiniz
 PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/chimer/issues
 PackageName: Chimer
-PackageUrl: https://sounddeck.lucashdo.com
+PackageUrl: https://chimer.lucashdo.com
 License: MIT
 LicenseUrl: https://github.com/LucasHenriqueDiniz/chimer/blob/master/LICENSE
 Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski

--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.Chimer
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Lucas Henrique Diniz Ostroski
+PublisherUrl: https://github.com/LucasHenriqueDiniz
+PublisherSupportUrl: https://github.com/LucasHenriqueDiniz/sounddeck/issues
+PackageName: Chimer
+PackageUrl: https://sounddeck.lucashdo.com
+License: MIT
+LicenseUrl: https://github.com/LucasHenriqueDiniz/sounddeck/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Lucas Henrique Diniz Ostroski
+ShortDescription: A sound scheme picker for Windows 10 and 11.
+Description: |-
+  Chimer replaces the Windows sound scheme editor with a modern app. Browse a
+  library of sound packs, preview every event before committing, and apply a whole
+  scheme in one click. Thirty packs are available: the Windows 98, XP, Vista, 7, 8
+  and 10 default schemes, the thirteen Windows 7 bonus themes, the Vista themes and
+  the Microsoft Plus! packs. You can also build your own pack from your own .wav
+  files, and a per-event editor swaps individual sounds.
+
+  The current scheme is backed up before every change, so any apply is reversible.
+  Chimer runs without administrator privileges, never modifies system files, and
+  writes only to the current user's registry hive (HKCU) — the same place the
+  official Control Panel applet uses.
+Moniker: chimer
+Tags:
+  - sound
+  - audio
+  - customization
+  - windows
+  - theme
+  - sound-scheme
+  - personalization
+ReleaseNotesUrl: https://github.com/LucasHenriqueDiniz/sounddeck/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.yaml
+++ b/manifests/l/LucasHenriqueDiniz/Chimer/0.4.0/LucasHenriqueDiniz.Chimer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LucasHenriqueDiniz.Chimer
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- Package: `LucasHenriqueDiniz.Chimer` version 0.4.0
- Installers: NSIS (user scope) and WiX MSI (machine scope), x64
- Manifest validated locally with `winget validate`

Chimer is a sound scheme picker for Windows 10 and 11. It applies a scheme by writing only to `HKCU\AppEvents\Schemes\Apps`, requires no administrator rights and modifies no system files.

The project was previously submitted as `LucasHenriqueDiniz.SoundDeck`; the app has since been renamed to Chimer. Those submissions were never merged, so there are no existing installs to migrate and no package move is required. The most recent one (#420566) has been closed as superseded.

The download URLs still point at the `sounddeck` repository because the repository itself has not been renamed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420722)