### PR TITLE
Update version: MarceloLvCabral.BrightScriptEmulator version 2.5.0

### DIFF
--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.installer.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+ReleaseDate: 2026-08-20
+AppsAndFeaturesEntries:
+- DisplayName: BrightScript Simulator 2.5.0
+  ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lvcabral/brs-desktop/releases/download/v2.5.0/brs-desktop-2.5.0-windows.exe
+  InstallerSha256: B88C5189189B2DA3AAEF1BF4FEC822B4FE2C795750DCF632FA7295BD6ACB999B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: Marcelo Lv Cabral
+PublisherUrl: https://github.com/lvcabral
+PublisherSupportUrl: https://github.com/lvcabral/brs-desktop/issues
+PackageName: BrightScript Emulator
+PackageUrl: https://github.com/lvcabral/brs-desktop
+License: MIT
+LicenseUrl: https://github.com/lvcabral/brs-desktop/blob/master/LICENSE
+Copyright: Copyright © 2021 Marcelo Lv Cabral
+ShortDescription: Desktop Emulator for Roku 2D API
+Tags:
+- desktop
+- electron-app
+- emulator
+- roku
+- roku-development
+- simulator
+ReleaseNotes: "This release replaces the **Home app** by a new SceneGraph-based one, with support for removing sideloaded packages and jumping straight to a settings section. Roku peer device discovery results are now cached to disk so the peer menu is populated immediately on startup instead of waiting for a fresh network scan, and the **Deploy to Peer Roku** menu label now shows the discovered device's friendly name. The editor also gains a configurable console log level. Bumped `brs-engine` to v2.5.1 and `brs-scenegraph` to v0.5.1, bringing MPEG-DASH streaming support, an `hls.js` upgrade, and spec-compliant `AnimatedImage`/`roAnimatedImage`. Electron is also upgraded from v39 to v43, closing a security-patch gap.\r\n\r\nSee the **BrightScript Simulation Engine** v2.5.1 [full changelog](https://github.com/lvcabral/brs-engine/releases/) for all the language and framework features and improvements.\r\n\r\n### New Features\r\n\r\n• Replaced the Home app by a new SceneGraph based, with new features for removing recent/sideloaded apps from the grid and opening a specific settings sections by @lvcabral in #336\r\n• Added persistence for Roku device discovery results and a dynamic peer Roku menu label showing the discovered device's name by @lvcabral in #335\r\n• Added a configurable console log level to the editor settings by @lvcabral in #334\r\n\r\n### Maintenance\r\n\r\n• Upgraded Electron from v39 to v43 by @lvcabral\r\n  • App windows now load from a privileged `app://` scheme instead of `file://` (`src/helpers/protocol.js`), since Electron 43 stopped granting `crossOriginIsolated` to `file://` documents ([electron/electron#50789](https://github.com/electron/electron/pull/50789)), which `brs-engine`'s worker needs for `SharedArrayBuffer`\r\n  • Restored CORS-free cross-origin fetches for channel content, which `file://` provided for free but a real origin like `app://` does not\r\n  • Home app recent-apps icons now serve from `app://` too, cached under a dedicated `icons/` subdirectory of `userData` rather than its root (so the rest of `userData`, including `brs-settings.json`, isn't reachable from the app windows), with a matching fix in the `brs-home.zip` app so its icon loading recognizes the new scheme. Icons cached by earlier versions are moved into the new location automatically on first launch\r\n  • `toastify-js` is now copied into the build output instead of referenced via `../node_modules/...`, which only worked under `file://`\r\n  • The `file://` → `app://` change also moves `localStorage` to a new origin, which would otherwise orphan the editor's saved code snippets and `brs-engine`'s per-channel registry values from before the upgrade. These are now migrated automatically on first launch of the new version\r\n  • Preserved the app's square frameless window look on Linux, where v43 defaults frameless windows to rounded corners\r\n\r\n### Documentation\r\n\r\n• Documented the Debug Server command set and updated the VS Code integration guide to drop the retired `rendezvousTracking` launch config option by @lvcabral in #333\r\n\r\n### Dependency Bumps\r\n\r\n• Bump `brs-engine` from 2.4.0 to 2.5.1 by @lvcabral\r\n• Bump `brs-scenegraph` from 0.4.0 to 0.5.0 by @lvcabral\r\n• Bump `electron` from 39.2.7 to 43.4.0 by @lvcabral\r\n\r\n**Full Changelog**：https://github.com/lvcabral/brs-desktop/compare/v2.4.0...v2.5.0"
+ReleaseNotesUrl: https://github.com/lvcabral/brs-desktop/releases/tag/v2.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.0/MarceloLvCabral.BrightScriptEmulator.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update MarceloLvCabral.BrightScriptEmulator to version 2.5.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422290)