### PR TITLE
New package: Macmod.ldapx version 1.3.3

### DIFF
--- a/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.installer.yaml
+++ b/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Macmod.ldapx
+PackageVersion: 1.3.3
+InstallerType: zip
+Commands:
+- ldapx
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Macmod/ldapx/releases/download/v1.3.3/ldapx-v1.3.3-windows-amd64.zip
+  InstallerSha256: D9163590B651751B847DB25831EE1CED7DAACB7BFD4EA2C5C1EFE562CE736457
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: ldapx.exe
+    PortableCommandAlias: ldapx
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.locale.en-US.yaml
+++ b/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Macmod.ldapx
+PackageVersion: 1.3.3
+PackageLocale: en-US
+Publisher: Macmod
+PublisherUrl: https://github.com/Macmod
+PackageName: ldapx
+PackageUrl: https://github.com/Macmod/ldapx
+License: MIT
+LicenseUrl: https://github.com/Macmod/ldapx/blob/v1.3.3/LICENSE
+ShortDescription: Flexible LDAP proxy for inspecting and transforming LDAP traffic
+Tags:
+- ldap
+- proxy
+- active-directory
+- security
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.yaml
+++ b/manifests/m/Macmod/ldapx/1.3.3/Macmod.ldapx.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Macmod.ldapx
+PackageVersion: 1.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Macmod.ldapx** version 1.3.3 — a flexible LDAP proxy for inspecting and
transforming LDAP traffic (https://github.com/Macmod/ldapx). Portable CLI shipped as a
zip with a nested `ldapx.exe` (x64).

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422140)