### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.0.7

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.0.7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.7
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{EF9D56F0-0059-4D29-AD61-6404BBB536A2}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{EF9D56F0-0059-4D29-AD61-6404BBB536A2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.0.7/GestureSign-V2-18.0.7-x64.msi
+  InstallerSha256: 00B44AE9A05E94B8C40F50B78B5CB646C0112838C5A42151E63E60BC7CA6AA8E
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-22

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created for GestureSign V2 18.0.7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.7
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Fixed a stale touch-interception threshold that could remain active after switching from a configured app to a game.
+  - Improved fullscreen detection for multi-monitor and borderless-fullscreen games.
+  - Added foreground-window fallback for desktop or transparent rendering surfaces and bypassed gesture capture for excluded fullscreen apps.
+  - Fresh configurations now exclude fullscreen games and apps by default.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.7
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.7/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created for GestureSign V2 18.0.7
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates Tomclanc.GestureSignV2 to version 18.0.7. The MSI is published in the corresponding GitHub Release, its SHA-256 is verified, and the manifests pass `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422658)