### PR TITLE
New version: hdosys.herdr-sandbox version 0.0.18

### DIFF
--- a/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.installer.yaml
+++ b/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-sandbox
+PackageVersion: 0.0.18
+MinimumOSVersion: 10.0.18362.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Commands:
+- sandbox
+ProductCode: '{BF6EF455-61AF-43BD-8A25-521C6C7E13F9}'
+UnsupportedArguments:
+- log
+- location
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hdosys/herdr-sandbox/releases/download/v0.0.18/herdr-sandbox_v0.0.18_windows_amd64_setup.exe
+  InstallerSha256: 64480AC608A802D9BF905079FF3A95DF5363C3C89A2F4A7AFC0235BF362EFDC6
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-21

--- a/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.locale.en-US.yaml
+++ b/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-sandbox
+PackageVersion: 0.0.18
+PackageLocale: en-US
+Publisher: hdosys
+PublisherUrl: https://github.com/hdosys
+PublisherSupportUrl: https://github.com/hdosys/herdr-sandbox/issues
+PackageName: Herdr Sandbox
+PackageUrl: https://github.com/hdosys/herdr-sandbox
+License: Apache-2.0
+LicenseUrl: https://github.com/hdosys/herdr-sandbox/blob/v0.0.18/LICENSE
+Copyright: Copyright (c) 2026 hdosys
+ShortDescription: Run Windows development and coding-agent workloads in disposable Windows Sandbox instances.
+Description: Herdr Sandbox launches disposable Windows Sandbox development environments, provisions native Windows toolchains, and connects an independently installed compatible Herdr client to the guest over SSH.
+Tags:
+- cli
+- developer-tools
+- sandbox
+- windows-sandbox
+ReleaseNotesUrl: https://github.com/hdosys/herdr-sandbox/releases/tag/v0.0.18
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.yaml
+++ b/manifests/h/hdosys/herdr-sandbox/0.0.18/hdosys.herdr-sandbox.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-sandbox
+PackageVersion: 0.0.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `hdosys.herdr-sandbox` to version `0.0.18` using the public GitHub release installer and its verified SHA-256. The manifest also carries the package's canonical uninstall ProductCode.

## Manifest checklist

- [x] Checked that there are no other open pull requests for this package version
- [x] This PR modifies one package manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [ ] Tested locally through `winget install --manifest <path>`
- [x] Manifest conforms to schema 1.12
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422126)