### PR TITLE
Update version: Vathivis.paperq version 1.0.1

### DIFF
--- a/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.installer.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: paperq.exe
+  PortableCommandAlias: paperq
+ReleaseDate: 2026-08-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Vathivis/paperq/releases/download/v1.0.1/paperq-1.0.1-win-x64.zip
+  InstallerSha256: 29BF4430C5FA48796A84D759937861EF497E1499FCBF09F4D568E35073734BFB
+- Architecture: arm64
+  InstallerUrl: https://github.com/Vathivis/paperq/releases/download/v1.0.1/paperq-1.0.1-win-arm64.zip
+  InstallerSha256: 70E3FC97E51D61EA5D91CED6B345832B9DCBF5D30D5A0A82E56364056313397B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.locale.en-US.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Vathivis
+PublisherUrl: https://vojtahumpl.com/
+PublisherSupportUrl: https://github.com/Vathivis/paperq/issues
+Author: Vojtěch Humpl
+PackageName: paperq
+PackageUrl: https://github.com/Vathivis/paperq
+License: MIT License
+LicenseUrl: https://github.com/Vathivis/paperq/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Vojtěch Humpl
+ShortDescription: A repository-local papercut queue for coding agents.
+Description: paperq is a small, repository-local queue for recording and managing the minor problems coding agents encounter during real work. It stores transparent Markdown records and provides commands to add, claim, block, reopen, resolve, and list them without running a model, collecting transcripts, starting a service, or sending data to a server.
+Moniker: paperq
+Tags:
+- cli
+- developer-tools
+- productivity
+- coding-agents
+- codex
+- claude
+ReleaseNotes: |-
+  ## What's Changed
+  • Add explicit out-of-order papercut claiming by @Vathivis in https://github.com/Vathivis/paperq/pull/2
+
+  ## New Contributors
+  • @Vathivis made their first contribution in https://github.com/Vathivis/paperq/pull/2
+
+  **Full Changelog**：https://github.com/Vathivis/paperq/compare/v1.0.0...v1.0.1
+ReleaseNotesUrl: https://github.com/Vathivis/paperq/releases/tag/v1.0.1
+InstallationNotes: Run `paperq init` from a repository root to create its local papercut queue.
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Vathivis/paperq/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.yaml
+++ b/manifests/v/Vathivis/paperq/1.0.1/Vathivis.paperq.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Vathivis.paperq
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Vathivis.paperq to version 1.0.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422550)