### PR TITLE
New package: WSL043.DSH-Portable version 0.4.4

### DIFF
--- a/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.installer.yaml
+++ b/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: WSL043.DSH-Portable
+PackageVersion: 0.4.4
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Custom: /NORESTART
+UpgradeBehavior: install
+ProductCode: '{1F096C3A-7991-4E55-B0F9-68A50B24C5A8}_is1'
+ReleaseDate: 2026-08-22
+AppsAndFeaturesEntries:
+- DisplayName: DeepSeek-Herness 0.4.4
+  Publisher: WSL043
+  DisplayVersion: 0.4.4
+  ProductCode: '{1F096C3A-7991-4E55-B0F9-68A50B24C5A8}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/WSL043/DSH-Portable/releases/download/v0.4.4/DeepSeek-Herness-Setup.exe
+  InstallerSha256: 731E13D1519D003D41B0110A1C0F5E372F536B43DFE56C14E2D4343409B6C6E8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.locale.en-US.yaml
+++ b/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: WSL043.DSH-Portable
+PackageVersion: 0.4.4
+PackageLocale: en-US
+Publisher: WSL043
+PublisherUrl: https://github.com/WSL043
+PublisherSupportUrl: https://github.com/WSL043/DSH-Portable/issues
+PackageName: DSH-Portable
+PackageUrl: https://wsl043.github.io/DSH-Portable/
+License: MIT
+LicenseUrl: https://github.com/WSL043/DSH-Portable/blob/main/LICENSE
+Copyright: Copyright (c) 2026 WSL043
+ShortDescription: Portable-first desktop distribution of DeepSeek Harness
+Description: A community-maintained desktop distribution of DeepSeek Harness with movable data, tested updates, plugin management, and native Windows integration. It is not an official DeepSeek desktop app.
+Moniker: dsh-portable
+Tags:
+- ai-agent
+- deepseek
+- deepseek-harness
+- desktop
+- portable
+ReleaseNotesUrl: https://github.com/WSL043/DSH-Portable/releases/tag/v0.4.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.locale.zh-CN.yaml
+++ b/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: WSL043.DSH-Portable
+PackageVersion: 0.4.4
+PackageLocale: zh-CN
+Publisher: WSL043
+PublisherUrl: https://github.com/WSL043
+PublisherSupportUrl: https://github.com/WSL043/DSH-Portable/issues
+PackageName: DSH-Portable
+PackageUrl: https://wsl043.github.io/DSH-Portable/
+License: MIT
+LicenseUrl: https://github.com/WSL043/DSH-Portable/blob/main/LICENSE
+Copyright: Copyright (c) 2026 WSL043
+ShortDescription: 便携优先的 DeepSeek Harness 桌面发行版
+Description: 由社区维护的 DeepSeek Harness 桌面发行版，提供可移动数据、经过成品验收的更新、插件管理与原生 Windows 集成；并非 DeepSeek 官方桌面应用。
+Tags:
+- AI-Agent
+- DeepSeek
+- DeepSeek-Harness
+- 便携
+- 桌面
+ReleaseNotesUrl: https://github.com/WSL043/DSH-Portable/releases/tag/v0.4.4
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.yaml
+++ b/manifests/w/WSL043/DSH-Portable/0.4.4/WSL043.DSH-Portable.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: WSL043.DSH-Portable
+PackageVersion: 0.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds DSH-Portable 0.4.4, an independent community desktop distribution of DeepSeek Harness.

The x64 user-scope Inno installer is taken from the immutable v0.4.4 GitHub release. Its SHA-256 matches the published checksum. The installer was also exercised through a silent install, installed-product check, and silent uninstall on Windows; this machine cannot enable WinGet's administrator-only `LocalManifestFiles` setting, so the local `winget install --manifest` checkbox remains intentionally unchecked.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (awaiting the CLA bot)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest build/winget-submit-v0.4.4`
- [ ] Tested manifest locally with `winget install --manifest <path>` (administrator-only local manifests are disabled on the test host; the exact installer passed direct silent install/uninstall acceptance)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422583)