### PR TITLE
New version: M-Igashi.baken version 3.0.3

### DIFF
--- a/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.installer.yaml
+++ b/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.installer.yaml
@@ -1,0 +1,20 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.0.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: baken.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-08-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/baken/releases/download/v3.0.3/baken-v3.0.3-windows-x86_64.zip
+    InstallerSha256: 9CA4FA5EAD997B5158B828EFB6037A63AF640B228848AF196557723622086601
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.0.3
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/baken/issues
+Author: M-Igashi
+PackageName: Bake'n Deck
+PackageUrl: https://github.com/M-Igashi/baken
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/baken/blob/main/LICENSE
+ShortDescription: Rekordbox to CDJ prep toolkit - loudness gain, Key+BPM playlist sort, and CDJ-safe MP3 transcode
+Description: |-
+  Bake'n Deck (baken) is a Rekordbox to CDJ prep toolkit, the successor to headroom (renamed at v3.0.0).
+  The headroom subcommand analyzes audio files for loudness (LUFS) and True Peak headroom, then applies lossless gain adjustment. It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files, with batch processing, lossless MP3/AAC gain via mp3rgain, and a scriptable non-interactive CLI mode.
+  The rbsort subcommand sorts a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep - no audio touched, no ffmpeg required.
+  The cdjsafe subcommand (new in v3.0.0) converts every track in a playlist to 320 kbps CBR MP3 at 44.1 kHz for pre-NXS2 CDJs, emitting an updated XML in which converted tracks inherit beatgrids and cue points verbatim.
+Moniker: baken
+Tags:
+  - aac
+  - audio
+  - cdj
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/baken/releases/tag/v3.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.yaml
+++ b/manifests/m/M-Igashi/baken/3.0.3/M-Igashi.baken.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of Bake'n Deck (`baken`), a Rekordbox → CDJ prep toolkit written in Rust.

- Release: https://github.com/M-Igashi/baken/releases/tag/v3.0.3
- Manifests follow schema 1.12.0, unchanged from 3.0.2 apart from version, URL, hash and release date
- SHA256 verified against the published `baken-v3.0.3-checksums.txt`

### Changes in 3.0.3
- Lossless files (WAV/AIFF/FLAC) now keep their original bit depth after gain application instead of being forced to 24-bit
- Dependency updates: mp3rgain 3.2.0, clap 4.6.6, thiserror 2.0.20

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422119)