### PR TITLE
New package: i-snyder.unbramble version 0.1.0

### DIFF
--- a/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.installer.yaml
+++ b/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: i-snyder.unbramble
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - unbramble
+ArchiveBinariesDependOnPath: true
+ReleaseDate: 2026-08-20
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/i-snyder/unbramble/releases/download/v0.1.0/unbramble-win-x64.zip
+    InstallerSha256: F88A84418A5DD8D43A3F86361F045B0D656ABDDE2ED91510BD1BC38425286A43
+    NestedInstallerFiles:
+      - RelativeFilePath: unbramble.exe
+        PortableCommandAlias: unbramble
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.locale.en-US.yaml
+++ b/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: i-snyder.unbramble
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Ian Snyder
+PublisherUrl: https://github.com/i-snyder
+PublisherSupportUrl: https://github.com/i-snyder/unbramble/issues
+PackageName: UnBramble
+PackageUrl: https://github.com/i-snyder/unbramble
+License: MIT
+LicenseUrl: https://github.com/i-snyder/unbramble/blob/v0.1.0/LICENSE
+Copyright: Copyright (c) 2026 Ian Snyder
+ShortDescription: Builds a dependency graph for Unity projects so coding agents can trace asset and C# relationships.
+Description: UnBramble builds a current, queryable dependency graph for Unity projects, covering Unity asset references and semantic C# relationships so coding agents can trace what a change touches.
+Moniker: unbramble
+Tags:
+  - cli
+  - dependency-graph
+  - game-development
+  - static-analysis
+  - unity
+ReleaseNotesUrl: https://github.com/i-snyder/unbramble/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.yaml
+++ b/manifests/i/i-snyder/unbramble/0.1.0/i-snyder.unbramble.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: i-snyder.unbramble
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial WinGet manifest for UnBramble 0.1.0, a Windows x64 CLI that builds a dependency graph for Unity projects.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The published ZIP checksum was independently verified and `unbramble --version` was run successfully from the extracted release. The local WinGet install test requires enabling the administrator-only `LocalManifestFiles` setting; automated install validation is left to the repository checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/421778)