### PR TITLE
New package: Codemake.DBTool version 1.0.0

### DIFF
--- a/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.installer.yaml
+++ b/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Codemake.DBTool
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/achi777/db-tool/releases/download/v1.0.0/DBTool-Setup-1.0.0.exe
+  InstallerSha256: 7D03575C1B07DC823955BB807AB1681DA2C47D0C75F7584D93602DFCB0DDBD72
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.locale.en-US.yaml
+++ b/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.locale.en-US.yaml
@@ -1,0 +1,43 @@
+PackageIdentifier: Codemake.DBTool
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: CodeMake
+PublisherUrl: https://codemake.co
+PublisherSupportUrl: https://github.com/achi777/db-tool/issues
+PackageName: DBTool
+PackageUrl: https://codemake.co/software
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/achi777/db-tool/blob/main/LICENSE
+Copyright: Copyright (c) 2026 DB Tool
+ShortDescription: A free, open-source desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and SQL Server.
+Description: |-
+  DBTool is a free and open-source desktop database client that connects to PostgreSQL,
+  MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server through a single interface.
+
+  It offers true server-side pagination for large tables, a schema-aware SQL editor with
+  autocomplete, a drag-to-join visual query builder that generates the SELECT for you, a
+  visual table designer with a live DDL preview, editable ER diagrams, cross-engine data
+  transfer, and CSV / JSON / Excel / SQL import and export.
+
+  Connection passwords are stored in the operating system keychain. There is no telemetry,
+  no account, and nothing leaves your machine.
+Moniker: dbtool
+Tags:
+- database
+- database-client
+- database-gui
+- mariadb
+- mysql
+- oracle
+- postgresql
+- sql
+- sql-client
+- sql-editor
+- sqlite
+- sqlserver
+ReleaseNotesUrl: https://github.com/achi777/db-tool/releases/tag/v1.0.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/achi777/db-tool/blob/main/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.yaml
+++ b/manifests/c/Codemake/DBTool/1.0.0/Codemake.DBTool.yaml
@@ -1,0 +1,6 @@
+# Created for DBTool v1.0.0
+PackageIdentifier: Codemake.DBTool
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Codemake.DBTool` version 1.0.0

DBTool is a free, open-source desktop database client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server. Electron + React + TypeScript.

- Homepage: https://codemake.co/software
- Source: https://github.com/achi777/db-tool
- Release: https://github.com/achi777/db-tool/releases/tag/v1.0.0
- License: AGPL-3.0-only

I am the author of this package. The installer is the NSIS build produced by `electron-builder` in the tagged CI release; it is a per-user install and needs no elevation. A `SHA256SUMS.txt` is published alongside every release.

#### Checklist

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? — `Manifest validation succeeded.`
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not run.** Local manifest installs require the one-time elevated `winget settings --enable LocalManifestFiles` opt-in, which I have not enabled on this machine. The installer itself has been installed and run on Windows 11 from the same NSIS build. Happy to run the local-manifest test and report back if that is needed before review.
- [x] Does your manifest conform to the 1.6 manifest schema?

The Microsoft CLA has not been signed yet — I will sign it when the bot prompts on this PR.
