### PR TITLE
New version: Aleckstygit.WayCoder version 0.79.89

### DIFF
--- a/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.79.89
+InstallerLocale: zh-CN
+InstallerType: portable
+Commands:
+  - waycoder
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://gitee.com/aleckstygit/my-coder/releases/download/v0.79.89/waycoder-v0.79.89-win-x64.zip
+    InstallerSha256: be7d478c032df15d0ac6a53ac3297f0d8fa3e94098f9a00c8648697075e540d4
+  - Architecture: arm64
+    InstallerUrl: https://gitee.com/aleckstygit/my-coder/releases/download/v0.79.89/waycoder-v0.79.89-win-arm64.zip
+    InstallerSha256: f346c90c8c9d3899a18ff6be0fe1fa3e996dd82c2c0dcba0c0a77ccc8e3adc15
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.locale.zh-CN.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.79.89
+PackageLocale: zh-CN
+Publisher: Aleckstygit
+PublisherUrl: https://gitee.com/aleckstygit/my-coder
+PublisherSupportUrl: https://gitee.com/aleckstygit/my-coder/issues
+PackageName: WayCoder
+PackageUrl: https://gitee.com/aleckstygit/my-coder
+License: MIT
+ShortDescription: 中文编程智能体 CLI Coding Agent
+Tags:
+  - coding
+  - agent
+  - ai
+  - cli
+  - programmer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.79.89/Aleckstygit.WayCoder.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.79.89
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
#### Description

First-time submission of **Aleckstygit.WayCoder** v0.79.89.

- Package: WayCoder — 中文编程智能体 CLI Coding Agent
- Installer: portable (waycoder.exe), x64 + arm64
- Download source: Gitee Release (fast in mainland China), domain matches PackageUrl/PublisherUrl
- Verified locally: `winget validate` passed; installer sha256 matches the live download URLs

#### Manifest
`manifests/a/Aleckstygit/WayCoder/0.79.89/`

###### Microsoft Reviewers: [Open in Codespaces](https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=5500624&skip_quickstart=true&machine=basicLinux32gb&location=WestUs2)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421327)