### PR TITLE
New version: Elinesoft.XTester version 0.0.89

### DIFF
--- a/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.installer.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Inno-инсталлер: winget сам подставляет тихие ключи (/VERYSILENT /NORESTART).
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.89
+InstallerLocale: ru-RU
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/79231232393/XTester-releases/releases/download/v.0.0.89/XTester-Installer-0.0.89.exe
+    InstallerSha256: 44D21BB7509B19C6644F2A7358A4947FB2DE3742EEAFCDB3CECFA727505CA290
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.locale.en-US.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.89
+PackageLocale: en-US
+Publisher: Elinesoft
+PublisherUrl: https://xtester.pw
+PublisherSupportUrl: https://github.com/79231232393/XTester-releases/issues
+PackageName: XTester
+PackageUrl: https://xtester.pw
+License: Freeware
+ShortDescription: Desktop cryptocurrency trading strategy simulator and backtester with an AI strategy builder.
+Description: |-
+  XTester is a Windows desktop application for designing, backtesting and simulating
+  cryptocurrency trading strategies on historical market data from major exchanges.
+  Includes a C# strategy editor with IntelliSense, an AI-assisted strategy builder,
+  interactive charts, portfolio statistics and automatic updates.
+Moniker: xtester
+Tags:
+  - trading
+  - backtesting
+  - cryptocurrency
+  - strategy
+  - simulator
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.89/Elinesoft.XTester.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Корневой (version) манифест winget-пакета XTester. Публикуется тройкой файлов в
+# microsoft/winget-pkgs → manifests/e/Elinesoft/XTester/<версия>/
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.89
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update Elinesoft.XTester to 0.0.89.

Installer: https://github.com/79231232393/XTester-releases/releases/download/v.0.0.89/XTester-Installer-0.0.89.exe (SHA256 from the GitHub release asset digest).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421409)