### PR TITLE
Update LoreoInc.Loreo to version 2.0.2

### DIFF
--- a/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.installer.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/farrokh/loreo-releases/releases/download/v2.0.2/Loreo_2.0.2_x64-setup.exe
+    InstallerSha256: CDAF5CC850A7CEE98A62E82E14302E65BE15F3363EE40E01989372348BAB001C
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.locale.en-US.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: Loreo Inc.
+PublisherUrl: https://getloreo.com
+PublisherSupportUrl: https://getloreo.com
+PackageName: Loreo
+PackageUrl: https://getloreo.com
+License: Proprietary
+Copyright: Copyright (c) Loreo Inc.
+ShortDescription: Turns meetings and long-form audio into transcripts and structured notes.
+Moniker: loreo
+Tags:
+  - transcription
+  - meeting-notes
+  - audio
+  - notes
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.2/LoreoInc.Loreo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates LoreoInc.Loreo from the currently merged 1.9.41 package to the published Loreo 2.0.2 installer. Supersedes #421248 (2.0.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422340)