### PR TITLE
New package: Orahu01.AeroWidget version 5.4.0

### DIFF
--- a/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.installer.yaml
+++ b/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Orahu01.AeroWidget
+PackageVersion: 5.4.0
+InstallerLocale: ja-JP
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Orahu01/aerowidget/releases/download/v5.4.0/AeroWidget-Setup-5.4.0.exe
+  InstallerSha256: EEF6ED34D7A0E8AB871C7E0573A128C05EC2A23DD825DC987267076AEE5A4205
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.locale.en-US.yaml
+++ b/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: Orahu01.AeroWidget
+PackageVersion: 5.4.0
+PackageLocale: en-US
+Publisher: Orahu01
+PackageName: AeroWidget
+ShortDescription: Lightweight live-wallpaper app that pins clocks, weather, PC monitors and more behind your desktop icons
+Description: |-
+  AeroWidget is a live wallpaper app for Windows that places widgets such as
+  clocks, weather, agenda, hardware monitors, sticky notes and now-playing
+  info behind your desktop icons, with any font, size and position.
+  One-click themes, multi-monitor support, power-efficient design
+  (0% GPU when idle) and auto-updates included.
+Tags:
+- desktop
+- wallpaper
+- widget
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.locale.ja-JP.yaml
+++ b/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.locale.ja-JP.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Orahu01.AeroWidget
+PackageVersion: 5.4.0
+PackageLocale: ja-JP
+Publisher: Orahu01
+PublisherUrl: https://github.com/Orahu01
+PublisherSupportUrl: https://github.com/Orahu01/aerowidget/issues
+PackageName: AeroWidget
+PackageUrl: https://orahu01.github.io/aerowidget/
+License: MIT
+LicenseUrl: https://github.com/Orahu01/aerowidget/blob/main/LICENSE
+ShortDescription: 時計・天気・PC モニタなどをデスクトップアイコンの背面に自由に配置できる軽量ウィジェット壁紙アプリ
+Description: |-
+  AeroWidget は、時計・天気・予定表・ハードウェアモニタ・メモ・再生中の曲などの
+  ウィジェットを、デスクトップアイコンの背面に好きなフォント・サイズ・位置で
+  配置できる Windows 用のライブ壁紙アプリです。テーマのワンクリック適用、
+  マルチモニタ、省電力設計 (アイドル時 GPU 0%)、自動アップデートに対応しています。
+Moniker: aerowidget
+Tags:
+- desktop
+- wallpaper
+- widget
+- ウィジェット
+- 壁紙
+ReleaseNotesUrl: https://github.com/Orahu01/aerowidget/releases/tag/v5.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.yaml
+++ b/manifests/o/Orahu01/AeroWidget/5.4.0/Orahu01.AeroWidget.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Orahu01.AeroWidget
+PackageVersion: 5.4.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Orahu01.AeroWidget 5.4.0

AeroWidget is a free, open-source (MIT) live-wallpaper app for Windows that places widgets — clocks, weather, calendar agendas, hardware monitors, sticky notes, now-playing info and more — behind the desktop icons.

- Homepage: https://orahu01.github.io/aerowidget/
- Repository: https://github.com/Orahu01/aerowidget
- Release: https://github.com/Orahu01/aerowidget/releases/tag/v5.4.0
- Installer: NSIS (oneClick, per-user), silent install via `/S`

This replaces #420486, which I closed: the project was previously called WidgetWall, but that name is already used by an app on the Mac App Store, so it has been renamed to AeroWidget and the repository moved accordingly.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421452)