### PR TITLE
New package: StephanOrgiazzi.EverythingNext version 0.9.1

### DIFF
--- a/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.installer.yaml
+++ b/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StephanOrgiazzi.EverythingNext
+PackageVersion: 0.9.1
+InstallerType: nullsoft
+Scope: machine
+UpgradeBehavior: install
+RequireExplicitUpgrade: true
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StephanOrgiazzi/EverythingNext/releases/download/v0.9.1/Everything.Next_0.9.1_x64-setup.exe
+  InstallerSha256: CFF401E5AA2CC0C37B9C4CC2776BAB77B1018A42D4CBB192C4CDB93B5D6B4487
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.locale.en-US.yaml
+++ b/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StephanOrgiazzi.EverythingNext
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: Stephan Orgiazzi
+PublisherUrl: https://github.com/StephanOrgiazzi
+PublisherSupportUrl: https://github.com/StephanOrgiazzi/EverythingNext/issues
+PackageName: Everything Next
+PackageUrl: https://github.com/StephanOrgiazzi/EverythingNext
+License: MIT
+LicenseUrl: https://github.com/StephanOrgiazzi/EverythingNext/blob/master/LICENSE
+ShortDescription: Fast, native-style file search for Windows 11
+Description: Everything Next is an open-source desktop client for Everything 1.5, with native query syntax, instant indexing, file actions, and a Windows 11 native-style interface.
+Moniker: everything-next
+Tags:
+- everything
+- file-search
+- search
+- windows
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.yaml
+++ b/manifests/s/StephanOrgiazzi/EverythingNext/0.9.1/StephanOrgiazzi.EverythingNext.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StephanOrgiazzi.EverythingNext
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the WinGet manifest for Everything Next version 0.9.1.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422278)
