### PR TITLE
New version: Eumenes.HOSMeeting version 0.4.5

### DIFF
--- a/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.installer.yaml
+++ b/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Eumenes.HOSMeeting
+PackageVersion: 0.4.5
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.eumenes.ai/downloads/EumenesHOSMeeting-Setup-0.4.5.exe
+  InstallerSha256: DBC925F2D0D75D8B39B183208AFFE6AF4848813F3486BC4059E0A102391ABD67
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.locale.en-US.yaml
+++ b/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Eumenes.HOSMeeting
+PackageVersion: 0.4.5
+PackageLocale: en-US
+Publisher: Eumenes.ai
+PublisherUrl: https://eumenes.ai
+PublisherSupportUrl: https://hos.eumenes.ai
+PrivacyUrl: https://hos.eumenes.ai/privacy.html
+PackageName: Eumenes HOS Meeting
+PackageUrl: https://hos.eumenes.ai
+License: Proprietary
+LicenseUrl: https://hos.eumenes.ai/downloads/eula.txt
+Copyright: Copyright (c) 2026 Eumenes.ai
+ShortDescription: Local AI meeting note-taker that records both sides of your calls as separate streams, captures key slides, and transcribes on-device.
+Description: |-
+  Eumenes HOS Meeting is an AI note-taker that lives on your PC, not in your
+  calls. No bot joins your meeting and no audio leaves your laptop. It detects
+  video conferences (Teams, Zoom, Meet, Webex and browser calls), records your
+  microphone and the remote participants as two separate audio streams,
+  captures screenshots only when shared content changes, and transcribes
+  everything on-device in 25 languages when the call ends. Includes a 15-day
+  free trial; continued use requires a subscription.
+Moniker: hos-meeting
+Tags:
+- meeting
+- transcription
+- recorder
+- notes
+- speech-to-text
+- productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.yaml
+++ b/manifests/e/Eumenes/HOSMeeting/0.4.5/Eumenes.HOSMeeting.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Eumenes.HOSMeeting
+PackageVersion: 0.4.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### New version: Eumenes.HOSMeeting 0.4.5

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This PR only modifies one (1) manifest

Update to 0.4.5. Installer is per-user Inno Setup; SHA-256 verified against the hosted installer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422310)