### PR TITLE
New version: Feci.ParleyDeckCli version 1.46.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.46.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.46.0/parley-v1.46.0-windows-x64.exe
+  InstallerSha256: A36C89F7F2582651FD710900EDEC2C4193AF1D07501DB28B303C13EFA329D165
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.46.0/parley-v1.46.0-windows-arm64.exe
+  InstallerSha256: 0E71A67615168D1BBB855D91D138492D6B16A462390514EF1ADE9509704F01E2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.46.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: CLI that orchestrates Parley Deck multi-agent cooperation workflows.
+Description: "parley orchestrates multi-agent Parley Deck cooperation across local CLI agents. v1.46.0 is the result of a six-agent audit of the protocol and the companion skill; 37 findings were confirmed and 33 are fixed here. Nothing in it is a feature - it is enforcement catching up with what the protocol already said. Most of the fixes share one shape: a printed rule that bound only where enforcement lived. The consensus finalizer and the auto-driver each owned a FINAL validator and only one checked the declared idea slug and status; the driver validated a review's reviewed-commit while the manual command did not; parley run probed the roster in preflight while standalone preflight probed every installed adapter family, including one removed from the roster, and still reported ready. Gates that accepted emptiness now require content: a blank round no longer passes as filed, an unwritten FINAL scaffold no longer closes an idea, and an implementation artifact can no longer declare an unknown status with an empty summary. A freshness check that treated two missing hashes as equal reported an altered protocol as in sync; the gate that replaced it could not be cleared by its own documented command, and now can. Four findings remain deferred with recorded reasons."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.46.0
+Tags:
+- ai
+- agents
+- automation
+- cli
+- codex
+- consensus
+- loop
+- multi-agent
+- orchestration
+- preflight
+- roster
+- tui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.46.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.46.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckCli.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Portable installer; x64 and arm64 binaries published on the GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422111)