### PR TITLE
Update version: LANCommander.Server version 2.1.10

### DIFF
--- a/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.installer.yaml
+++ b/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.10
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.10/LANCommander.Server-2.1.10-x64-Setup.exe
+  InstallerSha256: 6C93E7A74BB74292067058ED7A6F0DAB8CEC10147CBA9F6B5D1B3AC6E28FD1B2
+- Architecture: arm64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.10/LANCommander.Server-2.1.10-arm64-Setup.exe
+  InstallerSha256: F27A051821898D92063C21DB4619AA9E12DA7D214E6FC3C9CC4E1B814E254F8F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.locale.en-US.yaml
+++ b/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.locale.en-US.yaml
@@ -18,5 +18,9 @@ ShortDescription: |
 Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://docs.lancommander.app
+ReleaseNotes: |-
+  View the full release notes over on the official documentation site:
+  https://lancommander.app/Releases/2.1.10
+ReleaseNotesUrl: https://github.com/LANCommander/LANCommander/releases/tag/v2.1.10
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.locale.en-US.yaml
+++ b/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.10
+PackageLocale: en-US
+Publisher: LANCommander LLC
+PublisherUrl: https://github.com/LANCommander
+PublisherSupportUrl: https://github.com/LANCommander/LANCommander/issues
+Author: Pat Hartl
+PackageName: LANCommander Server
+PackageUrl: https://github.com/LANCommander/LANCommander
+License: MIT
+Copyright: Copyright (c) LANCommander LLC
+ShortDescription: |
+  LANCommander is a self-hosted game distribution platform designed for LAN parties and personal libraries.
+  This server software is your central repository for games, redistributables, saves, and users.
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.lancommander.app
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.yaml
+++ b/manifests/l/LANCommander/Server/2.1.10/LANCommander.Server.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update LANCommander.Server to version 2.1.10.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421364)