### PR TITLE
Update version: Crate-CI.Typos version 1.49.0

### DIFF
--- a/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.installer.yaml
+++ b/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Crate-CI.Typos
+PackageVersion: 1.49.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: typos.exe
+ReleaseDate: 2026-08-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/crate-ci/typos/releases/download/v1.49.0/typos-v1.49.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 06D3A1B71C282E021671070696A72696D5C60EA485B47DC4F8F1FBCF90144D02
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.locale.en-US.yaml
+++ b/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Crate-CI.Typos
+PackageVersion: 1.49.0
+PackageLocale: en-US
+Publisher: Crate-CI
+PublisherUrl: https://github.com/crate-ci
+PublisherSupportUrl: https://github.com/crate-ci/typos/issues
+PackageName: Typos
+PackageUrl: https://github.com/crate-ci/typos
+License: Apache-2.0
+ShortDescription: Source code spell checker
+Tags:
+- cli
+- code-quality
+- rust
+- spell-checker
+ReleaseNotes: |-
+  ## [1.49.0] - 2026-08-03
+
+  ### Features
+
+  • Updated the dictionary with the [July 2026](https://github.com/crate-ci/typos/issues/1573) changes
+ReleaseNotesUrl: https://github.com/crate-ci/typos/releases/tag/v1.49.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/crate-ci/typos/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.yaml
+++ b/manifests/c/Crate-CI/Typos/1.49.0/Crate-CI.Typos.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Crate-CI.Typos
+PackageVersion: 1.49.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Crate-CI.Typos to version 1.49.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422603)