### PR TITLE
New package: StruisICT.InSearch version 0.2.0

### DIFF
--- a/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.installer.yaml
+++ b/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.installer.yaml
@@ -1,0 +1,20 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InSearch
+PackageVersion: 0.2.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ReleaseDate: 2026-08-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/InSearch/releases/download/v0.2.0/InSearch-0.2.0-x86_64.msi
+  InstallerSha256: 023FBDE80CBE621F98EC9CFBF4F30DF6D66407418F6ADF8D9810F6C66E12C10A
+  ProductCode: '{849E8E1D-62E9-4633-AA77-5512DD98AA80}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.locale.en-US.yaml
+++ b/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InSearch
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/StruisICT/InSearch/issues
+PackageName: InSearch
+PackageUrl: https://github.com/StruisICT/InSearch
+License: MIT
+LicenseUrl: https://github.com/StruisICT/InSearch/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Real-time, content-aware file search â€” find files and search inside them.
+Description: |-
+  InSearch is a real-time file search tool that finds files on disk and searches
+  inside them, streaming matches as it goes. It searches plain text and logs plus
+  PDF, Word (docx) and Excel (xls/xlsx/ods), with matches reported per line or per
+  timestamp-to-timestamp block. Query with substring, regex, all-words (AND),
+  any-words (OR) and exclude (NOT); filter by name, extension, size and date;
+  watch folders for changes (log-tailing); export results; and search a folder
+  straight from the Explorer right-click menu. Everything runs locally.
+Moniker: insearch
+Tags:
+- search
+- file-search
+- content-search
+- grep
+- find
+- logs
+- utility
+- windows
+ReleaseNotes: |-
+  See the full release notes at https://github.com/StruisICT/InSearch/releases/tag/v0.2.0
+ReleaseNotesUrl: https://github.com/StruisICT/InSearch/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.yaml
+++ b/manifests/s/StruisICT/InSearch/0.2.0/StruisICT.InSearch.yaml
@@ -1,0 +1,8 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InSearch
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds **StruisICT.InSearch** version 0.2.0 (MSI installer).

- [x] Manifest validated with `winget validate` (passed)
- [x] Installation tested with `winget install --manifest` (installs; detected by ProductCode)
- [x] Schema 1.12.0; `InstallerSha256` and `ProductCode` taken from the published GitHub release MSI

InSearch is a real-time, content-aware file search app — it finds files and searches inside them (text, logs, pdf, docx, xls). Source: https://github.com/StruisICT/InSearch
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422147)