### PR TITLE
New version: EazyMake.EazyMake version 1.2.5

### DIFF
--- a/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.installer.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.2.5
+InstallerLocale: en-US
+InstallerType: zip
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/3667808244/EazyMake/releases/download/v1.2.5/ezmk-windows-x64.zip
+    InstallerSha256: 35f912016798bc19b0d2391ccbf94234739e8417a8df9807304498f3d0d02cef
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: ezmk.exe
+        PortableCommandAlias: ezmk
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.locale.en-US.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.2.5
+PackageLocale: en-US
+Publisher: EazyMake
+PackageName: EazyMake
+PackageUrl: https://github.com/3667808244/EazyMake
+ShortDescription: A simple C/C++ build tool
+Description: EazyMake is a simple C/C++ build tool (CLI named ezmk) designed for ease of use. Supports GCC, Clang, and MSVC. Features zero-config setup, automatic package management, Lua scripting, and cross-compiler compatibility.
+Moniker: ezmk
+Tags:
+  - build-tool
+  - cpp
+  - c
+  - compiler
+  - package-manager
+ReleaseNotesUrl: https://github.com/3667808244/EazyMake/releases/tag/v1.2.5
+License: MIT
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.2.5/EazyMake.EazyMake.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
###### Microsoft Reviewers: [Open in Codespaces](https://codespaces.new/Microsoft/winget-pkgs?quickstart=1&repo=Microsoft/winget-pkgs&ref=master)

## Pull Request Information
- **Version:** 1.2.5
- **Affected Package:** EazyMake.EazyMake

## Validation
- [x] Manifest validated locally with winget validate (清单验证成功)
- [x] 3-file split manifest (version / installer / defaultLocale)

## Summary
New version of EazyMake (CLI ezmk) 1.2.5 — \ezmk project pack\ default package format is now a source package (platform-independent); \--precompiled\ keeps the legacy prebuilt archive; test-cache signature fix included.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421464)