### PR TITLE
New package: hirovel.Lightee version 0.10.0

### DIFF
--- a/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.installer.yaml
+++ b/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: hirovel.Lightee
+PackageVersion: 0.10.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: 48876e85-d0a7-5ec5-836a-7ab186ad81e9
+ReleaseDate: 2026-08-17
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hirovel/lightee-translator/releases/download/v0.10.0/Lightee-0.10.0-win-x64-setup.exe
+  InstallerSha256: 3C027CE618D07A00FDB0DEFB02AB8E9BE8C6E958A7796D0D1CE1E1D51F633517
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.locale.en-US.yaml
+++ b/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: hirovel.Lightee
+PackageVersion: 0.10.0
+PackageLocale: en-US
+Publisher: hirovel
+PublisherUrl: https://github.com/hirovel
+PublisherSupportUrl: https://github.com/hirovel/lightee-translator/issues
+Author: hirovel
+PackageName: Lightee
+PackageUrl: https://github.com/hirovel/lightee-translator
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/hirovel/lightee-translator/blob/main/LICENSE
+Copyright: Copyright (C) 2026 hirovel
+ShortDescription: An AI agent-assisted translation workbench for Japanese light novels.
+Description: |-
+  Lightee is a local-first desktop workbench for translating Japanese light novels into Chinese.
+  It uses an AI agent workflow to keep terminology consistent across a book, so the machine
+  translation gives translators a usable first pass and they can focus on refinement.
+
+  Features include EPUB and text import, chapter-by-chapter translation, a side-by-side
+  bilingual editor, terminology highlighting and review, and export.
+
+  An API key from an AI provider is required and is entered in the app settings. The key is
+  encrypted with Windows DPAPI and stored locally; it is never written in plain text and never
+  appears in logs. All data is kept in a single folder under %APPDATA%\Lightee.
+Moniker: lightee
+Tags:
+- ai
+- editor
+- epub
+- japanese
+- light-novel
+- llm
+- translation
+- translator
+ReleaseNotesUrl: https://github.com/hirovel/lightee-translator/releases/tag/v0.10.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.locale.zh-CN.yaml
+++ b/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.locale.zh-CN.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+
+PackageIdentifier: hirovel.Lightee
+PackageVersion: 0.10.0
+PackageLocale: zh-CN
+Publisher: hirovel
+PublisherUrl: https://github.com/hirovel
+PublisherSupportUrl: https://github.com/hirovel/lightee-translator/issues
+Author: hirovel
+PackageName: 轻小译 Lightee
+PackageUrl: https://github.com/hirovel/lightee-translator
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/hirovel/lightee-translator/blob/main/LICENSE
+Copyright: Copyright (C) 2026 hirovel
+ShortDescription: AI Agent 辅助翻译的日文轻小说工作台。
+Description: |-
+  用 AI Agent 工作流解决轻小说机翻的术语问题，让 AI 高效打底，译者专注精修。
+
+  支持导入、逐章翻译、双语对照修改、流畅编辑、基础审校、快捷导出。
+
+  翻译需要一个 AI 服务商的 API Key，在设置内填写。Key 经 Windows DPAPI 加密后存在本机，
+  不会明文落盘，也不会出现在日志里。本机数据全部集中在 %APPDATA%\Lightee 一个目录下。
+Tags:
+- ai
+- epub
+- 日语
+- 机器翻译
+- 翻译
+- 轻小说
+ReleaseNotesUrl: https://github.com/hirovel/lightee-translator/releases/tag/v0.10.0
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.yaml
+++ b/manifests/h/hirovel/Lightee/0.10.0/hirovel.Lightee.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: hirovel.Lightee
+PackageVersion: 0.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New package: **hirovel.Lightee** version **0.10.0**

Lightee (轻小译) is an open-source, local-first desktop workbench for translating
Japanese light novels into Chinese, using an AI agent workflow to keep terminology
consistent across a book.

- Homepage: https://github.com/hirovel/lightee-translator
- Release: https://github.com/hirovel/lightee-translator/releases/tag/v0.10.0
- License: AGPL-3.0-only
- Installer: NSIS (electron-builder), per-user scope, x64

I am the author and publisher of this package.

### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the 1.10 schema?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?

**Note on the last item:** local manifest installation requires
`winget settings --enable LocalManifestFiles`, which needs administrator rights that
weren't available in the environment where these manifests were prepared. The installer
itself was tested directly and repeatedly on Windows 11 x64 — silent install (`/S`),
silent uninstall, and full uninstall with `--delete-app-data` — and the `ProductCode`
in the manifest was read from the actual `HKCU` uninstall key created by the installer,
not guessed. The `InstallerSha256` was verified against an anonymous download of the
published release asset. I'll gladly run the local install test if that's preferred
before merge.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/420902)