### PR TITLE
Added ARP Publisher: hadc188.Reader version 1.4.3

### DIFF
--- a/manifests/h/hadc188/Reader/1.4.3/hadc188.Reader.installer.yaml
+++ b/manifests/h/hadc188/Reader/1.4.3/hadc188.Reader.installer.yaml
@@ -1,4 +1,3 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: hadc188.Reader
@@ -11,5 +10,7 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/hadc188/reader/releases/download/v1.4.3/Reader-v1.4.3-windows-x64-setup.exe
   InstallerSha256: A1ACF58663DDE433165C344129871972AB60721F9E9CA77A103EEE4BF64DE382
+AppsAndFeaturesEntries:
+- Publisher: hadc188
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
It turns out that there are multiple apps out there whose registry ProductCode is "Reader" (which in hindsight isn't all that surprising). This made `hadc188.Reader` show up as an update for people who had the unrelated app [Readwise Reader](https://readwise.io/read/download) installed.

This PR *most likely* prevents it from being shown as such an update.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves https://github.com/microsoft/winget-cli/issues/6475.

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422393)