### PR TITLE
Update version: weselow.beads-web version 0.12.2

### DIFF
--- a/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.installer.yaml
+++ b/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.12.2
+InstallerType: portable
+Commands:
+- beads-web
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/weselow/beads-web/releases/download/v0.12.2/beads-web-win-x64.exe
+  InstallerSha256: 3AA5DDCD0309567F9DFFC4B47BF8DE5F03433DC420EFEB64FB09E3AA9A877F68
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.locale.en-US.yaml
+++ b/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.12.2
+PackageLocale: en-US
+Publisher: weselow
+PublisherUrl: https://github.com/weselow
+PublisherSupportUrl: https://github.com/weselow/beads-web/issues
+PackageName: beads-web
+PackageUrl: https://github.com/weselow/beads-web
+License: MIT
+LicenseUrl: https://github.com/weselow/beads-web/blob/main/LICENSE
+ShortDescription: Visual Kanban board and multi-project dashboard for beads task tracking
+Moniker: beads-web
+Tags:
+- kanban
+- beads
+- task-tracker
+- project-management
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.yaml
+++ b/manifests/w/weselow/beads-web/0.12.2/weselow.beads-web.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.12.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update weselow.beads-web to version 0.12.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421283)