### PR TITLE
New package: scarlone.WinBoost version 0.1.0

### DIFF
--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.installer.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+PackageIdentifier: scarlone.WinBoost
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+# winget stesso richiede Windows 10 1809: dichiarare meno sarebbe una promessa vuota.
+MinimumOSVersion: 10.0.17763.0
+# "portable": winget copia l'exe in %LOCALAPPDATA%\Microsoft\WinGet\Packages e crea
+# l'alias qui sotto. Niente installer da scrivere ne' Program Files da toccare.
+InstallerType: portable
+# L'alias con cui l'exe e' invocabile da terminale dopo l'installazione. Ha senso
+# anche per un'app WPF: WinBoost accetta argomenti a riga di comando
+# (--catalog, --profile-inspector), quindi "winboost --catalog x.json" e' un uso reale.
+Commands:
+- winboost
+# Su winget va il profilo framework-dependent (~0,6 MB): il runtime lo installa
+# winget come dipendenza, non ha senso far scaricare 68 MB di runtime incorporato.
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/scarlone/WinBoost/releases/download/v0.1.0/WinBoost-0.1.0-win-x64-framework.exe
+  # SHA256 dell'asset pubblicato nella release v0.1.0, verificato riscaricando il
+  # file e ricalcolandolo: coincide con quanto dichiarato in SHA256SUMS.txt.
+  InstallerSha256: D35BBA5BD28AE1A5ACFD86391780437BB5460008CCD089A81C7E9BE19CEF8A22
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.installer.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: scarlone.WinBoost
 PackageVersion: 0.1.0
 InstallerLocale: en-US
@@ -26,4 +26,4 @@ Installers:
   # file e ricalcolandolo: coincide con quanto dichiarato in SHA256SUMS.txt.
   InstallerSha256: D35BBA5BD28AE1A5ACFD86391780437BB5460008CCD089A81C7E9BE19CEF8A22
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.locale.en-US.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # winget deduce il tipo di manifesto da questo URL: "defaultLocale" va scritto in
 # camelCase anche se il $id ufficiale dello schema e' tutto minuscolo.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 # winget-pkgs vuole en-US come defaultLocale: i campi destinati agli utenti
 # (ShortDescription, Description, Tags, InstallationNotes) sono in inglese.
 PackageIdentifier: scarlone.WinBoost
@@ -48,4 +48,4 @@ InstallationNotes: |-
   signed yet: SmartScreen may warn on first launch. Requires the .NET 8 Desktop
   Runtime, which winget installs as a declared dependency.
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.locale.en-US.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# winget deduce il tipo di manifesto da questo URL: "defaultLocale" va scritto in
+# camelCase anche se il $id ufficiale dello schema e' tutto minuscolo.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# winget-pkgs vuole en-US come defaultLocale: i campi destinati agli utenti
+# (ShortDescription, Description, Tags, InstallationNotes) sono in inglese.
+PackageIdentifier: scarlone.WinBoost
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: scarlone
+PublisherUrl: https://github.com/scarlone/WinBoost
+PublisherSupportUrl: https://github.com/scarlone/WinBoost/issues
+PackageName: WinBoost
+PackageUrl: https://github.com/scarlone/WinBoost
+License: MIT
+LicenseUrl: https://github.com/scarlone/WinBoost/blob/main/LICENSE
+Copyright: Copyright (c) 2026 scarlone
+ShortDescription: Data-driven Windows optimizer with non-destructive preview and real rollback
+Description: |-
+  WinBoost is a portable, single-executable Windows optimizer. Its tweak catalog
+  (registry keys, services, network parameters, power plans, GPU profiles,
+  preinstalled apps) is declarative data embedded in the executable, and every
+  change is shown in a preview with the current and the proposed value before
+  anything is written. Each apply session keeps a journal with the previous
+  value of every operation, so applied tweaks can be rolled back; operations
+  that cannot be undone are declared as such in the UI. The application runs
+  without administrator rights and requests elevation only when applying tweaks
+  that need it.
+Moniker: winboost
+Tags:
+- debloat
+- gaming
+- network
+- optimization
+- performance
+- portable
+- registry
+- rollback
+- tweak
+- windows
+ReleaseNotesUrl: https://github.com/scarlone/WinBoost/releases/tag/v0.1.0
+# Nota di conformita': mette per iscritto cosa fa il pacchetto sul sistema e come
+# si comporta con l'elevazione, cosi' l'utente (e il reviewer) non deve dedurlo.
+InstallationNotes: |-
+  WinBoost modifies the Windows registry, services and network settings only
+  when you explicitly apply a tweak, and keeps a per-session journal so changes
+  can be rolled back. It runs unelevated and asks for administrator rights per
+  session, only when a selected tweak requires them. The executable is not code
+  signed yet: SmartScreen may warn on first launch. Requires the .NET 8 Desktop
+  Runtime, which winget installs as a declared dependency.
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: scarlone.WinBoost
 PackageVersion: 0.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.yaml
+++ b/manifests/s/scarlone/WinBoost/0.1.0/scarlone.WinBoost.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+PackageIdentifier: scarlone.WinBoost
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
### New package: `scarlone.WinBoost` version `0.1.0`

WinBoost is a portable, single-executable Windows optimizer with a non-destructive
preview and a per-session rollback journal.

- Repository: https://github.com/scarlone/WinBoost
- Release: https://github.com/scarlone/WinBoost/releases/tag/v0.1.0
- License: MIT

#### Notes for reviewers

- `InstallerType: portable`, x64 only. The published installer is the
  **framework-dependent** build (~0.75 MB); the .NET 8 Desktop Runtime is declared as a
  package dependency (`Microsoft.DotNet.DesktopRuntime.8`) rather than bundled.
- **The executable is not code signed yet.** SmartScreen may warn on first launch. This
  is stated in `InstallationNotes` so it is visible to users at install time.
- **The package modifies the system**: registry values, service start types, network
  settings and power plans. It does so only when the user explicitly applies a tweak.
  The application runs unelevated (`asInvoker`) and requests elevation per session, only
  when a selected tweak requires it. Every applied change is journaled with its previous
  value so it can be rolled back from the UI. `InstallationNotes` states this too.

#### Verification performed

- `winget validate --manifest` passes (only the expected warning about the dependency
  not being resolvable locally).
- The `InstallerSha256` was verified by downloading the release asset anonymously and
  recomputing the hash; it matches the `SHA256SUMS.txt` published alongside it.
- The downloaded executable was launched and starts correctly.

#### Not verified

- `winget install --manifest` was **not** run locally: enabling `LocalManifestFiles`
  requires administrator privileges that were unavailable in the environment used to
  prepare this submission. Flagging it rather than silently ticking the box.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422222)