### PR TITLE
New package: Pulkitxm.Quinjet version 0.0.35

### DIFF
--- a/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.installer.yaml
+++ b/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Pulkitxm.Quinjet
+PackageVersion: "0.0.35"
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - quinjet
+  - q
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Git.Git
+ReleaseDate: "2026-08-21"
+Installers:
+  - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: quinjet.exe
+        PortableCommandAlias: quinjet
+      - RelativeFilePath: q.exe
+        PortableCommandAlias: q
+    InstallerUrl: https://github.com/pulkitxm/quinjet/releases/download/v0.0.35/quinjet-windows-x86_64.zip
+    InstallerSha256: "7C73E1AA7833B552AB6E5FDC2D58F436AE5B1316040F5D7B41A1758F03B0DD18"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.locale.en-US.yaml
+++ b/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Pulkitxm.Quinjet
+PackageVersion: "0.0.35"
+PackageLocale: en-US
+Publisher: Pulkit
+PublisherUrl: https://github.com/pulkitxm
+PublisherSupportUrl: https://github.com/pulkitxm/quinjet/issues
+PackageName: Quinjet
+PackageUrl: https://github.com/pulkitxm/quinjet
+License: MIT
+LicenseUrl: https://github.com/pulkitxm/quinjet/blob/v0.0.35/LICENSE
+ShortDescription: Fast, live, keyboard-first Git source-control interface for the terminal
+Description: >-
+  Quinjet combines repository status, syntax-highlighted diffs, commit history,
+  branches, stashes, and pull requests in one terminal executable.
+Tags:
+  - cli
+  - git
+  - github
+  - source-control
+  - terminal
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.yaml
+++ b/manifests/p/Pulkitxm/Quinjet/0.0.35/Pulkitxm.Quinjet.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Pulkitxm.Quinjet
+PackageVersion: "0.0.35"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the Quinjet 0.0.35 portable x64 manifest from its signed GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422098)