### PR TITLE
New version: maze-mei.DXManager version 2.0.0

### DIFF
--- a/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.installer.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+- dxmanager
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: DX Manager\DXManager.exe
+  PortableCommandAlias: dxmanager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/maze-mei/DX-Manager/releases/download/v2.0.0/DX-Manager-v2.0.0-win-x64.zip
+  InstallerSha256: CA78A306F61235708DBDDE0541C06E071C646DC0F8B47BC8F2487E5518E8AF86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.locale.en-US.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v2.0.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Manage Samsung DeX virtual displays and scrcpy app windows on Windows.
+Description: DX Manager creates and manages Samsung DeX virtual displays and separately configured Android app windows for multiple Galaxy phones over USB or wireless ADB. It also includes DX Companion for recovery and bidirectional file transfer.
+Moniker: dxmanager
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v2.0.0
+InstallationNotes: DX Manager requires .NET Framework 4.6.2 or later, Android Developer options, and USB debugging. Initial ADB authorization requires a data-capable USB connection. DX Companion is bundled but is installed only when the user requests it.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.locale.ko-KR.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.locale.ko-KR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.0
+PackageLocale: ko-KR
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v2.0.0/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Windows에서 Samsung DeX 가상 디스플레이와 scrcpy 앱 창을 관리합니다.
+Description: DX Manager는 여러 Galaxy 휴대폰의 Samsung DeX 가상 디스플레이와 서로 다르게 설정한 Android 앱 창을 USB 또는 무선 ADB로 동시에 관리합니다. 복구와 양방향 파일 전송을 위한 DX Companion도 포함합니다.
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v2.0.0
+InstallationNotes: DX Manager를 사용하려면 .NET Framework 4.6.2 이상, Android 개발자 옵션, USB 디버깅이 필요합니다. 최초 ADB 인증에는 데이터 통신이 가능한 USB 연결이 필요합니다. DX Companion은 번들에 포함되지만 사용자가 요청할 때만 설치됩니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.0/maze-mei.DXManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates maze-mei.DXManager from 1.3.0 to 2.0.0 using the official GitHub release asset. The release archive SHA256 and nested portable executable path were verified. The English and Korean metadata now describe multi-device management, the bundled DX Companion, recovery, and bidirectional file transfer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422168)