### PR TITLE
New version: fejdraus.CreatioHelper version 1.1.8

### DIFF
--- a/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.installer.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.installer.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json

--- a/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.locale.en-US.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.locale.en-US.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json

--- a/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.yaml
+++ b/manifests/f/fejdraus/CreatioHelper/1.1.8/fejdraus.CreatioHelper.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json


### PR DESCRIPTION
### Pull request has been verified against the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

Update to version 1.1.8, which restores the log clearing that was dropped in 1.1.7.

The installer URL and SHA256 point at the release asset; `winget validate` passes. The local install check has not been run on this manifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422112)