### PR TITLE
New version: TraceCommons.Contributor version 0.4.6

### DIFF
--- a/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.installer.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.4.6
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: trace-commons-contributor.exe
+  PortableCommandAlias: trace-commons-contributor
+Commands:
+- trace-commons-contributor
+ReleaseDate: "2026-08-21"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TraceCommons/trace-commons-server/releases/download/contributor-v0.4.6/trace-commons-contributor-x86_64-pc-windows-msvc.zip
+  InstallerSha256: FFD9C7C7215DC3E246DCC8CF9DF73740DE364F003476C2DE853673F97C6EB2BA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.locale.en-US.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.4.6
+PackageLocale: en-US
+Publisher: Iqlusion Inc
+PublisherUrl: https://tracecommons.ai
+PublisherSupportUrl: https://github.com/TraceCommons/trace-commons-server/issues
+PackageName: Trace Commons Contributor
+PackageUrl: https://tracecommons.ai/install/
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/TraceCommons/trace-commons-server/blob/main/LICENSE
+ShortDescription: Share the traces your coding agents produce, on your terms, and earn credits.
+Description: |-
+  The Trace Commons contributor CLI finds the sessions your local coding agents
+  have already written, shows you exactly what would be sent before anything is,
+  and submits only what you approve. Discovery, parsing and redaction all happen
+  on your own machine; nothing leaves it until you run submit.
+Moniker: trace-commons
+Tags:
+- ai
+- agent
+- cli
+- developer-tools
+- llm
+- traces
+ReleaseNotesUrl: https://github.com/TraceCommons/trace-commons-server/releases/tag/contributor-v0.4.6
+Documentations:
+- DocumentLabel: Quickstart
+  DocumentUrl: https://docs.tracecommons.ai/cli/quickstart/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.yaml
+++ b/manifests/t/TraceCommons/Contributor/0.4.6/TraceCommons.Contributor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TraceCommons.Contributor
+PackageVersion: 0.4.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version of the Trace Commons contributor CLI: `TraceCommons.Contributor` 0.4.6.

Portable zip containing a single Authenticode-signed executable
(`trace-commons-contributor.exe`, signed as `CN=Iqlusion Inc` via Azure Trusted
Signing and RFC3161-timestamped), published from the `contributor-v0.4.6`
release of TraceCommons/trace-commons-server. The manifests are generated by
that repository's release workflow and the installer SHA256 matches the
checksum published beside the asset on the release.

Supersedes the earlier new-package submissions #420015 (0.3.0) and #422116
(0.4.4), which are for the same package at older versions.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — the `license/cla` check passed on this account's earlier submissions (#420015, #422116); if the bot disagrees here, say so and it will be signed.
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — not run: submitted from macOS, where `winget` is unavailable. Relying on this repository's validation pipeline.
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run, same reason.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422225)