### PR TITLE
New version: Filegram.FilegramDesktop version 0.2.11

### DIFF
--- a/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.installer.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.11
+InstallerType: inno
+ReleaseDate: 2026-08-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.11/filegram-windows-x86_64-setup.exe
+  InstallerSha256: AA430C4D6A2580241242E3A0DA6620FD85E110DCA13D9718FB77CFE4E3294AFB
+- Architecture: x86
+  InstallerUrl: https://github.com/filegram/filegram-desktop/releases/download/v0.2.11/filegram-windows-i686-setup.exe
+  InstallerSha256: 962242ADE17AED11DD004A91AF8878083742C469200B22329652CBCDDDC0FC18
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.locale.en-US.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.11
+PackageLocale: en-US
+Publisher: Filegram
+PublisherUrl: https://github.com/filegram
+PublisherSupportUrl: https://github.com/filegram/filegram-desktop/issues
+Author: Filegram
+PackageName: Filegram
+PackageUrl: https://github.com/filegram/filegram-desktop
+License: MIT
+LicenseUrl: https://github.com/filegram/filegram-desktop/blob/master/LICENSE
+Copyright: Copyright (c) Filegram
+ShortDescription: Disk space analyzer with an interactive treemap
+Description: |-
+  Filegram is a desktop disk analyzer that scans a directory and visualizes file
+  sizes as an interactive treemap chart, letting you navigate the file tree and
+  quickly find what is taking up space.
+Moniker: filegram
+Tags:
+- disk
+- disk-analyzer
+- disk-usage
+- filesystem
+- rust
+- storage
+- treemap
+ReleaseNotes: |-
+  - Filegram can now send anonymous usage statistics: the app version, the
+    operating system and which features get used. File names, paths and folder
+    contents never leave the machine, counts and sizes are reported as ranges,
+    and the chart button on the start screen turns reporting off at any time.
+    See PRIVACY.md in the repository for the full list.
+ReleaseNotesUrl: https://github.com/filegram/filegram-desktop/releases/tag/v0.2.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.yaml
+++ b/manifests/f/Filegram/FilegramDesktop/0.2.11/Filegram.FilegramDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Filegram.FilegramDesktop
+PackageVersion: 0.2.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Version bump only: same package, same Inno installer, same stable AppId as 0.2.7. Installer URLs and SHA256 values are taken from the release assets of [v0.2.11](https://github.com/filegram/filegram-desktop/releases/tag/v0.2.11).
