### PR TITLE
New version: KopioRapido.KopioRapido version 2026.08.22

### DIFF
--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.installer.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.installer.yaml
@@ -1,0 +1,26 @@
+# Winget installer manifest
+# Version and hashes updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kp.exe
+    PortableCommandAlias: kp
+Commands:
+  - kp
+  - kopiorapido
+Dependencies:
+  PackageDependencies: []
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.22/cli/kopiorapido-cli-win-x64-2026.08.22.zip
+    InstallerSha256: 5be626b626c7dfeac9c2c2e7538d8fa75def9d29d2a097d3a518657bd692e9a1
+  - Architecture: arm64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.22/cli/kopiorapido-cli-win-arm64-2026.08.22.zip
+    InstallerSha256: 535a900fa5bedf697fc6976f2f5922a922db590f0dac402dcd0abdc1b4ded1f7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.locale.en-US.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Winget locale manifest (en-US)
+# Version updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22
+PackageLocale: en-US
+Publisher: KopioRapido
+PublisherUrl: https://kopiorapido.com
+PublisherSupportUrl: https://kopiorapido.com
+PackageName: KopioRapido CLI
+PackageUrl: https://kopiorapido.com
+License: Shareware
+LicenseUrl: https://kopiorapido.com
+Copyright: Copyright (c) 2026 KopioRapido
+ShortDescription: High-performance file copying CLI with delta sync and intelligent transfer
+Description: |-
+  KopioRapido is a high-performance cross-platform file copying CLI with intelligent transfer optimization.
+
+  Features:
+  - Delta synchronization for efficient updates
+  - Smart compression for network transfers
+  - Multiple operation modes: Copy, Move, Sync, Mirror, BiDirectional Sync
+  - Resumable operations
+  - Real-time progress tracking
+  - JSON output for scripting
+  - Intelligent transfer engine that analyzes storage devices
+  - Adaptive performance monitoring
+Moniker: kp
+Tags:
+  - backup
+  - cli
+  - copy
+  - file-management
+  - rsync
+  - sync
+  - robocopy
+ReleaseNotesUrl: https://kopiorapido.com/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22/KopioRapido.KopioRapido.yaml
@@ -1,0 +1,9 @@
+# Winget manifest (main version file)
+# Version updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
#### Description
New version of KopioRapido CLI: 2026.08.22

- Manifest: [winget-create](https://github.com/microsoft/winget-create) validated locally
- Installer URL: https://releases.kopiorapido.com/2026.08.22/cli/kopiorapido-cli-win-x64-2026.08.22.zip
- Hashes taken from the published .sha256 sidecar files

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422577)