### PR TITLE
Update: SerZhyAle.StreamsPlayer to 26.0821.1208

### DIFF
--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.installer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.installer.yaml
@@ -1,17 +1,14 @@
 ﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: SerZhyAle.StreamsPlayer
 PackageVersion: 26.0821.1208
-InstallerType: zip
-NestedInstallerType: portable
+InstallerType: inno
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.17763.0
-NestedInstallerFiles:
-- RelativeFilePath: StreamsPlayer.exe
-  PortableCommandAlias: streamsplayer
+ProductCode: '{15F4F08C-E78B-41B7-9039-6A3332D7D080}_is1'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0821.1208/StreamsPlayer-26.0821.1208-windows-x64.zip
-  InstallerSha256: 8A9360C1CEBFEE2106FEDE25FCB0F01AEB9A58D294AC2C1D6106095A4D83CD92
+  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0821.1208/StreamsPlayer-26.0821.1208-windows-x64-setup.exe
+  InstallerSha256: FE82DB09310F45A08915F073F462EEEBF6B55D3338C61432171197F2CE979456
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.installer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.installer.yaml
@@ -1,0 +1,17 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0821.1208
+InstallerType: zip
+NestedInstallerType: portable
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+NestedInstallerFiles:
+- RelativeFilePath: StreamsPlayer.exe
+  PortableCommandAlias: streamsplayer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/download/v26.0821.1208/StreamsPlayer-26.0821.1208-windows-x64.zip
+  InstallerSha256: 8A9360C1CEBFEE2106FEDE25FCB0F01AEB9A58D294AC2C1D6106095A4D83CD92
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.en-US.yaml
@@ -1,0 +1,34 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0821.1208
+PackageLocale: en-US
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: STREAMS Player
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+Moniker: streamsplayer
+ShortDescription: Browse internet radio and live video in a focused Windows stream catalog.
+Description: STREAMS Player is a Windows desktop app for browsing a curated internet radio, live video, and RTSP address catalog, with its interface available in thirteen languages. Search, filter, pin, and add streams; choose List or Grid mode with optional live thumbnails; and open video with always-on-top and fullscreen controls. Catalog refresh is explicit, local state stays on the device, and the app has no account, advertising, analytics, or telemetry. Playback compatibility varies by provider, protocol, and codec.
+Tags:
+- radio
+- streaming
+- video
+- rtsp
+- live-tv
+- iptv
+- windows
+ReleaseNotes: |-
+  Version 26.0821.1208
+
+  - Radio plays again. In 26.0820.1828 every station failed the moment it was opened, on every machine - the fault was in the Windows runtime the application shipped with, not in the station or your connection. If that version played nothing for you, this one fixes it and nothing needs to be reset.
+  - There is now an installer. Download one file, run it, and the application installs for your account without asking for administrator rights, adds itself to the Start menu and to the list of installed applications, and uninstalls from there. The portable ZIP stays exactly as it was for anyone who prefers to unpack a folder.
+  - Removing the application leaves your own data alone - pinned channels, collections, history and settings survive an uninstall, and are still there if you install again.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0821.1208
+ReleaseDate: 2026-08-21
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.ru-RU.yaml
@@ -1,0 +1,31 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0821.1208
+PackageLocale: ru-RU
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляции
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог интернет-радио и live-видео для Windows с русским интерфейсом.
+Description: Трансляции - приложение Windows для просмотра каталога интернет-радио, live-видео и адресов RTSP; интерфейс доступен на тринадцати языках. Ищите, фильтруйте, закрепляйте и добавляйте потоки; выбирайте список или сетку с отключаемыми живыми миниатюрами; открывайте видео поверх окон или во весь экран. Каталог обновляется только по команде, локальные данные остаются на устройстве, в приложении нет аккаунта, рекламы, аналитики и телеметрии. Совместимость воспроизведения зависит от поставщика, протокола и кодека.
+Tags:
+- радио
+- потоки
+- видео
+- rtsp
+- телевидение
+- iptv
+ReleaseNotes: |-
+  Версия 26.0821.1208
+
+  - Радио снова играет. В 26.0820.1828 любая станция обрывалась сразу при открытии, на любой машине - причина была в системном рантайме Windows, с которым поставлялось приложение, а не в станции и не в вашем соединении. Если та версия не играла ничего, эта чинит это, и ничего сбрасывать не нужно.
+  - Появился установщик. Скачайте один файл, запустите, и приложение установится для вашей учётной записи, не спрашивая прав администратора, добавится в меню «Пуск» и в список установленных программ и оттуда же удаляется. Переносимый ZIP остался ровно таким, каким был, для тех, кто предпочитает распаковать папку.
+  - Удаление приложения не трогает ваши данные - закреплённые каналы, подборки, история и настройки переживают удаление и остаются на месте, если вы установите приложение снова.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0821.1208
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.uk-UA.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.locale.uk-UA.yaml
@@ -1,0 +1,31 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0821.1208
+PackageLocale: uk-UA
+Publisher: SerZhyAle
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/StreamsPlayer/issues
+PrivacyUrl: https://serzhyale.github.io/StreamsPlayer/privacy.html
+PackageName: Трансляції
+PackageUrl: https://serzhyale.github.io/StreamsPlayer/
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/StreamsPlayer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Serhii Zhyhunenko
+ShortDescription: Каталог інтернет-радіо та live-відео для Windows з українським інтерфейсом.
+Description: Трансляції - застосунок Windows для перегляду каталогу інтернет-радіо, live-відео й адрес RTSP; інтерфейс доступний тринадцятьма мовами. Шукайте, фільтруйте, закріплюйте та додавайте потоки; вибирайте список або сітку з живими мініатюрами, які можна вимкнути; відкривайте відео поверх усіх вікон або на весь екран. Каталог оновлюється лише за командою, локальні дані залишаються на пристрої, у застосунку немає облікового запису, реклами, аналітики й телеметрії. Сумісність відтворення залежить від постачальника, протоколу та кодека.
+Tags:
+- радіо
+- потоки
+- відео
+- rtsp
+- телебачення
+- iptv
+ReleaseNotes: |-
+  Версія 26.0821.1208
+
+  - Радіо знову грає. У 26.0820.1828 будь-яка станція обривалася одразу при відкритті, на будь-якій машині - причина була в системному рантаймі Windows, з яким постачалася програма, а не в станції і не у вашому з'єднанні. Якщо та версія не грала нічого, ця це виправляє, і нічого скидати не потрібно.
+  - З'явився інсталятор. Завантажте один файл, запустіть, і програма встановиться для вашого облікового запису, не питаючи прав адміністратора, додасться в меню «Пуск» і до списку встановлених програм і звідти ж видаляється. Переносний ZIP лишився рівно таким, яким був, для тих, хто воліє розпакувати теку.
+  - Видалення програми не чіпає ваші дані - закріплені канали, добірки, історія та налаштування переживають видалення і лишаються на місці, якщо ви встановите програму знову.
+ReleaseNotesUrl: https://github.com/SerZhyAle/StreamsPlayer/releases/tag/v26.0821.1208
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.yaml
+++ b/manifests/s/SerZhyAle/StreamsPlayer/26.0821.1208/SerZhyAle.StreamsPlayer.yaml
@@ -1,0 +1,6 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: SerZhyAle.StreamsPlayer
+PackageVersion: 26.0821.1208
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

STREAMS Player (`SerZhyAle.StreamsPlayer`) 26.0821.1208. Portable zip, x64, published as a GitHub Release by the project's own release workflow.

This version exists to fix a total playback failure. 26.0820.1828 - the version currently in this repository - shipped a WPF runtime that breaks `MediaElement` network audio outright, so the application opens, loads its catalog and plays nothing at all, on every machine. The runtime is pinned back in 26.0821.1208 and playback works again. Anyone who installs or upgrades the current manifest today gets a silent application, which is why this is worth a look ahead of a normal feature update. Release notes are in the en-US, ru-RU and uk-UA locale manifests.

Verification on the exact `InstallerUrl` in the installer manifest, beyond the local install below: the asset was downloaded from that URL, its SHA256 recomputed and compared to `InstallerSha256` (`8A9360C1...3CD92`, match), and the archive checked to contain the declared `NestedInstallerFiles` entry `StreamsPlayer.exe` at its root. The installed payload was then launched and played a live stream, confirming the fix is in the artifact this manifest points at and not only in the source.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422124)