### PR TITLE
Update version: GolangCI.golangci-lint version 2.13.1

### DIFF
--- a/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.installer.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.1
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-20
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.1-windows-386/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.1/golangci-lint-2.13.1-windows-386.zip
+  InstallerSha256: 58196B82C6BE5DC0C9EC4CCC4FABF0506ACCD3F391F10152384EC9E10C06C19B
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.1-windows-amd64/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.1/golangci-lint-2.13.1-windows-amd64.zip
+  InstallerSha256: CC119BDD57D2B35CE36FBC174B54949E1A1E45F2CADAF64372CC799CABAF88A9
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.1-windows-arm64/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.1/golangci-lint-2.13.1-windows-arm64.zip
+  InstallerSha256: 88EE9636AB1EEAFF9384A8894B377FB8C2F4A820310FFA2FF5BAFB1173DC87CE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.locale.en-US.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.1
+PackageLocale: en-US
+Publisher: GolangCI
+PublisherUrl: https://golangci-lint.run/
+PublisherSupportUrl: https://github.com/golangci/golangci-lint/issues
+PackageName: golangci-lint
+PackageUrl: https://github.com/golangci/golangci-lint
+License: GPL-3.0
+LicenseUrl: https://github.com/golangci/golangci-lint/blob/HEAD/LICENSE
+ShortDescription: Fast linters Runner for Go
+Description: golangci-lint is a fast Go linters runner. It runs linters in parallel, uses caching, supports YAML configuration, integrates with all major IDEs, and includes over a hundred linters.
+Tags:
+- ci
+- go
+- golang
+- golangci-lint
+- linter
+ReleaseNotes: |-
+  `golangci-lint` is a free and open-source project built by volunteers.
+
+  If you value it, consider supporting us, the [maintainers](https://donate.golangci.org) and [linter authors](https://golangci-lint.run/docs/product/thanks/).
+
+  We appreciate it! :heart:
+
+  For key updates, see the [changelog](https://golangci-lint.run/docs/product/changelog/#2131).
+
+  ## Changelog
+  • c3ab374844721687ee00313e847d6e8a7d4cffa2 build(deps)：bump github.com/bombsimon/wsl/v5 from 5.8.0 to 5.9.0 (#6737)
+  • e602199aba3a75d917b300815b0ba7f7dbd6360b build(deps)：bump github.com/nunnatsa/ginkgolinter from 0.23.1 to 0.24.0 (#6735)
+  • 62afbbeaf6d09592bfd9d93ec3795b7eae5d83af build(deps)：bump github.com/sirupsen/logrus from 1.10.0 to 1.10.1 (#6734)
+  • 0924cfd9899de3a6f89eb2eeeecc01ed471195b4 build(deps)：bump gofmt to e84e05053792 (#6740)
+  • e2a4f0a347ef99790f5ecbcac33f911a4bab6797 build(deps)：bump honnef.co/go/tools from 0.8.0-rc.1 to 0.8.0 (#6738)
+  • eac982716187a41e859a6e24bcac18666dd4e1e2 build(deps)：bump the github-actions group with 2 updates (#6739)
+ReleaseNotesUrl: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.1/GolangCI.golangci-lint.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update GolangCI.golangci-lint to version 2.13.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422073)