### PR TITLE
New version: BlueStack.BlueStacks version 4.280.1.1002

### DIFF
--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.installer.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.installer.yaml
@@ -1,0 +1,30 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS1.CRLF.7-6-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BlueStack.BlueStacks
+PackageVersion: 4.280.1.1002
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: -s
+  SilentWithProgress: -s
+UpgradeBehavior: install
+Protocols:
+- bluestacksgp
+FileExtensions:
+- apk
+- xapk
+ProductCode: BlueStacks
+ReleaseDate: 2021-05-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ak-build.bluestacks.com/public/app-player/windows/bgp/4.280.1.1002/c9da3f767aed4858fde55c0f37209f8a/x64/BlueStacks-Installer_4.280.1.1002_amd64_native.exe
+  InstallerSha256: AD9EFD6EBAB55BBF3A07BB8F909516C107BE5C69CBB89E50D4A7BF4DFFA53B16
+- Architecture: x86
+  InstallerUrl: https://ak-build.bluestacks.com/public/app-player/windows/bgp/4.280.1.1002/c9da3f767aed4858fde55c0f37209f8a/x86/BlueStacks-Installer_4.280.1.1002_x86_native.exe
+  InstallerSha256: 43534656B6C43CEA5AD4052C48EA0FE245968752FCB952B354F9404E9DBD3024
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.en-US.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.en-US.yaml
@@ -41,6 +41,8 @@ ReleaseNotes: |-
 ReleaseNotesUrl: https://support.bluestacks.com/hc/articles/360021469391
 # PurchaseUrl:
 InstallationNotes: |-
+  Consider trying out the [Phone Link](https://support.microsoft.com/windows/apps/phonelink/phone-link-requirements-and-setup "Phone Link requirements and setup") as an alternative before using this software.
+
   This version is especially for those computers with 2~4 GB RAMs.  Learn more about the system requirements at
   • [BlueStacks 4](https://support.bluestacks.com/hc/articles/360014581811 "System requirements for BlueStacks 4")
   • [BlueStacks 5](https://support.bluestacks.com/hc/articles/360056129211 "System requirements for BlueStacks 5")

--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.en-US.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.en-US.yaml
@@ -1,0 +1,57 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS1.CRLF.7-6-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BlueStack.BlueStacks
+PackageVersion: 4.280.1.1002
+PackageLocale: en-US
+Publisher: BlueStack Systems, Inc.
+PublisherUrl: https://www.bluestacks.com/
+PublisherSupportUrl: https://support.bluestacks.com/
+PrivacyUrl: https://www.bluestacks.com/terms-and-privacy.html#privacy
+Author: BlueStack Systems, Inc.
+PackageName: BlueStacks
+PackageUrl: https://support.bluestacks.com/hc/articles/360014008792
+License: Proprietary
+LicenseUrl: https://www.bluestacks.com/terms-and-privacy.html#terms
+# This is the updated copyright statement on the UI, as the value to `STRING_INSTALLER` key, stored at "%ProgramData%\BlueStacks\Locales\i18n.en-US.txt" (the default location for example), which shall prevail.  Ignore others you may find in the properties of EXE/DLL files.
+Copyright: © 2011 through 2021 Bluestack Systems, Inc. All rights reserved worldwide
+CopyrightUrl: https://www.bluestacks.com/copyright-dispute-policy.html
+ShortDescription: Play Android games on PC or try instantly from our cloud.
+Description: Play Android games on PC or try instantly from our cloud.
+Moniker: bluestacks
+Tags:
+- android
+- androidapps
+- emulation
+- emulator
+- google-play-store
+- googleplaystore
+- lan-device-detections
+- virtual-machine
+- virtualmachine
+- vm
+ReleaseNotes: |-
+  1. You can now play ブルーアーカイブ (com.YostarJP.BlueArchive) without any game crashes. They can now only be found in history books.
+  2. Enter the fantastic world of AOD-龍神無双- (com.coc.jplh) where black screen, graphical and crash issues no longer exist!
+  3. Make new records in Churchill Solitaire Card Game (com.productiveedge.churchill) as it won't crash after the opening film anymore. Time to make Winston proud!
+  4. Brace for a flawless gaming experience in 日向坂46とふしぎな図書室 (jp.co.sonymusic.game.hinatosho)!
+  5. You can now play ラストオリジン –次世代美少女×戦略RPG- (com.pig.laojp.aos) without a crash at launch. Fight for humanity in this epic RPG!
+  6. While playing Rise of Kingdoms: Lost Crusade (com.lilithgame.roc.gp), you won't see any pink patches in Ark of Osiris. Feast your eyes on a splendid gaming experience.
+  7. 프린세스 커넥트! Re:Dive (com.kakaogames.pcr) won't show an error message and then crash at launch for you. Time to be the princess knight in shining armor!
+ReleaseNotesUrl: https://support.bluestacks.com/hc/articles/360021469391
+# PurchaseUrl:
+InstallationNotes: |-
+  This version is especially for those computers with 2~4 GB RAMs.  Learn more about the system requirements at
+  • [BlueStacks 4](https://support.bluestacks.com/hc/articles/360014581811 "System requirements for BlueStacks 4")
+  • [BlueStacks 5](https://support.bluestacks.com/hc/articles/360056129211 "System requirements for BlueStacks 5")
+
+  No available releases are specifically for Arm®‑based PCs, who get x64 releases by default, which are not optimized for such a purpose and hardly ever work there, so do not install this package there.  Learn more about this issue at
+  • [your PC's architecture](https://support.microsoft.com/Windows/Experience/find-information-about-your-windows-device "Find information about your Windows device")
+  • [Arm-based PCs FAQ](https://support.microsoft.com/windows/experience/platform-variants/windows-arm-based-pcs-faq "Windows Arm-based PCs FAQ")
+
+  Whatever troubles you have encountered with this package, please contact the publisher for support or, especially in the case in which it does not work on an Arm®‑based PC, just uninstall this package.
+Documentations:
+- DocumentLabel: BlueStacks 4
+  DocumentUrl: https://support.bluestacks.com/hc/categories/360000451812
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.zh-CN.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.zh-CN.yaml
@@ -36,6 +36,8 @@ ReleaseNotes: |-
 ReleaseNotesUrl: https://support.bluestacks.com/hc/articles/360021469391
 # PurchaseUrl:
 InstallationNotes: |-
+  使用此软件前，不妨考虑尝试[手机连接](https://support.microsoft.com/windows/apps/phonelink/phone-link-requirements-and-setup "“手机连接”要求和设置")作为替代方案。
+
   此版本特别适用于那些拥有 2~4 GB RAM 的电脑。了解更多关于系统要求的信息，请访问
   • [BlueStacks 4](https://support.bluestacks.com/hc/articles/360014581811 "BlueStacks 4 的系统要求")
   • [BlueStacks 5](https://support.bluestacks.com/hc/articles/360056129211 "BlueStacks 5 的系统要求")

--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.zh-CN.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.locale.zh-CN.yaml
@@ -1,0 +1,52 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS1.CRLF.7-6-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: BlueStack.BlueStacks
+PackageVersion: 4.280.1.1002
+PackageLocale: zh-CN
+Publisher: BlueStack Systems, Inc.
+PublisherUrl: https://www.bluestacks.com/
+PublisherSupportUrl: https://support.bluestacks.com/
+PrivacyUrl: https://www.bluestacks.com/terms-and-privacy.html#privacy
+Author: BlueStack Systems, Inc.
+PackageName: BlueStacks
+PackageUrl: https://www.bluestacks.com/download.html
+License: 专有软件
+LicenseUrl: https://www.bluestacks.com/terms-and-privacy.html#terms
+# This is the updated copyright statement on the UI, as the value to `STRING_INSTALLER` key, falling back to "%ProgramData%\BlueStacks\Locales\i18n.zh-TW.txt" (the default location for example), which shall prevail.  Ignore others you may find in the properties of EXE/DLL files.
+# 这是 UI 上更新的版权声明，是 `STRING_INSTALLER` 键的值，回退到 "%ProgramData%\BlueStacks\Locales\i18n.zh-TW.txt"（以默认位置为例），该值应优先。请忽略您可能在 EXE/DLL 文件属性中找到的其他值。
+Copyright: ©2011年至2021年Bluestack Systems,Inc.在全世界保留所有權利
+CopyrightUrl: https://www.bluestacks.com/copyright-dispute-policy.html
+ShortDescription: 在电脑上玩安卓游戏，或从我们的云端立即体验
+Description: 在电脑上玩安卓游戏，或从我们的云端立即体验
+# Moniker:
+Tags:
+- 安卓
+- 模拟器
+# This is the international release rather than that for the People's Republic of China (hosted on https://www.bluestacks.cn/ , which may be added later).  At least the Release Notes is not available in "Chinese - People's Republic of China" (https://docs.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a) (Release Notes to 4.x is not available on that [page for the People's Republic of China](https://www.bluestacks.cn/release_notes.html "BlueStacks蓝叠历史更新")).  Maintainers, please search for this further when adding one(s) for the People's Republic of China.  The following content, from https://support.bluestacks.com/hc/zh-tw/articles/360021469391 , is for users' convenience only, whose translation without BlueStack Systems, Inc.'s prior consent will violate _Bluestacks Terms of Use_.
+# 这是国际发行版，而不是面向中华人民共和国的发行版（托管在 https://www.bluestacks.cn/ 上，可能会在以后添加）。至少此版本的发行说明未提供“中文(中华人民共和国)”（https://docs.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a）版本（[面向中华人民共和国的发行版的发行说明](https://www.bluestacks.cn/release_notes.html "BlueStacks蓝叠历史更新")不包含 4.x 版本，请维护者在添加面向中华人民共和国的发行版时继续寻找）。下列内容来自 https://support.bluestacks.com/hc/zh-tw/articles/360021469391 ，仅供用户方便使用；未经 BlueStack Systems, Inc. 事先同意的翻译将违反 _Bluestacks Terms of Use_。
+ReleaseNotes: |-
+  1.  ブルーアーカイブ (com.YostarJP.BlueArchive)閃退問題修復
+  2.  AOD-龍神無双- (com.coc.jplh)黑畫面問題修復
+  3.  Churchill Solitaire Card Game (com.productiveedge.churchill) 建立新記錄時閃退問題已修復
+  4. 日向坂46とふしぎな図書室 (jp.co.sonymusic.game.hinatosho)享受完美的遊戲體驗
+  5. ラストオリジン –次世代美少女×戦略RPG- (com.pig.laojp.aos) 啟動時閃退問題已修復
+  6. Rise of Kingdoms: Lost Crusade (com.lilithgame.roc.gp)畫面粉色方塊問題已修復
+  7. 프린세스 커넥트! Re:Dive (com.kakaogames.pcr) 錯誤提示問題已修復
+ReleaseNotesUrl: https://support.bluestacks.com/hc/articles/360021469391
+# PurchaseUrl:
+InstallationNotes: |-
+  此版本特别适用于那些拥有 2~4 GB RAM 的电脑。了解更多关于系统要求的信息，请访问
+  • [BlueStacks 4](https://support.bluestacks.com/hc/articles/360014581811 "BlueStacks 4 的系统要求")
+  • [BlueStacks 5](https://support.bluestacks.com/hc/articles/360056129211 "BlueStacks 5 的系统要求")
+
+  基于 Arm® 的电脑没有特别适用的可用发行版，默认获得提供 x64 发行版；这些发行版未做相应优化，从而在这些设备上几乎不可用，因此请勿在这些设备上安装本包。了解更多关于此问题的信息，请访问
+  • [你的电脑的体系结构](https://support.microsoft.com/Windows/Experience/find-information-about-your-windows-device "查找有关 Windows 设备的信息")
+  • [基于 ARM 的电脑常见问题解答](https://support.microsoft.com/windows/experience/platform-variants/windows-arm-based-pcs-faq "基于 Windows ARM 的电脑常见问题解答")
+
+  无论你遇到什么故障，都请联系发布者以获取支持；特别是在本包在基于 Arm® 的 PC 上无法工作的情况下，请直接卸载此软件包。
+Documentations:
+- DocumentLabel: BlueStacks 4
+  DocumentUrl: https://support.bluestacks.com/hc/categories/360000451812
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.yaml
+++ b/manifests/b/BlueStack/BlueStacks/4.280.1.1002/BlueStack.BlueStacks.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS1.CRLF.7-6-5.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BlueStack.BlueStacks
+PackageVersion: 4.280.1.1002
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

This commit adds BlueStack.BlueStacks version 4.280.1.1002 (rather than 4.280.1.1022, which you may also find on [BlueStacks 4 download page](https://support.bluestacks.com/hc/articles/360014008792 "Download BlueStacks 4 installer compatible with your PC"), which may be added later), featuring
- the `x64` (`64-bit`) installer together with the `x86` (`32-bit`) installer provided, and
- `InstallationNotes` replaced by lower system requirements and issues on Arm®‑based PCs, and
- better L10n for `zh-CN`.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #421808
  - Resolves #421569

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422597)