### PR TITLE
New package: AceisX.MiniBar version 1.1.0

### DIFF
--- a/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.installer.yaml
+++ b/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AceisX.MiniBar
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.22000.0
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+- minibar
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AceisX/minibar-now-playing-overlay/releases/download/v1.1.0/minibar.exe
+  InstallerSha256: 67B2352EA8DE719E3F59E0C897681B40C283E137C3D84CF49CA18F2E6835DFC7
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2026-08-22

--- a/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.locale.en-US.yaml
+++ b/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AceisX.MiniBar
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: AceisX
+PublisherUrl: https://github.com/AceisX
+PublisherSupportUrl: https://github.com/AceisX/minibar-now-playing-overlay/issues
+PackageName: MiniBar
+PackageUrl: https://github.com/AceisX/minibar-now-playing-overlay
+License: MIT
+LicenseUrl: https://github.com/AceisX/minibar-now-playing-overlay/blob/main/LICENSE
+Copyright: Copyright (c) 2026 MiniBar contributors
+ShortDescription: The lightest music overlay for Windows 11.
+Description: |-
+  MiniBar is a small always-on-top bar that shows what is playing and controls it:
+  cover, title, artist, progress, and play/pause/previous/next on hover. It reads the
+  media session Windows already knows about, so it works with any player that registers
+  one - Spotify, Tidal, YouTube Music in a browser, foobar2000 - with no account, API key
+  or plugin.
+
+  It uses about 7 MB of RAM, ships as a single ~300 KB executable with no runtime to
+  install, and does no GPU work between redraws. It never injects a DLL and never installs
+  a hook, so it is safe to run alongside anti-cheat software.
+
+  Three modes: a free-floating overlay that stays above fullscreen-windowed games and is
+  click-through until you hover it, a docked strip that reserves screen space, and a pill
+  that sits in the taskbar's empty space. The mouse wheel changes the player's own volume
+  in the Windows mixer, not the system volume.
+Moniker: minibar
+Tags:
+- audio
+- media-controls
+- music
+- now-playing
+- overlay
+- smtc
+- spotify
+- taskbar
+ReleaseNotesUrl: https://github.com/AceisX/minibar-now-playing-overlay/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.yaml
+++ b/manifests/a/AceisX/MiniBar/1.1.0/AceisX.MiniBar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: AceisX.MiniBar
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package: **AceisX.MiniBar 1.1.0** — MiniBar, a small native now-playing overlay / mini player for Windows 11 (Win32, ~6 MB RAM, single portable executable, MIT).

- Installer type: `portable` (single `minibar.exe`, no installer, nothing written to the registry).
- Source and release: https://github.com/AceisX/minibar-now-playing-overlay/releases/tag/v1.1.0
- SHA256 of the released asset verified against the manifest.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` (local manifests are disabled on the submitting machine; the portable install was tested by hand)
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) — written against 1.6.0; happy to bump if required

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422717)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422717)