### PR TITLE
Update: TX230.winproc-tui to 1.0.0

### DIFF
--- a/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.installer.yaml
+++ b/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- winproc-tui
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: winproc-tui.exe
+    PortableCommandAlias: winproc-tui
+  InstallerUrl: https://github.com/TX230/winproc-tui/releases/download/v1.0.0/winproc-tui-1.0.0-windows-x64.zip
+  InstallerSha256: 35A17A4D3A1E2632E1919289AD5E64EC48724A2B1B11596CD62A9DF90BC89915
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-22

--- a/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.locale.en-US.yaml
+++ b/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: TX230
+PublisherUrl: https://github.com/TX230
+PublisherSupportUrl: https://github.com/TX230/winproc-tui/issues
+Author: TX230
+PackageName: winproc-tui
+PackageUrl: https://github.com/TX230/winproc-tui
+License: MIT
+LicenseUrl: https://github.com/TX230/winproc-tui/blob/v1.0.0/LICENSE
+Copyright: Copyright (c) 2026 TX230 (ft)
+ShortDescription: A Windows 11 x64 process monitoring TUI for tracking per-process resource usage over time.
+Description: |-
+  winproc-tui is a terminal process monitor for Windows 11 x64. It shows memory pressure,
+  per-adapter GPU activity and memory, CPU and system activity, plus per-process memory,
+  handles, GUI resources, GPU, and I/O metrics. It provides up to 16 graphs, A/B comparison,
+  recording, saved-log review, and tabbed process inspection for executable details,
+  open files, loaded DLLs, and environment variables.
+Moniker: winproc-tui
+Tags:
+- gpu
+- monitoring
+- process
+- ratatui
+- terminal
+- tui
+- windows
+ReleaseNotesUrl: https://github.com/TX230/winproc-tui/releases/tag/v1.0.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v1.0.0/README.md
+- DocumentLabel: Japanese README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v1.0.0/README.ja.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.locale.ja-JP.yaml
+++ b/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.locale.ja-JP.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 1.0.0
+PackageLocale: ja-JP
+Publisher: TX230
+PackageName: winproc-tui
+ShortDescription: Windows 11 x64向けのターミナルプロセス監視TUIです。
+Description: |-
+  winproc-tuiは、Windows 11 x64向けのターミナルプロセスモニターです。
+  システム全体のメモリ負荷、GPUアダプター別の負荷とメモリ、CPU、ネットワークとディスク、
+  プロセス別のメモリ、ハンドル、GUIリソース、GPU、I/Oを表示します。最大16個のグラフ、
+  A/B比較、記録、保存済みログの確認、実行ファイル情報、オープンファイル、ロード済みDLL、
+  環境変数をタブで確認できるプロセス調査機能を備えています。
+Tags:
+- GPU
+- Windows
+- ターミナル
+- プロセス
+- モニタリング
+Documentations:
+- DocumentLabel: 日本語README
+  DocumentUrl: https://github.com/TX230/winproc-tui/blob/v1.0.0/README.ja.md
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.yaml
+++ b/manifests/t/TX230/winproc-tui/1.0.0/TX230.winproc-tui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TX230.winproc-tui
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `TX230.winproc-tui` to the statically linked v1.0.0 release.

The manifest was validated with `winget validate` and tested with the repository's official `Tools/SandboxTest.ps1`. The Windows Sandbox test installed v0.9.0 in machine scope, upgraded to v1.0.0 while preserving `winproc-tui.toml`, verified a clean v1.0.0 install, and successfully uninstalled the package without leaving its command alias.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422482)