### PR TITLE
New version: Feci.ParleyDeckSkill version 2.10.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.10.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.10.0/parley-deck-skill-v2.10.0-windows-x64.exe
+  InstallerSha256: B2F01D72DDB05B316812CD8ED5017A4473A5EFBE955A716AE9F6EC80FAD8F514
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.10.0/parley-deck-skill-v2.10.0-windows-arm64.exe
+  InstallerSha256: F9EC1EA4B42FB9B5127911CCF9999E0FCF220644F7AFF1CB0D18B798ABED24B0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.10.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, zcode, Antigravity CLI, Hermes, Kimi Code, or a custom skill directory. v2.10.0 fixes advice that pointed the wrong way. Nothing in the package read a project's recorded protocol role, so on a deck marked as the protocol source, the one place where the packaged copy is by definition the older one, the status command recommended reviewing local changes before adopting packaged protocol updates. Following that there means treating an older snapshot as an update to the newer live protocol. The recommendation now branches on the recorded role: a source deck is told the difference is expected and not to adopt, while a consumer deck keeps the advice it had. A deck with no recorded role also keeps the conservative wording rather than guessing which side is upstream, because the tool cannot tell and a confident wrong answer is the defect being fixed. The bundled protocol snapshot also carries this release cycle's audit corrections to the roster authority section, the quickstart, the directory layout, and the branch protection guidance."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.10.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- kimi
+- multi-agent
+- skill
+- zcode
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.10.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Feci.ParleyDeckSkill.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Portable installer; x64 and arm64 binaries published on the GitHub release. This PR touches only Feci.ParleyDeckSkill.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422113)