### PR TITLE
Add version 0.17.0 to caomengxuan666.WinuxCmd

### DIFF
--- a/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.installer.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.17.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- winuxcmd
+ReleaseDate: 2026-08-21
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: WinuxCmd-0.17.0-win-x64/usr/bin/winuxcmd.exe
+  InstallerUrl: https://github.com/unixwin/WinuxCmd/releases/download/v0.17.0/WinuxCmd-0.17.0-win-x64.zip
+  InstallerSha256: FB1154789DE1650E6F2BF7DCDFE714F76A970C2CD65E043F2EA4F74C655CCBD6
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: WinuxCmd-0.17.0-win-arm64/usr/bin/winuxcmd.exe
+  InstallerUrl: https://github.com/unixwin/WinuxCmd/releases/download/v0.17.0/WinuxCmd-0.17.0-win-arm64.zip
+  InstallerSha256: 0D75F7D7DFF9AA38D7EC84E91A57969DA88FCD8B43FED1E1A6E5E18DEB2235FD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.locale.en-US.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.17.0
+PackageLocale: en-US
+Publisher: Cao Mengxuan
+PublisherUrl: https://github.com/caomengxuan666
+PublisherSupportUrl: https://github.com/unixwin/WinuxCmd/issues
+Author: Cao Mengxuan
+PackageName: WinuxCmd
+PackageUrl: https://github.com/unixwin/WinuxCmd
+License: MIT
+LicenseUrl: https://github.com/unixwin/WinuxCmd/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 caomengxuan666
+ShortDescription: Linux-style command set for Windows terminals
+Description: |-
+  WinuxCmd provides native Windows implementations of common Linux-style commands for Windows terminals.
+
+  It includes GNU-style commands such as ls, cat, grep, sed, ps, and lsof, works without WSL, and supports
+  Windows and Linux-style command workflows in PowerShell, Command Prompt, and other shells.
+  The bundled `wpm` package manager installs a curated set of portable Unix-side tools with
+  SHA-256 verification and an isolated opt/ layout for DLL-bearing packages.
+Tags:
+- command-line
+- coreutils
+- grep
+- linux
+- ls
+- powershell
+- shell
+- terminal
+- wpm
+ReleaseNotes: |-
+  Windows binaries for v0.17.0
+
+  ### Highlights:
+  - wpm: shim layout for DLL-bearing packages (self-contained payload under opt/, hardlink forwarders in usr/bin)
+  - wpm: one-step migration of legacy flat installs via `wpm install --force`
+  - wpm: uninstall support; JSON output now exposes artifact layout
+  - Removed the benchmark suite
+
+  ### Architectures:
+  **x64**: Windows 64-bit
+  **ARM64**: Windows ARM64 (cross-compiled)
+
+  **Full Changelog**: https://github.com/unixwin/WinuxCmd/compare/v0.16.3...v0.17.0
+ReleaseNotesUrl: https://github.com/unixwin/WinuxCmd/releases/tag/v0.17.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.locale.zh-CN.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.17.0
+PackageLocale: zh-CN
+Publisher: 曹梦轩
+Author: 曹梦轩
+PackageName: WinuxCmd
+ShortDescription: 面向 Windows 终端的 Linux 风格命令集
+Description: |-
+  WinuxCmd 为 Windows 终端提供常见 Linux 风格命令的原生实现。
+  它包含 ls、cat、grep、sed、ps、lsof 等 GNU 风格命令，无需 WSL，
+  可在 PowerShell、命令提示符和其他 shell 中支持 Windows 与 Linux 风格命令工作流。
+  内置的 wpm 包管理器提供经 SHA-256 校验的可移植 Unix 工具集，
+  并通过 opt/ 私享目录隔离带 DLL 的软件包。
+Tags:
+- linux
+- powershell
+- shell
+- terminal
+- 命令行
+- 终端
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.yaml
+++ b/manifests/c/caomengxuan666/WinuxCmd/0.17.0/caomengxuan666.WinuxCmd.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: caomengxuan666.WinuxCmd
+PackageVersion: 0.17.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
# caomengxuan666.WinuxCmd 0.17.0

- Pull request has been submitted to the upstream repository: N/A (manifest update for an existing package)
- Have you verified that the manifest is correct? **Yes** — sha256 values computed from the published release assets; RelativeFilePath matches the archive layout (`WinuxCmd-0.17.0-win-<arch>/usr/bin/winuxcmd.exe`).
- Have you tested the installation and uninstallation locally? **Yes** — `winget install --manifest .` succeeded on Windows x64, portable command `winuxcmd` resolves after install, uninstall removes the package directory.

## Changes
- Adds version 0.17.0 of caomengxuan666.WinuxCmd (x64 + arm64 zip portable installers).

## Release notes
- wpm: shim layout for DLL-bearing packages (self-contained payload under opt/, hardlink forwarders in usr/bin)
- wpm: one-step migration of legacy flat installs via `wpm install --force`
- wpm: uninstall support; JSON output exposes artifact layout
- Removed the benchmark suite

Upstream release: https://github.com/unixwin/WinuxCmd/releases/tag/v0.17.0

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421775)