### PR TITLE
New package: GreenYogaInc.PDFLiteViewer version 1.0.13

### DIFF
--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.installer.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.13
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+# The portable bundle ships pdfium.dll, SkiaSharp native deps, and the .NET
+# runtime side-by-side with PdfLiteViewer.exe, so winget must track the binary
+# dependencies by path (not by content hash) — see PR review feedback.
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+  - RelativeFilePath: PdfLiteViewer.exe
+    PortableCommandAlias: PdfLiteViewer
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.13/PdfLiteViewer-1.0.13-win-x64.zip
+    InstallerSha256: 91A5D10CEB173FE4B5AECD8B4365BB84F878D105874A2960EC5553CEC14BE8B0
+  - Architecture: arm64
+    InstallerUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.13/PdfLiteViewer-1.0.13-win-arm64.zip
+    InstallerSha256: 60F49FBBAC7C63CCDCD028025D949DFEC2ABF440211CF6A7AAD453D1206193B6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.locale.en-US.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.13
+PackageLocale: en-US
+Publisher: Green Yoga Inc
+PublisherUrl: https://github.com/greenyogainc
+PublisherSupportUrl: https://github.com/greenyogainc/pdf-lite-viewer/issues
+PackageName: PDF Lite Viewer
+PackageUrl: https://github.com/greenyogainc/pdf-lite-viewer
+License: MIT
+LicenseUrl: https://github.com/greenyogainc/pdf-lite-viewer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Green Yoga Inc
+ShortDescription: A free, lightweight PDF viewer for Windows.
+Description: |-
+  Free, minimal, fast PDF viewer. Three viewing modes: facing pages,
+  single page full screen, and continuous scrolling. No bloat.
+Moniker: pdf-lite-viewer
+Tags:
+  - freeware
+  - pdf
+  - pdf-viewer
+  - reader
+  - viewer
+ReleaseNotesUrl: https://github.com/greenyogainc/pdf-lite-viewer/releases/tag/v1.0.13
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.yaml
+++ b/manifests/g/GreenYogaInc/PDFLiteViewer/1.0.13/GreenYogaInc.PDFLiteViewer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: GreenYogaInc.PDFLiteViewer
+PackageVersion: 1.0.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: PDF Lite Viewer 1.0.13 — free, lightweight (MIT) PDF viewer for Windows by Green Yoga Inc. Self-contained portable zip installers (x64 + arm64) from the project's GitHub release.

Supersedes #407850 (1.0.5). Adds \ArchiveBinariesDependOnPath: true\ to the installer manifest as requested in that PR's review — the bundle ships \pdfium.dll\, the SkiaSharp native dependency, and the full .NET runtime side-by-side with \PdfLiteViewer.exe\, so winget must track binary dependencies by archive path rather than by content hash.

Installer URLs:
- https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.13/PdfLiteViewer-1.0.13-win-x64.zip
- https://github.com/greenyogainc/pdf-lite-viewer/releases/download/v1.0.13/PdfLiteViewer-1.0.13-win-arm64.zip

- Have you signed the Contributor License Agreement? Yes
- Have you checked that there aren't other open pull requests for the same manifest update/change? This PR only modifies one (1) manifest
- Have you validated your manifest locally with \winget validate --manifest <path>\? Yes
- Have you tested your manifest locally with \winget install --manifest <path>\? Yes
- Does your manifest conform to the 1.6 schema? Yes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422363)