### PR TITLE
Update LoreoInc.Loreo to version 2.0.0

### DIFF
--- a/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.installer.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/farrokh/loreo-releases/releases/download/v2.0.0/Loreo_2.0.0_x64-setup.exe
+    InstallerSha256: 29DF1A295C59DB29CF4555D6D09CA93A3E380E217DF08667D345C00EAED0357F
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.locale.en-US.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Loreo Inc.
+PublisherUrl: https://getloreo.com
+PublisherSupportUrl: https://getloreo.com
+PackageName: Loreo
+PackageUrl: https://getloreo.com
+License: Proprietary
+Copyright: Copyright (c) Loreo Inc.
+ShortDescription: Turns meetings and long-form audio into transcripts and structured notes.
+Moniker: loreo
+Tags:
+  - transcription
+  - meeting-notes
+  - audio
+  - notes
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.0/LoreoInc.Loreo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`? *(authored on macOS — relying on pipeline validation)*
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(authored on macOS — relying on pipeline validation)*
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Version bump for Loreo (publisher: Loreo Inc.), same shape as the 1.9.41 manifests merged in #419972.

- Installer: official Authenticode-signed NSIS x64 setup from the public releases repo
- `InstallerSha256` matches the published release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421248)