### PR TITLE
New package: dixieflatline76.NachoFlow version 0.5.1

### DIFF
--- a/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.installer.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.installer.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.1
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/dixieflatline76/nacho-flow/releases/download/v0.5.1/nacho-flow-0.5.1-windows-amd64.exe
+    InstallerSha256: BB9C95D4E44CD79860C69DE26F0C902DAF5BF924C54E26A2B316C030C704A141
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.locale.en-US.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.1
+PackageLocale: en-US
+Publisher: dixieflatline76
+PackageName: Nacho Flow
+License: MIT
+ShortDescription: High-performance OpenAI-compatible hybrid AI gateway for local GPUs and cloud APIs (spicebox.dev).
+Moniker: nacho-flow
+Tags:
+  - ai
+  - llm
+  - proxy
+  - gateway
+  - ollama
+  - openrouter
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.1/dixieflatline76.NachoFlow.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description
Initial submission to add **dixieflatline76.NachoFlow** version **0.5.1** to the Windows Package Manager repository.

### 🏷️ Package & Publisher Metadata
* **Package Identifier:** `dixieflatline76.NachoFlow`
* **Package Name:** Nacho Flow
* **Publisher:** dixieflatline76 (part of the [spicebox.dev](https://spicebox.dev) developer tool suite)
* **Author / Publisher URL:** https://spicebox.dev
* **Source Repository:** https://github.com/dixieflatline76/nacho-flow
* **License:** MIT (https://github.com/dixieflatline76/nacho-flow/blob/main/LICENSE)
* **Release Page:** https://github.com/dixieflatline76/nacho-flow/releases/tag/v0.5.1

### 🛠️ Architecture & Installer Details
* **Installer Type:** Portable executable (`portable`)
* **Architecture:** `x64`
* **Download URL:** https://github.com/dixieflatline76/nacho-flow/releases/download/v0.5.1/nacho-flow-0.5.1-windows-amd64.exe
* **SHA-256 Hash:** `BB9C95D4E44CD79860C69DE26F0C902DAF5BF924C54E26A2B316C030C704A141`

### 📝 Software Overview
Nacho Flow is a lightweight, zero-dependency OpenAI-compatible proxy gateway built in Go. It sits locally on Windows (defaulting to `localhost:8000`) between autonomous coding assistants ([Roo Code](https://github.com/RooVetGit/Roo-Code), [Cline](https://github.com/cline/cline), [Aider](https://github.com/paul-gauthier/aider), [Cursor](https://www.cursor.com), [Continue](https://continue.dev)) and LLM backends.

* **Hybrid Cost Optimization**: Dynamically evaluates each prompt turn to route routine, small context turns to local workstation GPUs (Ollama, vLLM, LM Studio) for $0.00, and escalates heavy multi-file reasoning tasks to cloud endpoints (OpenRouter, DeepSeek, Azure OpenAI).
* **Zero Runtime Dependencies**: Distributed as a single self-contained binary with built-in background service management.

---

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same package
- [x] This PR only modifies one (1) manifest (`manifests/d/dixieflatline76/NachoFlow/0.5.1`)
- [x] Validated manifest locally with `winget validate --manifest`
- [x] Tested manifest locally with `winget install --manifest`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422327)