### PR TITLE
Add Win-CodexBar 0.54.0

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.54.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+AppsAndFeaturesEntries:
+- DisplayName: CodexBar 0.54.0
+  Publisher: CodexBar Contributors
+  DisplayVersion: 0.54.0
+  ProductCode: WinCodexBar_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.54.0/CodexBar-0.54.0-Setup.exe
+  InstallerSha256: 2DBBE9B3156EB9407330925F37E6EEB1A2210D04D5D69A32F313AB5981EB67AA
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-22

--- a/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.54.0
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing OpenAI Codex and Claude Code usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Windows port of upstream CodexBar 0.53.0 to 0.54.0.
+
+  New providers and data sources: Codex Personal Access Token usage, Grok local session tokens, OpenCode Go usage API, OpenRouter Activity 30-day spend tracking, and Antigravity idle-family filtering.
+
+  Spend and pricing: date-gated historical GPT-5.6 Terra/Luna pricing, typed OpenCodex spend routing across Codex/OpenCode Go/Kimi/DeepSeek subscriptions, and xAI daily spend breakdown.
+
+  Settings and dashboard: new show_pace toggle for pace visualizations, OpenRouter management API token UI, and Antigravity idle-family dashboard filtering.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.54.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.54.0/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.54.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Win-CodexBar 0.54.0

### Package Information
- **PackageIdentifier:** Finesssee.Win-CodexBar
- **PackageVersion:** 0.54.0
- **Publisher:** CodexBar Contributors

### Release Notes
https://github.com/nesszer/Win-CodexBar/releases/tag/v0.54.0

New features: Codex PAT support, Grok local session tokens, OpenCode Go usage API, OpenRouter Activity spend tracking, Antigravity idle-family filtering, historical GPT-5.6 pricing, OpenCodex spend routing, show_pace setting, management API token UI.

### Installer
- **URL:** https://github.com/nesszer/Win-CodexBar/releases/download/v0.54.0/CodexBar-0.54.0-Setup.exe
- **SHA-256:** 2DBBE9B3156EB9407330925F37E6EEB1A2210D04D5D69A32F313AB5981EB67AA
- Verified against the published `.sha256` sidecar on the release; matches exactly.

### Validation
- `winget validate manifests/f/Finesssee/Win-CodexBar/0.54.0/` → Manifest validation succeeded.

### Previous PR
#420587 (0.48.0 → 0.53.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422647)