### PR TITLE
New package: YesterdaysLemon.CodexContinuity version 0.2.1

### DIFF
--- a/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.installer.yaml
+++ b/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.installer.yaml
@@ -13,8 +13,8 @@ Installers:
     InstallerUrl: https://github.com/YesterdaysLemon/codex-continuity/releases/download/v0.2.1/CodexContinuity-v0.2.1-Setup.exe
     InstallerSha256: 886EA4878F252A0B65C0E826CB631AFFED09B861F5280E5DF4DFE000BBE47EB9
     InstallerSwitches:
-      Silent: --silent
-      SilentWithProgress: --silent
+      Silent: --silent --skip-self-test --no-start
+      SilentWithProgress: --silent --skip-self-test --no-start
     ProductCode: CodexContinuity
     AppsAndFeaturesEntries:
       - DisplayName: Codex Continuity

--- a/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.installer.yaml
+++ b/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: YesterdaysLemon.CodexContinuity
+PackageVersion: 0.2.1
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/YesterdaysLemon/codex-continuity/releases/download/v0.2.1/CodexContinuity-v0.2.1-Setup.exe
+    InstallerSha256: 886EA4878F252A0B65C0E826CB631AFFED09B861F5280E5DF4DFE000BBE47EB9
+    InstallerSwitches:
+      Silent: --silent
+      SilentWithProgress: --silent
+    ProductCode: CodexContinuity
+    AppsAndFeaturesEntries:
+      - DisplayName: Codex Continuity
+        Publisher: YesterdaysLemon
+        DisplayVersion: 0.2.1
+        ProductCode: CodexContinuity
+        InstallerType: exe
+    RepairBehavior: installer
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.locale.en-US.yaml
+++ b/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: YesterdaysLemon.CodexContinuity
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: YesterdaysLemon
+PublisherUrl: https://alirezaafshan.com
+PublisherSupportUrl: https://github.com/YesterdaysLemon/codex-continuity/issues
+Author: Alireza Afshan
+PackageName: Codex Continuity
+PackageUrl: https://continuity.alirezaafshan.com
+License: MIT
+LicenseUrl: https://github.com/YesterdaysLemon/codex-continuity/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Alireza Afshan
+ShortDescription: Keep Codex agent threads alive while the Windows desktop UI updates or restarts.
+Description: An unofficial per-user Windows continuity supervisor with an optional notification-area status controller. It uses the official Codex app-server over loopback and never patches or restarts the desktop app during installation.
+Moniker: codex-continuity
+Tags:
+  - agent
+  - codex
+  - continuity
+  - developer-tools
+  - windows
+ReleaseNotesUrl: https://github.com/YesterdaysLemon/codex-continuity/releases/tag/v0.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.yaml
+++ b/manifests/y/YesterdaysLemon/CodexContinuity/0.2.1/YesterdaysLemon.CodexContinuity.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: YesterdaysLemon.CodexContinuity
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the initial WinGet manifest for Codex Continuity 0.2.1 (`YesterdaysLemon.CodexContinuity`). The installer is the version-specific executable published by the upstream project release.

Local verification:

- Release installer SHA-256 independently matched `886EA4878F252A0B65C0E826CB631AFFED09B861F5280E5DF4DFE000BBE47EB9`.
- `winget validate --manifest manifests/y/YesterdaysLemon/CodexContinuity/0.2.1` succeeded.
- The published installer completed an unattended `--silent --no-start` setup and registered version 0.2.1, then its installed uninstaller restored owned configuration successfully.
- Windows Sandbox is not available on the test host, so the exact local-manifest `winget install` path was not claimed as tested.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (awaiting the automated CLA check)
- [x] Checked that there aren't other open pull requests for the same package/version
- [x] This PR only modifies one manifest set for one package version
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (direct unattended installer lifecycle tested; Sandbox unavailable)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422338)