### PR TITLE
New package: Wozzardman.Fsize version 1.1.0

### DIFF
--- a/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.installer.yaml
+++ b/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Wozzardman.Fsize
+PackageVersion: 1.1.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- fsize
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: fsize.exe
+    PortableCommandAlias: fsize
+  InstallerUrl: https://github.com/Wozzardman/Fsize/releases/download/v1.1.0/fsize-v1.1.0-windows-x64-portable.zip
+  InstallerSha256: 5F73D24F60D3E2E876209EC3E8DDECCAFB77B954A9B7C24A73A6B0FC50957445
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-19

--- a/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.locale.en-US.yaml
+++ b/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Wozzardman.Fsize
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Wozzardman
+PublisherUrl: https://github.com/Wozzardman
+PublisherSupportUrl: https://github.com/Wozzardman/Fsize/issues
+Author: Wozzardman
+PackageName: fsize
+PackageUrl: https://github.com/Wozzardman/Fsize
+License: MIT
+LicenseUrl: https://github.com/Wozzardman/Fsize/blob/v1.1.0/LICENSE
+ShortDescription: Analyze directory sizes and rank the largest files and folders on Windows.
+Description: A fast native Windows command-line utility for measuring directory sizes, ranking storage consumers, rendering depth scans as readable trees, and producing JSON output for automation.
+Moniker: fsize
+Tags:
+- cli
+- disk
+- disk-usage
+- filesystem
+- storage
+ReleaseNotes: Adds colored ranked output, depth-based tree visualization, JSON output, type filtering, and unreadable-path reporting.
+ReleaseNotesUrl: https://github.com/Wozzardman/Fsize/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.yaml
+++ b/manifests/w/Wozzardman/Fsize/1.1.0/Wozzardman.Fsize.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Wozzardman.Fsize
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Adds `Wozzardman.Fsize` version `1.1.0` as a new WinGet package.

Fsize is a native Windows command-line utility for quickly analyzing directory sizes and identifying the largest files and folders.

Repository: https://github.com/Wozzardman/Fsize

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `manifests\w\Wozzardman\Fsize\1.1.0` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420901)