### PR TITLE
New package: dixieflatline76.NachoFlow version 0.5.2

### DIFF
--- a/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.installer.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.2
+Commands:
+  - nacho-flow
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/dixieflatline76/nacho-flow/releases/download/v0.5.2/nacho-flow-0.5.2-windows-amd64.exe
+    InstallerSha256: 342700014ABA5472053949BB5BE0176897D5533FBF3F61DA28C2606BDE262129
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.2
+PackageLocale: en-US
+Publisher: dixieflatline76
+PublisherUrl: https://spicebox.dev
+PublisherSupportUrl: https://github.com/dixieflatline76/nacho-flow/issues
+PackageName: Nacho Flow
+PackageUrl: https://spicebox.dev/nacho-flow/
+License: MIT
+LicenseUrl: https://github.com/dixieflatline76/nacho-flow/blob/main/LICENSE
+Copyright: Copyright (c) 2026 dixieflatline76
+ShortDescription: High-performance OpenAI-compatible hybrid AI gateway for local GPUs and cloud APIs (spicebox.dev/nacho-flow).
+Description: High-performance, zero-dependency OpenAI-compatible proxy gateway in Go. Sits locally between autonomous coding agents (Roo Code, Cline, Aider, Cursor) and LLMs to route routine turns to local GPUs for $0.00 and escalate complex turns to cloud APIs.
+Moniker: nacho-flow
+Tags:
+  - ai
+  - llm
+  - proxy
+  - gateway
+  - ollama
+  - openrouter
+  - agents
+  - local-llm
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/0.5.2/dixieflatline76.NachoFlow.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 0.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description
Initial submission to add **dixieflatline76.NachoFlow** version **0.5.2** to the Windows Package Manager repository.

### 🏷️ Package & Publisher Metadata
* **Package Identifier:** `dixieflatline76.NachoFlow`
* **Package Name:** Nacho Flow
* **Publisher:** dixieflatline76 (part of the [spicebox.dev](https://spicebox.dev/nacho-flow/) developer tool suite)
* **Author / Publisher URL:** https://spicebox.dev/nacho-flow/
* **Source Repository:** https://github.com/dixieflatline76/nacho-flow
* **License:** MIT (https://github.com/dixieflatline76/nacho-flow/blob/main/LICENSE)
* **Release Page:** https://github.com/dixieflatline76/nacho-flow/releases/tag/v0.5.2

### 🛠️ Architecture & Installer Details
* **Installer Type:** Portable executable (`portable`)
* **Commands:** `nacho-flow`
* **Architecture:** `x64`
* **Download URL:** https://github.com/dixieflatline76/nacho-flow/releases/download/v0.5.2/nacho-flow-0.5.2-windows-amd64.exe
* **SHA-256 Hash:** `342700014ABA5472053949BB5BE0176897D5533FBF3F61DA28C2606BDE262129`

### 📝 Software Overview
Nacho Flow is a lightweight, zero-dependency OpenAI-compatible proxy gateway built in Go. It sits locally on Windows (defaulting to `localhost:8000`) between autonomous coding assistants ([Roo Code](https://github.com/RooVetGit/Roo-Code), [Cline](https://github.com/cline/cline), [Aider](https://github.com/paul-gauthier/aider), [Cursor](https://www.cursor.com), [Continue](https://continue.dev)) and LLM backends.

* **Hybrid Cost Optimization**: Dynamically evaluates each prompt turn to route routine, small context turns to local workstation GPUs (Ollama, vLLM, LM Studio) for $0.00, and escalates heavy multi-file reasoning tasks to cloud endpoints (OpenRouter, DeepSeek, Azure OpenAI).
* **Zero Runtime Dependencies**: Distributed as a single self-contained Authenticode-signed binary with built-in background service management.

---

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same package
- [x] This PR only modifies one (1) manifest (`manifests/d/dixieflatline76/NachoFlow/0.5.2`)
- [x] Validated manifest locally with `winget validate --manifest`
- [x] Tested manifest locally with `winget install --manifest`
- [x] Manifest conforms to the [1.5 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.5.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422551)