### PR TITLE
New version: rstream.rstream version 1.29.1

### DIFF
--- a/manifests/r/rstream/rstream/1.29.1/rstream.rstream.installer.yaml
+++ b/manifests/r/rstream/rstream/1.29.1/rstream.rstream.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.29.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/rstream.exe
+    PortableCommandAlias: rstream
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://rstream.io/api/packages/cmt4qkiu8000g04l7tcgzfqek/download
+    InstallerSha256: 7e7777fa3d7631ff3a363c2d79742127dd5b8abbce64dfdd1ec8e12be7f32f4a
+  - Architecture: arm64
+    InstallerUrl: https://rstream.io/api/packages/cmt4qkl2z000k04l7fi6ib167/download
+    InstallerSha256: 3457a605b0720f355b9baa6dc4fd2aa600cebeb061465dc0fc4a8c89449f4d31
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/rstream/rstream/1.29.1/rstream.rstream.installer.yaml
+++ b/manifests/r/rstream/rstream/1.29.1/rstream.rstream.installer.yaml
@@ -10,9 +10,9 @@ NestedInstallerFiles:
 Installers:
   - Architecture: x64
     InstallerUrl: https://rstream.io/api/packages/cmt4qkiu8000g04l7tcgzfqek/download
-    InstallerSha256: 7e7777fa3d7631ff3a363c2d79742127dd5b8abbce64dfdd1ec8e12be7f32f4a
+    InstallerSha256: ce22e9af9dacde6de8c402dc9d6710a8e2a50a41c1778f1b97b2932941b60044
   - Architecture: arm64
     InstallerUrl: https://rstream.io/api/packages/cmt4qkl2z000k04l7fi6ib167/download
-    InstallerSha256: 3457a605b0720f355b9baa6dc4fd2aa600cebeb061465dc0fc4a8c89449f4d31
+    InstallerSha256: 240c940df0c4d6e0e1681a08eb27674f80e40f59247f00afbfbcbd8f70c2f535
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/rstream/rstream/1.29.1/rstream.rstream.locale.en-US.yaml
+++ b/manifests/r/rstream/rstream/1.29.1/rstream.rstream.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.29.1
+PackageLocale: en-US
+Publisher: rstream
+PublisherUrl: https://rstream.io
+PublisherSupportUrl: https://rstream.io/docs
+Author: rstream
+PackageName: rstream
+PackageUrl: https://rstream.io
+License: Apache-2.0
+LicenseUrl: https://github.com/rstreamlabs/rstream-go/blob/main/LICENSE
+ShortDescription: Command-line client for rstream.
+Description: rstream is a developer-first platform for zero-trust networking.
+Moniker: rstream
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rstream/rstream/1.29.1/rstream.rstream.yaml
+++ b/manifests/r/rstream/rstream/1.29.1/rstream.rstream.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.29.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates the existing rstream.rstream package to version 1.29.1. The manifests reference rstream's existing published Windows x64 and arm64 archives.

## Checklist

- [x] The Microsoft Contributor License Agreement is already signed
- [x] Confirmed that no other open pull request targets rstream.rstream 1.29.1
- [x] Validated all three manifests against the official 1.12 JSON schemas
- [x] Downloaded both archives and verified their SHA-256 checksums
- [x] Verified both files are valid ZIP archives containing bin/rstream.exe
- [ ] Tested with winget validate and winget install on Windows; WinGet is not available on this macOS workstation
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422709)