### PR TITLE
New version: Joedsonalves.Vacuon version 0.4.0

### DIFF
--- a/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.installer.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.installer.yaml
@@ -1,0 +1,15 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.4.0
+MinimumOSVersion: 10.0.19044.0
+InstallerType: portable
+Commands:
+- vacuon
+ReleaseDate: 2026-08-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/joedsonalves/vacuon/releases/download/v0.4.0/Vacuon-0.4.0-win-x64.exe
+  InstallerSha256: 6E5FD4BED729BED8C459D8746ECC1FD0E132D5E083CF655C169D408D1B4AA486
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.locale.en-US.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.locale.en-US.yaml
@@ -1,0 +1,49 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Joedson Alves
+PublisherUrl: https://github.com/joedsonalves
+PublisherSupportUrl: https://github.com/joedsonalves/vacuon/issues
+PackageName: Vacuon
+PackageUrl: https://github.com/joedsonalves/vacuon
+License: MIT
+LicenseUrl: https://github.com/joedsonalves/vacuon/blob/main/LICENSE
+ShortDescription: Disk space analyzer that reads the NTFS MFT directly and shows what it is about to delete.
+Description: |-
+  Vacuon finds where the space on a Windows disk went. It reads the NTFS Master File
+  Table straight off the volume, which indexes a million files in seconds instead of
+  minutes, and falls back to the Windows API on volumes where that is not possible.
+
+  Images and videos are shown as thumbnails in six sizes, so you can tell which of five
+  large renders is the final one without opening any of them. Deletion goes to the Recycle
+  Bin by default, and permanently only behind a confirmation you have to tick, with a
+  protection list that refuses the volume root, Windows, System32 and kernel-owned files.
+
+  It also finds files with identical content, draws the volume as a treemap where every
+  box is sized by what it occupies, and can set files aside in a quarantine it can restore
+  them from, instead of deleting them.
+
+  Every scan cross-checks the space it attributed to files against what the volume reports
+  as used, and says so when the two disagree.
+
+  The interface is available in English and Portuguese. The fast path needs Administrator;
+  without it the app still works through the slower traversal and says which one it used.
+Moniker: vacuon
+Tags:
+- disk
+- disk-analyzer
+- disk-space
+- disk-usage
+- duplicate-finder
+- mft
+- ntfs
+- storage
+- treemap
+ReleaseNotesUrl: https://github.com/joedsonalves/vacuon/releases/tag/v0.4.0
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/joedsonalves/vacuon/blob/main/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
@@ -1,0 +1,30 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.4.0
+PackageLocale: pt-BR
+Publisher: Joedson Alves
+PackageName: Vacuon
+License: MIT
+ShortDescription: Analisador de espaco em disco que le a MFT do NTFS direto e mostra o que voce esta apagando.
+Description: |-
+  O Vacuon encontra para onde foi o espaco de um disco no Windows. Ele le a Master File
+  Table do NTFS direto do volume, o que indexa um milhao de arquivos em segundos em vez de
+  minutos, e cai para a API do Windows nos volumes onde isso nao e possivel.
+
+  Imagens e videos aparecem como miniaturas em seis tamanhos, para voce saber qual de cinco
+  renderizacoes grandes e a final sem abrir nenhuma. A exclusao vai para a Lixeira por
+  padrao, e definitiva so atras de uma confirmacao que voce precisa marcar, com uma lista
+  de protecao que recusa a raiz do volume, Windows, System32 e arquivos do kernel.
+
+  Ele tambem acha arquivos com conteudo identico, desenha o volume como um treemap onde
+  cada caixa tem o tamanho do que ocupa, e guarda arquivos numa quarentena de onde da para
+  restaurar, em vez de apagar de uma vez.
+
+  Toda varredura confere o espaco atribuido a arquivos contra o que o volume declara em uso,
+  e avisa quando os dois nao batem.
+
+  Interface em ingles e portugues. O caminho rapido exige Administrador; sem ele o app
+  funciona pela travessia mais lenta e diz qual dos dois usou.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.4.0/Joedsonalves.Vacuon.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version update: **Joedsonalves.Vacuon** from **0.3.2** to **0.4.0**.

Vacuon is a disk space analyzer for Windows. It reads the NTFS Master File Table directly to index a volume in seconds, shows thumbnails of images and videos so you can see what you are about to delete, and deletes to the Recycle Bin by default.

- Repository: https://github.com/joedsonalves/vacuon
- Release: https://github.com/joedsonalves/vacuon/releases/tag/v0.4.0
- Licence: MIT
- `InstallerType: portable` — a single self-contained executable, no installer.

The publisher is the repository owner; the installer is served from that repository's own release assets.

### What changed from 0.3.2

- `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and `ReleaseNotesUrl`.
- **`Tags`: `duplicate-finder` and `treemap` added.** `duplicate-finder` was removed in 0.3.2 because the app did not find duplicates at the time and a tag naming a feature that does not exist is a false claim. That feature shipped in 0.4.0, so the tag is accurate again. Nine tags total.
- **One sentence added to `Description`** in both locales, covering the three features this release adds. The existing paragraphs are byte-for-byte unchanged from the wording that has passed validation twice.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not for this version**, see below
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### What was verified

- `winget validate --manifest` passes with **no warnings**.
- **The `InstallerSha256` was checked against what winget will actually download.** The published asset was fetched from the `InstallerUrl` in this manifest and hashed, rather than hashed from a local copy. It matches `6E5FD4BE…4AA486`.
- The executable was verified to run **standalone**, copied on its own into an empty directory outside its build tree, since a portable package has nothing else beside it. It reports `Vacuon 0.4.0`.
- **The install checklist item is left unticked on purpose.** `winget install --manifest` was run locally for 0.3.2, which shares this manifest's shape and `InstallerType: portable`, but it was **not** re-run for 0.4.0 — so ticking that box would be claiming a check that did not happen for this version. What was done instead is above: the published asset was downloaded from the exact `InstallerUrl` in this manifest and its hash compared, and the executable was run standalone out of an empty folder. Say the word and I will run the install against the published URL and report back here before merge.

Happy to fix anything the review turns up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422496)