### PR TITLE
New package: VKrishna04.dev-prune version 1.5.0

### DIFF
--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
@@ -5,7 +5,6 @@ InstallerType: zip
 NestedInstallerType: portable
 Commands:
   - dev-prune
-  - devp
 ReleaseDate: 2026-08-22
 Installers:
   - Architecture: x64

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
@@ -1,5 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
-
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.5.0
 InstallerType: zip
@@ -28,4 +27,4 @@ Installers:
       - RelativeFilePath: dev-prune.exe
         PortableCommandAlias: dev-prune
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.installer.yaml
@@ -1,0 +1,31 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.5.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - dev-prune
+  - devp
+ReleaseDate: 2026-08-22
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.5.0/dev-prune-v1.5.0-windows-x64.zip
+    InstallerSha256: f26fec2bb7bc41b4fd3ab239839e6857c7d58f80bbf93a0d035787175b6f5529
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.5.0/dev-prune-v1.5.0-windows-arm64.zip
+    InstallerSha256: 4cffab149ff5de2b03feb39b84f6c1ef96b18c520d2fe80d7d9cd1a45e71cbbd
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+  - Architecture: x86
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.5.0/dev-prune-v1.5.0-windows-x86.zip
+    InstallerSha256: 65825b62660f2e545f1df2695cb28305265978b8d3e17026930dc3c685e6bb3a
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.locale.en-US.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.locale.en-US.yaml
@@ -1,0 +1,30 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: VKrishna04
+PublisherUrl: https://github.com/Life-Experimentalist
+PublisherSupportUrl: https://github.com/Life-Experimentalist/dev-prune/issues
+PackageName: dev-prune
+PackageUrl: https://devprune.vkrishna04.me
+License: Apache-2.0
+LicenseUrl: https://github.com/Life-Experimentalist/dev-prune/blob/main/LICENSE.md
+ShortDescription: Universal, lockfile-safe workspace pruner and background dependency cleaner
+Description: >-
+  dev-prune reclaims disk space from Git repositories you have stopped working in by
+  deleting the dependency and build directories a lockfile can rebuild — node_modules,
+  .venv, target, vendor and the rest — and refuses to delete anything it cannot prove is
+  recoverable. It verifies the lockfile before it touches a directory, never crosses a
+  .git boundary, never follows a symlink, and records every deletion so devp restore can
+  put it back.
+Moniker: dev-prune
+Tags:
+  - cli
+  - cleanup
+  - disk-space
+  - node-modules
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Life-Experimentalist/dev-prune/releases/tag/v1.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.locale.en-US.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.locale.en-US.yaml
@@ -1,5 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
-
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.5.0
 PackageLocale: en-US
@@ -27,4 +26,4 @@ Tags:
   - developer-tools
 ReleaseNotesUrl: https://github.com/Life-Experimentalist/dev-prune/releases/tag/v1.5.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.5.0/VKrishna04.dev-prune.yaml
@@ -1,7 +1,6 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
-
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.5.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `VKrishna04.dev-prune` version 1.5.0.

[dev-prune](https://github.com/Life-Experimentalist/dev-prune) is an open-source (Apache-2.0) command-line tool that reclaims disk space from Git repositories you have stopped working in, by deleting the dependency directories a lockfile can rebuild — `node_modules`, `.venv`, `target`, `vendor`, `Pods` and the rest — and refusing to delete anything it cannot prove is recoverable.

It ships as a single self-contained binary with no runtime dependency, published from a tagged GitHub Actions release with build provenance attestation. The manifest points at the x64, arm64 and x86 Windows zips from that release; each `InstallerSha256` is the digest published in the release's own `.sha256` sidecar.

- Homepage: https://devprune.vkrishna04.me
- Repository: https://github.com/Life-Experimentalist/dev-prune
- Release: https://github.com/Life-Experimentalist/dev-prune/releases/tag/v1.5.0

One note on `NestedInstallerFiles`: the archive contains a single `dev-prune.exe`, and the tool is normally used under the shorter alias `devp`. Since a `RelativeFilePath` cannot repeat within one installer, the portable install publishes `dev-prune` only; the binary creates its `devp` twin itself on first run.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — "Manifest validation succeeded", no warnings
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run: local manifest installs require `winget settings --enable LocalManifestFiles` as administrator, which I could not enable on this machine. The archives themselves are the ones published by the release and the digests are taken from its `.sha256` sidecars.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422665)