### PR TITLE
New package: Shreyam1008.ProtoPeek version 0.4.0

### DIFF
--- a/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.installer.yaml
+++ b/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Shreyam1008.ProtoPeek
+PackageVersion: 0.4.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/shreyam1008/ProtoPeek/releases/download/v0.4.0/protopeek_0.4.0_windows_x86_64.zip
+    InstallerSha256: 948670802514678FF3ABF6EBC6EA610FD279759B1FDD1DCB6CC3D7568DD86542
+    NestedInstallerFiles:
+      - RelativeFilePath: protopeek.exe
+        PortableCommandAlias: protopeek
+      - RelativeFilePath: pp.exe
+        PortableCommandAlias: pp
+  - Architecture: arm64
+    InstallerUrl: https://github.com/shreyam1008/ProtoPeek/releases/download/v0.4.0/protopeek_0.4.0_windows_arm64.zip
+    InstallerSha256: 61343F58E428EB8855BF3286E7247C6CBCDA8DEFA4618910A098EA0653E2AD48
+    NestedInstallerFiles:
+      - RelativeFilePath: protopeek.exe
+        PortableCommandAlias: protopeek
+      - RelativeFilePath: pp.exe
+        PortableCommandAlias: pp
+  - Architecture: x86
+    InstallerUrl: https://github.com/shreyam1008/ProtoPeek/releases/download/v0.4.0/protopeek_0.4.0_windows_x86_32.zip
+    InstallerSha256: FDB1E39DA08B914DADC9D6C37893034B2CCBDCB4D5BA52704836DE74B318207
+    NestedInstallerFiles:
+      - RelativeFilePath: protopeek.exe
+        PortableCommandAlias: protopeek
+      - RelativeFilePath: pp.exe
+        PortableCommandAlias: pp
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.locale.en-US.yaml
+++ b/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Shreyam1008.ProtoPeek
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Shreyam Adhikari
+PublisherUrl: https://shreyam1008.com.np/
+PublisherSupportUrl: https://github.com/shreyam1008/ProtoPeek/issues
+Author: Shreyam Adhikari
+PackageName: ProtoPeek
+PackageUrl: https://protopeek.shreyam1008.com.np/
+License: MIT
+LicenseUrl: https://github.com/shreyam1008/ProtoPeek/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Shreyam Adhikari
+ShortDescription: Local-first gRPC, HTTP, and bounded network workbench
+Description: |-
+  ProtoPeek is a local-first protocol workbench for gRPC and HTTP APIs.
+  It also provides bounded Linux path evidence, authorized private-network
+  discovery, saved snapshots, and a logical topology map while keeping
+  credentials and request history on the local machine.
+Moniker: protopeek
+Tags:
+  - grpc
+  - http
+  - rest
+  - api
+  - network
+  - networking
+  - developer-tools
+  - protocol
+  - diagnostics
+ReleaseNotesUrl: https://github.com/shreyam1008/ProtoPeek/releases/tag/v0.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.yaml
+++ b/manifests/s/Shreyam1008/ProtoPeek/0.4.0/Shreyam1008.ProtoPeek.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Shreyam1008.ProtoPeek
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## ProtoPeek 0.4.0

- Adds the first WinGet manifest for Shreyam1008.ProtoPeek.
- Uses the public v0.4.0 Windows x64, arm64, and x86 ZIP archives.
- Each archive is a portable nested installer exposing both `protopeek` and `pp` commands.
- SHA-256 values match the published v0.4.0 checksums.

Release: https://github.com/shreyam1008/ProtoPeek/releases/tag/v0.4.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422115)