### PR TITLE
New version: 0state.scafld 2.5.6

### DIFF
--- a/manifests/0/0state/scafld/2.5.6/0state.scafld.installer.yaml
+++ b/manifests/0/0state/scafld/2.5.6/0state.scafld.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.6
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - scafld
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.6/scafld_2.5.6_windows_amd64.exe
+    InstallerSha256: 4f2a69e552b3cb78cb798b9686dd8a8b6f82d6567428394d5e575a9b131d6da8
+  - Architecture: arm64
+    InstallerUrl: https://github.com/nilstate/scafld/releases/download/v2.5.6/scafld_2.5.6_windows_arm64.exe
+    InstallerSha256: 35983c35eabd64f7aaa0ac812542e2fdbaaeff44b3f8956f328ec47916999a13
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.6/0state.scafld.locale.en-US.yaml
+++ b/manifests/0/0state/scafld/2.5.6/0state.scafld.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.6
+PackageLocale: en-US
+Publisher: 0state
+PublisherUrl: https://0state.com
+PackageName: scafld
+License: MIT
+ShortDescription: Deterministic protocol for multi-phase agent work.
+PackageUrl: https://0state.com/scafld
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/0/0state/scafld/2.5.6/0state.scafld.yaml
+++ b/manifests/0/0state/scafld/2.5.6/0state.scafld.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 0state.scafld
+PackageVersion: 2.5.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- Adds `0state.scafld` version `2.5.6`.
- Installer URLs point to the public GitHub release `v2.5.6`.
- Installer SHA256 values were generated from the release `checksums.txt` and verified by `scripts/prepare-winget-submission.sh`.

Release: https://github.com/nilstate/scafld/releases/tag/v2.5.6

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421645)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421645)