### PR TITLE
New package: Pazent.ExploitSpec version 0.2.0

### DIFF
--- a/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.installer.yaml
+++ b/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Pazent.ExploitSpec
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- exploitspec
+ReleaseDate: 2026-08-21
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: exploitspec.exe
+    PortableCommandAlias: exploitspec
+  InstallerUrl: https://github.com/pazent/exploitspec/releases/download/v0.2.0/exploitspec_0.2.0_windows_amd64.zip
+  InstallerSha256: 086CD59B59D0AC8ACA21177B4962941379D66C9010953F3A14017C35CCD999AD
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: exploitspec.exe
+    PortableCommandAlias: exploitspec
+  InstallerUrl: https://github.com/pazent/exploitspec/releases/download/v0.2.0/exploitspec_0.2.0_windows_arm64.zip
+  InstallerSha256: 0816958BA466603906A961630610D24EBF74748D8BE1C69DB4C1805FF1B5703F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.locale.en-US.yaml
+++ b/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Pazent.ExploitSpec
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: pazent
+PublisherUrl: https://github.com/pazent
+PublisherSupportUrl: https://github.com/pazent/exploitspec/issues
+Author: Alessandro
+PackageName: ExploitSpec
+PackageUrl: https://github.com/pazent/exploitspec
+License: Apache-2.0
+LicenseUrl: https://github.com/pazent/exploitspec/blob/v0.2.0/LICENSE
+Copyright: Copyright 2026 pazent
+ShortDescription: Turn proven HTTP security findings into local, repeatable regression tests.
+Description: ExploitSpec is a local-first CLI for converting confirmed HTTP security findings into reviewable YAML regression tests. It supports multi-actor workflows, validation, execution, calibration, and privacy-safe cURL and HAR imports. It is not a vulnerability scanner.
+Moniker: exploitspec
+Tags:
+- application-security
+- appsec
+- authorization
+- bola
+- ci
+- cli
+- idor
+- regression-testing
+- security-testing
+ReleaseNotesUrl: https://github.com/pazent/exploitspec/releases/tag/v0.2.0
+Documentations:
+- DocumentLabel: Specification
+  DocumentUrl: https://github.com/pazent/exploitspec/blob/v0.2.0/docs/specification.md
+- DocumentLabel: Architecture
+  DocumentUrl: https://github.com/pazent/exploitspec/blob/v0.2.0/docs/architecture.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.yaml
+++ b/manifests/p/Pazent/ExploitSpec/0.2.0/Pazent.ExploitSpec.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Pazent.ExploitSpec
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the new open-source package `Pazent.ExploitSpec` version `0.2.0`.

ExploitSpec is an Apache-2.0 CLI for turning proven HTTP exploits into deterministic security regression tests. This manifest installs the versioned GitHub release archives for Windows x64 and arm64 and exposes the `exploitspec` command alias.

The three manifest files were validated against the official 1.12 JSON schemas. Release URLs, archive SHA-256 values, ZIP structure, PE architectures, and embedded Go v0.2.0 build metadata were independently verified against the published release and `SHA256SUMS`.

I prepared this submission on macOS, so I have not run `winget validate` or a local Windows installation; those items remain explicitly unchecked for the repository automation to evaluate.

Package: https://github.com/pazent/exploitspec

Release: https://github.com/pazent/exploitspec/releases/tag/v0.2.0

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — will complete if requested by the CLA bot
- [x] Linked to an issue (if applicable) — not applicable for this new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422343)