### PR TITLE
Update version: CargoLambda.CargoLambda version 1.9.2

### DIFF
--- a/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.installer.yaml
+++ b/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CargoLambda.CargoLambda
+PackageVersion: 1.9.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: cargo-lambda.exe
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - PackageIdentifier: zig.zig
+ReleaseDate: 2026-08-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cargo-lambda/cargo-lambda/releases/download/v1.9.2/cargo-lambda-v1.9.2.windows-x64.zip
+  InstallerSha256: 0AB876271D6283548F6D31F2F748E4C27C78802D4650B93D5F465B81E07E1332
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.locale.en-US.yaml
+++ b/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CargoLambda.CargoLambda
+PackageVersion: 1.9.2
+PackageLocale: en-US
+Publisher: CargoLambda
+PublisherUrl: https://github.com/cargo-lambda
+PublisherSupportUrl: https://github.com/cargo-lambda/cargo-lambda/issues
+PackageName: CargoLambda
+PackageUrl: https://github.com/cargo-lambda/cargo-lambda
+License: MIT
+LicenseUrl: https://github.com/cargo-lambda/cargo-lambda/blob/HEAD/LICENSE
+ShortDescription: Cargo Lambda is a Cargo subcommand to help you work with AWS Lambda.
+Tags:
+- aws-lambda
+- rust
+ReleaseNotes: |-
+  ## What's Changed
+  • fix：update typo in release-optimizations.md in docs by @s7500 in https://github.com/cargo-lambda/cargo-lambda/pull/929
+  • feat：Add Nix Flakes guide for Rust dev by @SkullCarverCoder in https://github.com/cargo-lambda/cargo-lambda/pull/932
+  • Added 2nd statement to resource poicy, now required per AWS change by @lpython in https://github.com/cargo-lambda/cargo-lambda/pull/935
+  • fix：support Rust 1.98 ARM64 builds by @Dgame in https://github.com/cargo-lambda/cargo-lambda/pull/937
+  • Release version 1.9.2 by @calavera in https://github.com/cargo-lambda/cargo-lambda/pull/938
+
+  ## New Contributors
+  • @s7500 made their first contribution in https://github.com/cargo-lambda/cargo-lambda/pull/929
+  • @SkullCarverCoder made their first contribution in https://github.com/cargo-lambda/cargo-lambda/pull/932
+  • @lpython made their first contribution in https://github.com/cargo-lambda/cargo-lambda/pull/935
+
+  **Full Changelog**：https://github.com/cargo-lambda/cargo-lambda/compare/v1.9.1...v1.9.2
+ReleaseNotesUrl: https://github.com/cargo-lambda/cargo-lambda/releases/tag/v1.9.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.yaml
+++ b/manifests/c/CargoLambda/CargoLambda/1.9.2/CargoLambda.CargoLambda.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CargoLambda.CargoLambda
+PackageVersion: 1.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update CargoLambda.CargoLambda to version 1.9.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422446)