### PR TITLE
Add Mudlet 4.22.0

### DIFF
--- a/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.installer.yaml
+++ b/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Mudlet.Mudlet
+PackageVersion: 4.22.0
+InstallerType: exe
+InstallerSwitches:
+  Silent: /silent
+  SilentWithProgress: /silent
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Mudlet/Mudlet/releases/download/Mudlet-4.22.0/Mudlet-4.22.0-windows-64-installer.exe
+  InstallerSha256: B9F49C8DD96F5CA736D37767DDDE9B4E5CF9D898F77B3DE3186EC46B9089BD39
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-07-06

--- a/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.locale.en-US.yaml
+++ b/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Mudlet.Mudlet
+PackageVersion: 4.22.0
+PackageLocale: en-US
+Publisher: Mudlet
+PackageName: Mudlet
+License: GPL-2.0 license
+Copyright: Copyright 2008-2026, Mudlet Makers
+ShortDescription: A cross-platform, open source, and super fast MUD client with scripting in Lua.
+ReleaseNotesUrl: https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.22.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.yaml
+++ b/manifests/m/Mudlet/Mudlet/4.22.0/Mudlet.Mudlet.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Mudlet.Mudlet
+PackageVersion: 4.22.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary
- Add the Mudlet 4.22.0 manifest for the official x64 Windows installer.
- Replace the retired mudlet.org download endpoint with the GitHub release asset and verified SHA-256.

## Validation
- winget validate --manifest manifests/m/Mudlet/Mudlet/4.22.0

Co-Authored-By: Warp <agent@warp.dev>
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421001)