### PR TITLE
New version: Unity.UnityHub version 3.21.0.65535

### DIFF
--- a/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.installer.yaml
+++ b/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.installer.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.21.0.65535
+UpgradeBehavior: install
+Protocols:
+- unityhub
+FileExtensions:
+- unityhub
+ReleaseDate: 2026-08-18
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.21.0
+    DisplayVersion: 3.21.0
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.21.0/UnityHubSetup-3.21.0-x64.exe
+  InstallerSha256: 9E418BDFAE1D5A6C279CD9DD327AF4BC80D5B8B6A75F9A745C5174146221CDD8
+- Architecture: arm64
+  InstallerType: nullsoft
+  Scope: machine
+  MinimumOSVersion: 10.0.10240.0
+  InstallerSwitches:
+    Upgrade: --updated
+  ProductCode: Unity Technologies - Hub
+  AppsAndFeaturesEntries:
+  - DisplayName: Unity Hub 3.21.0
+    DisplayVersion: 3.21.0
+    ProductCode: Unity Technologies - Hub
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.21.0/UnityHubSetup-3.21.0-arm64.exe
+  InstallerSha256: 4AC4BCE4D88CAE5D45BA15B1551200A0377EC497176690B001CF4BBF509F84F8
+- Platform:
+  - Windows.Desktop
+  MinimumOSVersion: 10.0.19043.0
+  Architecture: x64
+  InstallerType: msix
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.21.0/UnityHubSetup-3.21.0-x64.msix
+  InstallerSha256: 2A4CA9BF23B6C43A38C84B2591A822A96CA5A1E25E3215FA49F5381BA2B8285D
+  SignatureSha256: 2A48B80848D36B0F60B4BD6201FA836771AAFEDD63709DA9785F11A487EC61C3
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  RestrictedCapabilities:
+  - runFullTrust
+- Platform:
+  - Windows.Desktop
+  MinimumOSVersion: 10.0.19043.0
+  Architecture: arm64
+  InstallerType: msix
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/3.21.0/UnityHubSetup-3.21.0-arm64.msix
+  InstallerSha256: 77BF19BE8F704D498ABD1BF6E208B8937151CCF37B79EEE1A39B533281A63BC9
+  SignatureSha256: 7F58BF3ABC682ED6D092B120EC6DF0DE5A2E573FCFE39922AA1C3FAE7EB95FB1
+  PackageFamilyName: UnityTechnologies.UnityHub_2vrhnee42bhxm
+  RestrictedCapabilities:
+  - runFullTrust
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.locale.en-US.yaml
+++ b/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.21.0.65535
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity Hub
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Manage multiple installations of the Unity Editor, create new projects, and access your work.
+Description: The Unity Hub is a standalone application that streamlines the way you navigate, download, and manage your Unity projects and installations.
+Tags:
+- unity
+- unity3d
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.locale.zh-CN.yaml
+++ b/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.21.0.65535
+PackageLocale: zh-CN
+PublisherUrl: https://unity.com/cn
+PrivacyUrl: https://unity.com/cn/legal/privacy-policy
+PackageUrl: https://unity.com/cn/unity-hub
+License: 专有软件
+LicenseUrl: https://unity.com/cn/legal/terms-of-service
+CopyrightUrl: https://unity.com/cn/legal/trademarks
+ShortDescription: 管理 Unity 编辑器的多个安装、创建新项目和访问您的工作
+Description: Unity Hub 是一款独立应用程序，简化 Unity 项目和安装的浏览、下载和管理方式。
+Documentations:
+- DocumentLabel: 手册
+  DocumentUrl: https://docs.unity3d.com/hub/manual
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.yaml
+++ b/manifests/u/Unity/UnityHub/3.21.0.65535/Unity.UnityHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.UnityHub
+PackageVersion: 3.21.0.65535
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds Unity Hub 3.21.0 as `PackageVersion: 3.21.0.65535`.

Unity Hub's GA MSIX packages declare `Identity/@Version = X.Y.Z.65535` from 3.21.0 onward (the fourth field encodes our release channel; earlier versions such as 3.20.1 shipped `X.Y.Z.0`). Manifest validation therefore rejects a 3-part `PackageVersion: 3.21.0` as inconsistent with the MSIX identity, which is what blocked #419999:

```
Manifest Error: Inconsistent value in the manifest. [PackageVersion] Value: 3.21.0.65535
```

This submission supersedes #419999 (same release, different `PackageVersion`, so a separate manifest folder): the 4-part `PackageVersion` matches the MSIX identity exactly, the same approach as `Unity.CLI`, `Microsoft.PowerShell` (`7.6.5.0`, also a mixed MSIX + non-MSIX manifest), NanaZip, and FilesCommunity. Because the NSIS installers write the bare `3.21.0` into Add/Remove Programs, the nullsoft entries carry `AppsAndFeaturesEntries.DisplayVersion: 3.21.0` for upgrade correlation (as `Python.Python.3.13` does), alongside the `DisplayName`/`ProductCode` the hand-authored 3.20.1 manifests already carried.

I maintain Unity Hub's releases (previous versions 3.19.5 through 3.20.1 were submitted by me); the installer URLs, hashes, and `SignatureSha256` values are computed directly from the published artifacts.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change (#419999 covers the same release under an invalid 3-part `PackageVersion` and cannot pass validation; this PR supersedes it)
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` 
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421150)