### PR TITLE
New version: StruisICT.InLook version 1.2.0

### DIFF
--- a/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.installer.yaml
+++ b/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.installer.yaml
@@ -1,0 +1,30 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.2.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: '{EF88176B-2228-4171-8664-1D13DA7ACBC0}'
+ReleaseDate: 2026-08-22
+AppsAndFeaturesEntries:
+- ProductCode: '{EF88176B-2228-4171-8664-1D13DA7ACBC0}'
+  UpgradeCode: '{8E5A3C2B-1D4F-4E7A-9B6C-7D8E9F0A1B2C}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\InLook'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/InLook/releases/download/v1.2.0/inlook-1.2.0-x86_64.msi
+  InstallerSha256: 7A6D2EE500C48C0C13622F44BECD70F6A203E1E3995408E26D42771C50DE6FB8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.locale.en-US.yaml
+++ b/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com/
+PublisherSupportUrl: https://github.com/StruisICT/InLook/issues
+Author: Struis ICT
+PackageName: InLook
+PackageUrl: https://github.com/StruisICT/InLook
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/StruisICT/InLook/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast, free .eml email viewer
+Description: |-
+  InLook is a small, fast viewer for .eml email files (the standard RFC 822
+  / MIME format used by Outlook, Thunderbird, and most other mail clients
+  when saving a single message to disk). It renders headers, body (HTML or
+  plain text), and attachments, with embedded HTML sandboxed under a strict
+  Content Security Policy — no remote loads, no tracking pixels. Follows
+  the system light/dark theme, registers as the default .eml handler, and
+  never touches the network. Free Software from Struis ICT.
+Moniker: inlook
+Tags:
+- email
+- eml
+- mail
+- message
+- viewer
+ReleaseNotes: |-
+  1.2.0 (2026-08-22)
+  Features
+  - Opt-in remote images: a per-message "Load images" banner lets you fetch
+    a message's remote images on demand; blocked by default to prevent tracking.
+ReleaseNotesUrl: https://github.com/StruisICT/InLook/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.yaml
+++ b/manifests/s/StruisICT/InLook/1.2.0/StruisICT.InLook.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.InLook
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version of an existing package

- **Package:** StruisICT.InLook
- **Version:** 1.2.0 (adds opt-in remote images — a per-message "Load images" banner; blocked by default)
- **Installer:** `inlook-1.2.0-x86_64.msi` from the GitHub release [v1.2.0](https://github.com/StruisICT/InLook/releases/tag/v1.2.0)

Same manifest shape as the accepted 1.0.0–1.1.2 versions (schema 1.12.0); installer SHA256 and MSI ProductCode updated, UpgradeCode unchanged.

#### Checklist
- [x] This PR only modifies one (1) package
- [x] Validated locally with `winget validate --manifest <path>` — validation succeeded
- [x] Compliant with the [Windows Package Manager policies](https://learn.microsoft.com/windows/package-manager/package/repository)

Submitted manually (automated winget-releaser can't sync a stale fork); manifest identical in form to prior komac submissions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422557)