### PR TITLE
New version: masterlxz.TruthID version 2.0.0

### DIFF
--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.installer.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.installer.yaml
@@ -1,5 +1,5 @@
 # Created with wingetcreate equivalent (manual authoring)
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: masterlxz.TruthID
 PackageVersion: 2.0.0
@@ -18,4 +18,4 @@ Installers:
     InstallerUrl: https://github.com/masterlxz/truthid/releases/download/v2.0.0/TruthID_2.0.0_x64_en-US.msi
     InstallerSha256: EC05EC2B628B53C2F2F8F3076606994910CC507653695A5F18E305C944954E1B
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.installer.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.installer.yaml
@@ -1,0 +1,21 @@
+# Created with wingetcreate equivalent (manual authoring)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: masterlxz.TruthID
+PackageVersion: 2.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/masterlxz/truthid/releases/download/v2.0.0/TruthID_2.0.0_x64_en-US.msi
+    InstallerSha256: EC05EC2B628B53C2F2F8F3076606994910CC507653695A5F18E305C944954E1B
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.locale.en-US.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with wingetcreate equivalent (manual authoring)
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: masterlxz.TruthID
 PackageVersion: 2.0.0
@@ -19,4 +19,4 @@ Tags:
   - password-manager
   - self-sovereign-identity
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.locale.en-US.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created with wingetcreate equivalent (manual authoring)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: masterlxz.TruthID
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: masterlxz
+PublisherUrl: https://github.com/masterlxz
+PublisherSupportUrl: https://github.com/masterlxz/truthid/issues
+PackageName: TruthID
+PackageUrl: https://masterlxz.github.io/truthid
+License: MIT
+LicenseUrl: https://github.com/masterlxz/truthid/blob/main/LICENSE
+ShortDescription: Self-sovereign identity desktop app — your device holds the keys, no server in the middle
+Tags:
+  - authentication
+  - passwordless
+  - decentralized
+  - password-manager
+  - self-sovereign-identity
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.yaml
@@ -1,8 +1,8 @@
 # Created with wingetcreate equivalent (manual authoring)
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: masterlxz.TruthID
 PackageVersion: 2.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.yaml
+++ b/manifests/m/masterlxz/TruthID/2.0.0/masterlxz.TruthID.yaml
@@ -1,0 +1,8 @@
+# Created with wingetcreate equivalent (manual authoring)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: masterlxz.TruthID
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
# New Package

TruthID — self-sovereign identity desktop app, MIT licensed. Windows installer (.msi) built via Tauri/WiX, published at https://github.com/masterlxz/truthid/releases/tag/v2.0.0.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/)?

Note: the installer is not code-signed (no Windows code-signing certificate yet), so first-run SmartScreen will show an "Unknown Publisher" warning.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422612)