### PR TITLE
New package: LanTransfer.LanTransfer version 0.5.0

### DIFF
--- a/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.installer.yaml
+++ b/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'LanTransfer.LanTransfer'
+PackageVersion: '0.5.0'
+InstallerType: 'inno'
+Scope: 'user'
+UpgradeBehavior: 'install'
+InstallModes:
+- 'silent'
+- 'silentWithProgress'
+InstallerSwitches:
+  Silent: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+  SilentWithProgress: '/SILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+  Upgrade: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+ReleaseDate: '2026-08-20'
+Installers:
+- Architecture: 'x64'
+  InstallerUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/download/v0.5.0/LanTransfer-0.5.0-win-x64-Setup.exe'
+  InstallerSha256: 344E6032BB271FFB8E25A41FE01A329E7C7E056451512936589E435E89ABEC59
+ManifestType: installer
+ManifestVersion: '1.12.0'

--- a/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.locale.en-US.yaml
+++ b/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'LanTransfer.LanTransfer'
+PackageVersion: '0.5.0'
+PackageLocale: 'en-US'
+Publisher: 'LanTransfer contributors'
+PublisherUrl: 'https://github.com/hongjiapeng/LanTransfer'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: 'Cross-platform LAN file and text transfer tool.'
+Description: 'LanTransfer is a cross-platform LAN file and text transfer tool powered by .NET and a browser-based UI.'
+Moniker: 'lantransfer'
+Tags:
+- 'file-transfer'
+- 'local-network'
+- 'file-sharing'
+- 'browser'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.5.0'
+ManifestType: defaultLocale
+ManifestVersion: '1.12.0'

--- a/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.locale.zh-CN.yaml
+++ b/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'LanTransfer.LanTransfer'
+PackageVersion: '0.5.0'
+PackageLocale: 'zh-CN'
+Publisher: 'LanTransfer contributors'
+PublisherUrl: 'https://github.com/hongjiapeng/LanTransfer'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: '跨平台局域网文件和文本传输工具。'
+Description: 'LanTransfer 是一款基于 .NET 和浏览器界面的跨平台局域网文件和文本传输工具。'
+Tags:
+- '文件传输'
+- '局域网'
+- '文件共享'
+- '浏览器'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.5.0'
+ManifestType: locale
+ManifestVersion: '1.12.0'

--- a/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.yaml
+++ b/manifests/l/LanTransfer/LanTransfer/0.5.0/LanTransfer.LanTransfer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'LanTransfer.LanTransfer'
+PackageVersion: '0.5.0'
+DefaultLocale: 'en-US'
+ManifestType: version
+ManifestVersion: '1.12.0'


### PR DESCRIPTION
## Description

Add the first WinGet manifest for LanTransfer 0.5.0.

- Installer: x64 Inno Setup installer
- Source: official GitHub Release
- SHA256 verified against the published release asset
- Local `winget validate --manifest` passed

## Checklist

- [x] This PR contains one package version only
- [x] This PR contains manifest files only
- [x] Installer URL is version-specific and points to the publisher's release
- [x] Silent installer switches were verified with the release installer
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421688)