### PR TITLE
Update: JiaPeng.LanTransfer to 0.6.0

### DIFF
--- a/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.installer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.6.0'
+InstallerType: 'inno'
+InstallModes:
+- 'silent'
+- 'silentWithProgress'
+InstallerSwitches:
+  Silent: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+  SilentWithProgress: '/SILENT /SUPPRESSMSGBOXES /NORESTART'
+ReleaseDate: '2026-08-21'
+Installers:
+- Architecture: x64
+  InstallerUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/download/v0.6.0/LanTransfer-0.6.0-win-x64-Setup.exe'
+  InstallerSha256: CC9BF0F94AA1C76DA1E6B568B612B653E1599D43D6B6E8095957A8F394B01E99
+ManifestType: installer
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.locale.en-US.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.6.0'
+PackageLocale: 'en-US'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: 'Transfer files and text between devices on the same local network through a browser.'
+Description: 'LanTransfer is a cross-platform local-network file and text transfer tool with a browser-based interface, QR-code connection, and no cloud dependency.'
+Moniker: 'lantransfer'
+Tags:
+- 'file-transfer'
+- 'lan'
+- 'local-network'
+- 'qr-code'
+- 'text-transfer'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.6.0'
+ManifestType: defaultLocale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.6.0'
+PackageLocale: 'zh-CN'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: '通过浏览器在同一局域网的设备之间传输文件和文字。'
+Description: 'LanTransfer 是一个跨平台局域网文件和文字传输工具，提供浏览器界面、二维码连接，并且不依赖云服务。'
+Tags:
+- '二维码'
+- '局域网'
+- '文件传输'
+- '文字传输'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.6.0'
+ManifestType: locale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.6.0/JiaPeng.LanTransfer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.6.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: '1.12.0'


### PR DESCRIPTION
## Description

Update `JiaPeng.LanTransfer` to version 0.6.0.

- Installer: https://github.com/hongjiapeng/LanTransfer/releases/download/v0.6.0/LanTransfer-0.6.0-win-x64-Setup.exe
- SHA256: `CC9BF0F94AA1C76DA1E6B568B612B653E1599D43D6B6E8095957A8F394B01E99`
- Product version verified as `0.6.0`
- Local `winget validate --manifest` passed
- GitHub release workflow, including Windows installer build, passed

A full local install/upgrade/uninstall cycle was not run because it would replace the user's existing LanTransfer installation; the WinGet installation validation pipeline can perform the isolated installer test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421694)