### PR TITLE
New package: RobWalsh.BertCut version 0.1.0

### DIFF
--- a/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.installer.yaml
+++ b/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertCut
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto "<INSTALLPATH>"
+  Log: --log "<LOGPATH>"
+UpgradeBehavior: install
+ProductCode: BertCut
+ReleaseDate: 2026-08-22
+AppsAndFeaturesEntries:
+- ProductCode: BertCut
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\BertCut'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/robgwalsh/bertcut/releases/download/v0.1.0/BertCut-win-Setup.exe
+  InstallerSha256: ED6017F49D51D4AFC5BAB0CD2199869BFFF08C2C40DD2E57D4A3F051B188848C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.locale.en-US.yaml
+++ b/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertCut
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Rob Walsh
+PublisherUrl: https://github.com/robgwalsh
+PublisherSupportUrl: https://github.com/robgwalsh/bertcut/issues
+PackageName: BertCut
+PackageUrl: https://github.com/robgwalsh/bertcut
+License: MIT
+LicenseUrl: https://github.com/robgwalsh/bertcut/blob/HEAD/LICENSE
+Copyright: Copyright © 2026 Rob Walsh
+ShortDescription: A fast, small video editor for cutting, cropping, and overlaying
+Description: |-
+  A Windows video editor built around the three things most edits actually are: cut, crop, and
+  overlay. Mark a range and ripple it away, drag a crop rectangle over the picture, or lay a
+  second angle over the base track as picture-in-picture, with the two lined up automatically by
+  correlating their audio. Cut-only exports that land on keyframes are stream-copied rather than
+  re-encoded. FFmpeg is bundled, so there is nothing else to install.
+Tags:
+- crop
+- cut
+- editor
+- ffmpeg
+- movie
+- overlay
+- trim
+- video
+- video-editor
+ReleaseNotes: |-
+  The first release of BertCut.
+  Cutting - mark a range and ripple it away; reorder segments by dragging. A cut-only export on keyframe boundaries is stream-copied rather than re-encoded, so it loses no quality and finishes at copy speed.
+  Crop - drag a rectangle over the picture for any range. Zoom-to-fill, so the output keeps one constant size.
+  Overlay - put a second angle over the base track as picture-in-picture. Choosing what goes in the clip and aiming where it sits are separate steps, and a clip stops against whatever is in the way rather than being cut down by it.
+  Audio sync - for one event filmed twice, BertCut correlates the sound to line the angles up, and excludes the identity match so pulling both angles out of a single recording finds the other angle rather than itself.
+  Playback - nothing decodes on the UI thread. A read-ahead pump keeps scrubbing responsive instead of freezing for a seek, and reverse plays at 29 fps. At 1x the audio device is the master clock, so the picture follows the sound.
+  Export - hardware encoded via NVENC, Quick Sync, or AMF where the machine can, each confirmed by actually running it before it is chosen, falling back to CPU.
+  Sessions, key bindings and caches live in %USERPROFILE%\.bertcut and are restored by content key. Installed copies update themselves from GitHub Releases.
+ReleaseNotesUrl: https://github.com/robgwalsh/bertcut/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.yaml
+++ b/manifests/r/RobWalsh/BertCut/0.1.0/RobWalsh.BertCut.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobWalsh.BertCut
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

New package. BertCut is an open-source (MIT) Windows video editor for cutting, cropping, and overlaying video: https://github.com/robgwalsh/bertcut

The installer is packaged with [Velopack](https://velopack.io) — a per-user `exe` installing to `%LocalAppData%\BertCut` with no elevation, silent via `--silent`, matching the existing `RobWalsh.BertBrowser` package from the same publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422424)