### PR TITLE
New version: Mozilla.Firefox.ESR.skr version 153.1.0

### DIFF
--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.installer.yaml
@@ -1,0 +1,40 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.ESR.skr
+PackageVersion: 153.1.0
+InstallerType: nullsoft
+Scope: machine
+InstallerSwitches:
+  Silent: /S /PreventRebootRequired=true
+  SilentWithProgress: /S /PreventRebootRequired=true
+  InstallLocation: /InstallDirectoryPath="<INSTALLPATH>"
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+- mailto
+FileExtensions:
+- avif
+- htm
+- html
+- pdf
+- shtml
+- svg
+- webp
+- xht
+- xhtml
+ProductCode: Mozilla Firefox ESR
+ReleaseDate: 2026-08-18
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/153.1.0esr/win32/skr/Firefox%20Setup%20153.1.0esr.exe
+  InstallerSha256: B647EB7CA0A3DAC5317D0A8DCA20EA8C6DEB286CC25D06097B86FF98BDB4C02A
+- Architecture: x64
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/153.1.0esr/win64/skr/Firefox%20Setup%20153.1.0esr.exe
+  InstallerSha256: 38B6CAEFEA8BF017705C04004AFA9362D498EC1ECA36CB6A994794EAA0F00197
+- Architecture: arm64
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/firefox/releases/153.1.0esr/win64-aarch64/skr/Firefox%20Setup%20153.1.0esr.exe
+  InstallerSha256: 5B6CD64BD957D91EF7C641319D60F7627BBEB267A3D6743251665273B1A11B0D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.de-DE.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.de-DE.yaml
@@ -1,0 +1,21 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.ESR.skr
+PackageVersion: 153.1.0
+PackageLocale: de-DE
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/de/
+PublisherSupportUrl: https://support.mozilla.org/de/
+PrivacyUrl: https://www.mozilla.org/de/privacy/websites
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox ESR (skr)
+PackageUrl: https://www.mozilla.org/de/firefox/enterprise/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Holen Sie sich den Firefox Extended Support Release oder Rapid Release für umfassende Datensicherheit und Datenschutz.
+Tags:
+- webbrowser
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.ESR.skr
+PackageVersion: 153.1.0
+PackageLocale: en-US
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/
+PublisherSupportUrl: https://support.mozilla.org/
+PrivacyUrl: https://www.mozilla.org/privacy/firefox/
+Author: Mozilla Foundation
+PackageName: Mozilla Firefox ESR (skr)
+PackageUrl: https://www.mozilla.org/firefox/enterprise/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Get the Firefox Extended Support Release or Rapid Release browser for comprehensive data security and data protection.
+Moniker: firefox-esr
+Tags:
+- browser
+- cross-platform
+- foss
+- gecko
+- quantum
+- spidermonkey
+- web
+- web-browser
+ReleaseNotes: |-
+  Version 153.1.0, first offered to ESR channel users on August 18, 2026
+  Firefox 153 Extended Support Release (ESR) includes all of the enhancements since Firefox 140, along with many new features to make your enterprise deployments easier and even more flexible.
+
+  Fixed
+  - Various security fixes.
+
+  Developer
+
+  - Reference link to ESR 153.0 release notes.
+ReleaseNotesUrl: https://www.firefox.com/en-US/firefox/153.1.0/releasenotes/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.zh-CN.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.ESR.skr
+PackageVersion: 153.1.0
+PackageLocale: zh-CN
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/zh-CN/
+PublisherSupportUrl: https://support.mozilla.org/zh-CN/
+PrivacyUrl: https://www.mozilla.org/zh-CN/privacy/firefox/
+Author: Mozilla 基金会
+PackageName: Mozilla Firefox ESR (skr)
+PackageUrl: https://www.mozilla.org/zh-CN/firefox/enterprise/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: 下载部署 Firefox 延长支持版或快速发行版，获得全面的信息安全和数据保护。
+Tags:
+- mozilla
+- 浏览器
+- 火狐
+- 火狐浏览器
+- 网页浏览器
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.ESR.skr
+PackageVersion: 153.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
@@ -6,3 +6,4 @@ PackageVersion: 153.1.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0
+# CI retry marker (temporary)

--- a/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
+++ b/manifests/m/Mozilla/Firefox/ESR/skr/153.1.0/Mozilla.Firefox.ESR.skr.yaml
@@ -6,4 +6,3 @@ PackageVersion: 153.1.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0
-# CI retry marker (temporary)


### PR DESCRIPTION
## 📖 Description

Adds Mozilla.Firefox.ESR.skr version 153.1.0 using Mozilla's official x86, x64, and ARM64 ESR installers.

Installer URLs returned HTTP 200, and independently calculated SHA-256 hashes match Mozilla's official SHA256SUMS.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421042)