### PR TITLE
Update version: OpenCLICollective.gmail-ro version 1.0.27

### DIFF
--- a/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.installer.yaml
+++ b/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.gmail-ro
+PackageVersion: 1.0.27
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gmail-ro.exe
+  PortableCommandAlias: gmail-ro
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-cli-collective/gmail-ro/releases/download/v1.0.27/gmail-ro_v1.0.27_windows_amd64.zip
+  InstallerSha256: BAD6DD28384D1E658C3A85A6DFEAF17F5E695C67FCBA3D3DAF9A160D1353C6DC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.locale.en-US.yaml
+++ b/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.gmail-ro
+PackageVersion: 1.0.27
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PackageName: gmail-ro
+PackageUrl: https://github.com/open-cli-collective/gmail-ro
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/gmail-ro/blob/main/LICENSE
+ShortDescription: Read-only command-line interface for Gmail
+Description: |-
+  A read-only command-line interface for Gmail. Search, read, and view email
+  threads without any ability to modify, send, or delete messages.
+
+  Features:
+  - Read-only access using gmail.readonly OAuth scope
+  - Search messages with full Gmail search syntax support
+  - Read complete message content
+  - View entire conversation threads
+  - JSON output for scripting
+Tags:
+- cli
+- gmail
+- email
+- readonly
+- google
+- oauth
+ReleaseNotesUrl: https://github.com/open-cli-collective/gmail-ro/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.yaml
+++ b/manifests/o/OpenCLICollective/gmail-ro/1.0.27/OpenCLICollective.gmail-ro.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenCLICollective.gmail-ro
+PackageVersion: 1.0.27
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenCLICollective.gmail-ro to version 1.0.27.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420849)