### PR TITLE
New package: stickylfs.img-converter version 1.0.0

### DIFF
--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
@@ -19,12 +19,12 @@ AppsAndFeaturesEntries:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup.exe
-    InstallerSha256: 1EF451F2151291443878F8B2212B31D27B71F156D6ED6D1EFD560457B2D6CD6F
+    InstallerSha256: 3F4A70160B5671D8EF2AE2D88D30E9090BE40BABC6E6A4D667259949187B60B7
   - Architecture: arm64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-arm64.exe
-    InstallerSha256: 254D41F294658FBDC7A9D976E6373C8C4035C8A33A2E8D05BFF6EB5E0858DB08
+    InstallerSha256: 93F4FDCEC55B51BC0F3DEBC5F8F6B3D9A5079D246C0483C2F253129E7E15E723
   - Architecture: x86
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-x86.exe
-    InstallerSha256: 1FB063CD4579A0DF7FF8F47D3017B79BD81F4A851F5C8257FBEBF5B9CD69AD07
+    InstallerSha256: 8B861A1B367DF754151C6CD45E4F54F224F03451E34D77804663A2FA3A8E444D
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
@@ -11,15 +11,20 @@ InstallerSwitches:
   Silent: /SILENT
   SilentWithProgress: /SILENT
 UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: img-converter
+    DisplayVersion: 1.0.0
+    Publisher: stickylfs
+    ProductCode: img-converter
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup.exe
-    InstallerSha256: BC3C2B28492FA29C8B65DF936C4D772CDACE32B922A8DAEBA9B7A7D0D69C98A4
+    InstallerSha256: 1EF451F2151291443878F8B2212B31D27B71F156D6ED6D1EFD560457B2D6CD6F
   - Architecture: arm64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-arm64.exe
-    InstallerSha256: EEE7D06E1F0713FF40C68B6251EB1CABB8C785356C49829F3BAC2B1BF15A1DD6
+    InstallerSha256: 254D41F294658FBDC7A9D976E6373C8C4035C8A33A2E8D05BFF6EB5E0858DB08
   - Architecture: x86
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-x86.exe
-    InstallerSha256: A6AD3AEB64891B8EB72467D23DCB3DF703AD850476458E646CB5F40132744D15
+    InstallerSha256: 1FB063CD4579A0DF7FF8F47D3017B79BD81F4A851F5C8257FBEBF5B9CD69AD07
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
@@ -19,12 +19,12 @@ AppsAndFeaturesEntries:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup.exe
-    InstallerSha256: 3F4A70160B5671D8EF2AE2D88D30E9090BE40BABC6E6A4D667259949187B60B7
+    InstallerSha256: 98AA3720C8CC6FAB0276A17926B4F8ABD0013C9ABFBA7C5D1CBB783CB946C589
   - Architecture: arm64
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-arm64.exe
-    InstallerSha256: 93F4FDCEC55B51BC0F3DEBC5F8F6B3D9A5079D246C0483C2F253129E7E15E723
+    InstallerSha256: 5BB17EFF56A4018E09B2F6A097CDEF99690BDC642F38201A518066BCF7729123
   - Architecture: x86
     InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-x86.exe
-    InstallerSha256: 8B861A1B367DF754151C6CD45E4F54F224F03451E34D77804663A2FA3A8E444D
+    InstallerSha256: 306862BD1DB8C9387C3616055349FEED00953D11061CB6B566B8321A8B306F29
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: stickylfs.img-converter
+PackageVersion: 1.0.0
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /SILENT
+  SilentWithProgress: /SILENT
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup.exe
+    InstallerSha256: BC3C2B28492FA29C8B65DF936C4D772CDACE32B922A8DAEBA9B7A7D0D69C98A4
+  - Architecture: arm64
+    InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-arm64.exe
+    InstallerSha256: EEE7D06E1F0713FF40C68B6251EB1CABB8C785356C49829F3BAC2B1BF15A1DD6
+  - Architecture: x86
+    InstallerUrl: https://github.com/stickylfs/img-converter/releases/download/v1.0.0/img-converter-setup-x86.exe
+    InstallerSha256: A6AD3AEB64891B8EB72467D23DCB3DF703AD850476458E646CB5F40132744D15
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.locale.en-US.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: stickylfs.img-converter
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: stickylfs
+PublisherUrl: https://github.com/stickylfs
+PublisherSupportUrl: https://github.com/stickylfs/img-converter/issues
+PackageName: img-converter
+PackageUrl: https://github.com/stickylfs/img-converter
+License: MIT
+LicenseUrl: https://github.com/stickylfs/img-converter/blob/main/LICENSE-MIT
+ShortDescription: Ultra-fast native Windows File Explorer right-click image converter written in pure Rust.
+Description: |-
+  img-converter is an ultra-fast, 100% offline, native Windows File Explorer right-click image converter written in pure Rust.
+  Features:
+  - Single and batch conversion
+  - Supports AVIF, WebP, JPEG, PNG, GIF, ICO, BMP, SVG, TIFF, TGA, DDS, HDR, EXR, HEIC, RAW, PDF
+  - Zero telemetry, zero external dependencies, zero UAC elevation required.
+Moniker: img-converter
+Tags:
+  - image-converter
+  - context-menu
+  - shell-extension
+  - rust
+  - windows
+  - webp
+  - avif
+  - heic
+  - pdf
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.yaml
+++ b/manifests/s/stickylfs/img-converter/1.0.0/stickylfs.img-converter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: stickylfs.img-converter
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Pull Request Checklist
- [x] Package identifier is stickylfs.img-converter
- [x] Package version is 1.0.0
- [x] Tested with `winget validate` (Passes validation)
- [x] Silent switches `/SILENT` tested

### Description
New package submission for `stickylfs.img-converter` (v1.0.0):
Ultra-fast native Windows File Explorer right-click image converter written in pure Rust.
Includes x64, ARM64, and x86 installers.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422681)