### PR TITLE
Fix: CarthageSoftware.Mago 1.47.2 duplicate ReleaseNotesUrl key

### DIFF
--- a/manifests/c/CarthageSoftware/Mago/1.47.2/CarthageSoftware.Mago.locale.en-US.yaml
+++ b/manifests/c/CarthageSoftware/Mago/1.47.2/CarthageSoftware.Mago.locale.en-US.yaml
@@ -22,7 +22,6 @@ Tags:
 - php
 - semantic-checks
 - static-analysis
-ReleaseNotesUrl: https://github.com/carthage-software/mago/releases/tag/1.42.0
 Documentations:
 - DocumentLabel: Documentation
   DocumentUrl: https://mago.carthage.software/


### PR DESCRIPTION
## 📖 Description

`CarthageSoftware.Mago` version 1.47.2 has a duplicate `ReleaseNotesUrl` key in its `en-US` default locale manifest, which makes the file invalid YAML.

- Line 25: `ReleaseNotesUrl: .../releases/tag/1.42.0` — stale, carried over from an earlier version
- Line 74: `ReleaseNotesUrl: .../releases/tag/1.47.2` — correct for this version

The YAML 1.2 spec requires mapping keys to be unique, and strict parsers reject the file outright. With `gopkg.in/yaml.v3`:

```
yaml: unmarshal errors:
  line 74: mapping key "ReleaseNotesUrl" already defined at line 25
```

This breaks any tooling that walks the repository and parses manifests strictly. Parsers that are lenient about duplicate keys typically keep the *last* occurrence, so the practical impact is limited to strict consumers — but the file is malformed either way.

This PR deletes the stale line 25 and keeps the correct 1.47.2 URL. That is the only change: one line removed, 80 bytes, CRLF line endings and all other content preserved byte for byte.

Introduced in #421520. The manifest header says it was created with `winmatsch`; that tool looks to have appended a fresh `ReleaseNotesUrl` rather than replacing the one carried forward, so it may be worth a look upstream. Version 1.46.0 is unaffected (single key, though it also points at the 1.42.0 tag).

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Notes on the unchecked boxes: this was prepared on Linux, so `winget validate` and `winget install` were not available. Instead the manifest was validated against `https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json` with `jsonschema` (passes), and confirmed to parse cleanly with `gopkg.in/yaml.v3` after the change and to fail before it. No installer manifest, URL, or hash is touched by this PR, so installation behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421727)