### PR TITLE
Update version: GenericMappingTools.gmt version 6.7.0

### DIFF
--- a/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.installer.yaml
+++ b/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GenericMappingTools.gmt
+PackageVersion: 6.7.0
+InstallerType: nullsoft
+ReleaseDate: 2026-07-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GenericMappingTools/gmt/releases/download/6.7.0/gmt-6.7.0-win64.exe
+  InstallerSha256: 33595169E15AF02A45702193FC6E44915C97DA3B1806FCC75FD15A0CB49CE57C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.locale.en-US.yaml
+++ b/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.locale.en-US.yaml
@@ -26,5 +26,15 @@ Tags:
 Documentations:
 - DocumentLabel: Wiki
   DocumentUrl: https://github.com/GenericMappingTools/gmt/wiki
+ReleaseNotes: |-
+  | **File**                       | **Description**                         |  **SHA256 hash**       |
+  |--------------------------------|-----------------------------------------|----------------------|
+  | gmt-6.7.0-checksums.txt     | sha256sum of source and binary packages |    |
+  | gmt-6.7.0-src.tar.gz      | Source code                        | 408da664322b9328f36ef5eb73861e1e945e4ef52e9f2ff0a89eefff1abe9fe4|
+  | gmt-6.7.0-src.tar.xz       | Source code                        | 17c03353839c71a1b11efe4f4e9d5e3f0586a7a7b5f84a298d95ccc35241b001|
+  | gmt-6.7.0-win64.zip      | Source code                        | e2323f204a00b4ddbbbeac644f390da01d8de26fb5dd6fd2d7a8ceff5c412880|
+  | gmt-6.7.0-win64.exe     | Windows installer (64bit)    | 33595169e15af02a45702193fc6e44915c97da3b1806fcc75fd15a0cb49ce57c|
+
+ReleaseNotesUrl: https://github.com/GenericMappingTools/gmt/releases/tag/6.7.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.locale.en-US.yaml
+++ b/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GenericMappingTools.gmt
+PackageVersion: 6.7.0
+PackageLocale: en-US
+Publisher: The GMT Team
+PublisherUrl: https://www.generic-mapping-tools.org
+PublisherSupportUrl: https://github.com/GenericMappingTools/gmt/issues
+PackageName: GMT6
+PackageUrl: https://www.generic-mapping-tools.org
+License: LGPL-3.0-or-later
+LicenseUrl: https://github.com/GenericMappingTools/gmt/blob/master/LICENSE.TXT
+ShortDescription: A diverse community uses GMT to process data, generate publication-quality illustrations, automate workflows, and make animations.
+Description: |-
+  GMT is an open-source collection of command-line tools for manipulating geographic and Cartesian data sets (including filtering, trend fitting, gridding, projecting, etc.) and producing high-quality illustrations ranging from simple x–y plots via contour maps to artificially illuminated surfaces and 3D perspective views.
+  It supports many map projections and transformations and includes supporting data such as coastlines, rivers, and political boundaries and optionally country polygons.
+Moniker: gmt
+Tags:
+- c
+- earth-science
+- generic-mapping-tools
+- geophysics
+- geospatial
+- mapping
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/GenericMappingTools/gmt/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.yaml
+++ b/manifests/g/GenericMappingTools/gmt/6.7.0/GenericMappingTools.gmt.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GenericMappingTools.gmt
+PackageVersion: 6.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update GenericMappingTools.gmt to version 6.7.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421278)