### PR TITLE
New version: Unity.CLI version 1.0.0.20006

### DIFF
--- a/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.installer.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20006
+InstallerLocale: en-US
+InstallerType: msix
+MinimumOSVersion: 10.0.17763.0
+PackageFamilyName: UnityTechnologies.UnityCLI_2vrhnee42bhxm
+Commands:
+- unity
+ReleaseDate: 2026-08-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.6/unity-windows-x64.msix
+  InstallerSha256: EE7292BED6B25EDF5A3E06B2F94A97A4D1C56B6FD2DC31815C8A58F88CB9C33D
+  SignatureSha256: F38D038663613B61F98B701E5E6D0B99D7C6226BB52695BA8CD930408A194C04
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.6/unity-windows-arm64.msix
+  InstallerSha256: DFBF11B4C127E7A1F3430001148096CBB19C4552CA1128A7EAD5980234DB0B02
+  SignatureSha256: 151470E6D7FE63C886BF2D51728A92CE8B589BDF7997FA41BFFE89FB86F73FCF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.locale.en-US.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20006
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity CLI
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Command-line interface for installing Unity Editors and creating, opening, and building Unity projects.
+Description: The Unity CLI (invoked as "unity") manages Unity Editor installations and modules, creates and opens projects, runs builds and Editor commands, and manages licenses and cloud sign-in from the terminal. This build reports its version as 1.0.0-beta.6; MSIX package versions encode the prerelease channel in the fourth (revision) field.
+Moniker: unity-cli
+Tags:
+- cli
+- command-line
+- unity
+- unity3d
+ReleaseNotes: |-
+  Highlights of 1.0.0-beta.6 (full notes at the release notes URL):
+  - unity projects create and unity projects link vcs can now create the repository through gh, glab, or tea for hosts with no REST client: GitHub Enterprise Server, self-managed GitLab, self-hosted Gitea/Forgejo.
+  - unity projects clone and unity projects link vcs accept a plain git URL now, including full SSH transport, so any git host works.
+  - unity projects verify is a new command that checks a project for broken .meta files, duplicate GUIDs, and unresolved merge conflicts without needing an Editor or a license.
+  - unity build now writes a redacted build provenance manifest next to its output and prints a periodic stall heartbeat, with a new --timeout flag.
+  - unity collaboration (unity collab) is part of every build now instead of development builds only.
+  - unity test gains --shard, --retries, and --rerun-failed for CI, and now uses exit code 8 specifically for failing tests, reserving 6 for a run that never reached a verdict.
+ReleaseNotesUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.6/CHANGELOG.md
+Documentations:
+- DocumentLabel: Unity CLI Manual
+  DocumentUrl: https://docs.unity.com/unity-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20006/Unity.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20006
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Unity CLI **1.0.0-beta.6** as `Unity.CLI` version `1.0.0.20006`.

- `InstallerSha256` values cross-checked against the vendor's published `SHA256SUMS` for the release (both agree).
- `SignatureSha256` values computed from each downloaded `.msix`'s embedded `AppxSignature.p7x`.
- `PackageVersion` matches the 4-part MSIX encoding of the semver (`1.0.0-beta.6` → `1.0.0.20006`); `unity --version` reports the semver form.
- `ReleaseDate` taken from the GitHub release's publish date (2026-08-21).
- `PackageFamilyName` unchanged from the previous revision (`UnityTechnologies.UnityCLI_2vrhnee42bhxm`) — same signing identity.
- `ReleaseNotes` condensed from the shipped changelog; `ReleaseNotesUrl` points at the full notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (verified: `license/cla` passes on this PR).
- [ ] Linked to an issue (if applicable) — not applicable, this is a routine version bump.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change.
- [x] This PR only modifies one (1) manifest.
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)