### PR TITLE
New package: Chris0Jeky.IdleHarbor version 0.1.0

### DIFF
--- a/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.installer.yaml
+++ b/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.installer.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Chris0Jeky.IdleHarbor
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+ReleaseDate: 2026-08-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Chris0Jeky/IdleHarbor/releases/download/v0.1.0/IdleHarbor-0.1.0-windows-x64-portable.zip
+    InstallerSha256: B3BC7E5714543CEE3877E94F3C74ECFEDB30D3599DECEF316E57715FDF9F6D28
+    NestedInstallerFiles:
+      - RelativeFilePath: IdleHarbor-0.1.0-windows-x64-portable\IdleHarbor.exe
+        PortableCommandAlias: idleharbor
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Chris0Jeky/IdleHarbor/releases/download/v0.1.0/IdleHarbor-0.1.0-windows-arm64-portable.zip
+    InstallerSha256: 7109D42E248568027581A9110EBDB357C2D908C02872708A00FA9ACFDA7C904B
+    NestedInstallerFiles:
+      - RelativeFilePath: IdleHarbor-0.1.0-windows-arm64-portable\IdleHarbor.exe
+        PortableCommandAlias: idleharbor
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.locale.en-US.yaml
+++ b/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Chris0Jeky.IdleHarbor
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Cristian Tcaci
+PublisherUrl: https://github.com/Chris0Jeky
+PublisherSupportUrl: https://github.com/Chris0Jeky/IdleHarbor/issues
+Author: Cristian Tcaci
+PackageName: IdleHarbor
+PackageUrl: https://github.com/Chris0Jeky/IdleHarbor
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Chris0Jeky/IdleHarbor/blob/v0.1.0/LICENSE
+Copyright: Copyright (c) 2026 Cristian Tcaci
+ShortDescription: Lightweight, transparent Windows keep-awake utility with intelligent safety pauses.
+Description: IdleHarbor is a native Windows keep-awake utility with optional mouse movement, power-request modes, activity-aware pausing, lock and disconnect safety, battery protection, active hours, session limits, a notification-area menu, and an emergency stop hotkey. It is user-visible, configurable, and does not require a managed runtime.
+Moniker: idleharbor
+Tags:
+  - keep-awake
+  - mouse-jiggler
+  - power-management
+  - productivity
+  - sleep
+  - tray
+  - windows
+ReleaseNotesUrl: https://github.com/Chris0Jeky/IdleHarbor/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.locale.en-US.yaml
+++ b/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.locale.en-US.yaml
@@ -12,7 +12,6 @@ PackageName: IdleHarbor
 PackageUrl: https://github.com/Chris0Jeky/IdleHarbor
 License: GPL-3.0-only
 LicenseUrl: https://github.com/Chris0Jeky/IdleHarbor/blob/v0.1.0/LICENSE
-Copyright: Copyright (c) 2026 Cristian Tcaci
 ShortDescription: Lightweight, transparent Windows keep-awake utility with intelligent safety pauses.
 Description: IdleHarbor is a native Windows keep-awake utility with optional mouse movement, power-request modes, activity-aware pausing, lock and disconnect safety, battery protection, active hours, session limits, a notification-area menu, and an emergency stop hotkey. It is user-visible, configurable, and does not require a managed runtime.
 Moniker: idleharbor

--- a/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.yaml
+++ b/manifests/c/Chris0Jeky/IdleHarbor/0.1.0/Chris0Jeky.IdleHarbor.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Chris0Jeky.IdleHarbor
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first stable IdleHarbor release (`Chris0Jeky.IdleHarbor` 0.1.0) as x64 and ARM64 nested portable ZIP installers.

Release: https://github.com/Chris0Jeky/IdleHarbor/releases/tag/v0.1.0

The release archives, SHA-256 values, nested executable paths, GPL-3.0-only metadata, PE version metadata, SPDX SBOMs, and GitHub build attestations were independently verified. The local `winget validate --manifest <path>` gate passes without warnings.

A full `winget install --manifest <path>` lifecycle was not run because `LocalManifestFiles` is disabled on the available test machine and changing that administrator setting requires elevation. No elevated change was attempted. The same released x64 executable was installed and visually/runtime tested through the project's non-elevated per-user installer.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (the hosted CLA check is green)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for this manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (blocked by the machine's administrator setting; disclosed above)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421663)