### PR TITLE
New package: SecurStack.CLI version 0.2.0

### DIFF
--- a/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.installer.yaml
+++ b/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SecurStack.CLI
+PackageVersion: 0.2.0
+InstallerType: portable
+Commands:
+  - securstack
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.securstack.io/cli/v0.2.0/securstack-windows-x64.exe
+    InstallerSha256: 772a91f50bc9f9e5ea89f0e32d5a3d5c2962f56895599471acfbda67d0646886
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.locale.en-US.yaml
+++ b/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SecurStack.CLI
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: SecurStack
+PublisherUrl: https://securstack.io
+PublisherSupportUrl: https://securstack.io/support
+PackageName: SecurStack CLI
+PackageUrl: https://downloads.securstack.io
+License: Proprietary
+LicenseUrl: https://securstack.io/legal/terms
+ShortDescription: SecurStack CLI for repository security scans and Shielding workflows.
+Tags:
+  - appsec
+  - cli
+  - devsecops
+  - security
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.yaml
+++ b/manifests/s/SecurStack/CLI/0.2.0/SecurStack.CLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SecurStack.CLI
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the official SecurStack CLI 0.2.0 portable Windows x64 package. The manifest references the immutable binary at downloads.securstack.io and its published SHA-256 checksum.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (Windows tooling unavailable in the publishing environment)
- [ ] Tested manifest locally with `winget install --manifest <path>` (will be covered by repository validation)
- [x] Manifest conforms to the 1.12 schema

Official release: https://github.com/securstack/securstack-cli/releases/tag/v0.2.0
Official downloads: https://downloads.securstack.io/cli/v0.2.0/manifest.json
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421341)