### PR TITLE
New version: neyham.AIUsageDashboard version 0.8.0

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.8.0/AI-Usage-Dashboard_0.8.0_x64-setup.exe
+    InstallerSha256: 6099F8955F80254C3D74A76661852A42E6D01B84C60C0D37E6087A15DD1170B1
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        DisplayVersion: 0.8.0
+        Publisher: neyha
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.8.0/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code, Codex, Grok Build, Cursor, Antigravity, and DeepSeek usage.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code, Codex, Grok Build, Cursor, and Antigravity usage
+  windows alongside a DeepSeek API balance. Display Settings provide a
+  write-only DeepSeek API key field, optional Cursor and Antigravity panels
+  that stay off by default, and an optional Low Power Mode that disables
+  animation and reduces renderer update work. Credentials and provider
+  requests stay in the native Rust backend; the renderer receives sanitized
+  usage summaries only. The project has no developer-operated server,
+  analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - antigravity
+  - claude
+  - claude-code
+  - codex
+  - cursor
+  - dashboard
+  - deepseek
+  - grok
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.0/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package update

Updates neyham.AIUsageDashboard to version 0.8.0.

- Installer: official NSIS asset from the v0.8.0 GitHub Release
- SHA-256 verified against both the GitHub asset digest and published SHA256SUMS (`6099F8955F80254C3D74A76661852A42E6D01B84C60C0D37E6087A15DD1170B1`)
- Locale URLs point at the v0.8.0 tag
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422511)