### PR TITLE
Update version: AdGuard.dnsproxy version 0.84.1

### DIFF
--- a/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.installer.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.1
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-386/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.1/dnsproxy-windows-386-v0.84.1.zip
+  InstallerSha256: 9A78ED5386B7963B14FE90E5B40C26AD73C00602A8D08AD352DA978504971173
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-amd64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.1/dnsproxy-windows-amd64-v0.84.1.zip
+  InstallerSha256: 83AF4B4D8B185B93F7B2EB001D30EB93A659E8F5F057C085F662810A76AA87E5
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-arm64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.1/dnsproxy-windows-arm64-v0.84.1.zip
+  InstallerSha256: 6613EB5030185E65EA12AB240E462AE9F36D5A929B6766257A9B467F93B690E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.locale.en-US.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.locale.en-US.yaml
@@ -22,9 +22,9 @@ Tags:
 - open-source
 - proxy
 ReleaseNotes: |-
-  Fixed
-  • Docker image versioning.
-  • AA flag processing.
-ReleaseNotesUrl: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.82.1
+  ### Added
+
+  Package [`dnsproxytest`](https://pkg.go.dev/github.com/AdguardTeam/dnsproxy@v0.84.1/dnsproxytest).
+ReleaseNotesUrl: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.84.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.locale.en-US.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.1
+PackageLocale: en-US
+Publisher: AdGuard
+PublisherUrl: https://adguard.com/
+PublisherSupportUrl: https://github.com/AdguardTeam/dnsproxy/issues
+PackageName: DNS Proxy
+PackageUrl: https://github.com/AdguardTeam/dnsproxy
+License: Apache-2.0
+LicenseUrl: https://github.com/AdguardTeam/dnsproxy/blob/HEAD/LICENSE
+ShortDescription: Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
+Tags:
+- dns
+- dns-over-https
+- dns-over-quic
+- dns-over-tls
+- dnscrypt
+- golang
+- open-source
+- proxy
+ReleaseNotes: |-
+  Fixed
+  • Docker image versioning.
+  • AA flag processing.
+ReleaseNotesUrl: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.82.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.1/AdGuard.dnsproxy.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update AdGuard.dnsproxy to version 0.84.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420855)