### PR TITLE
Update version: Tyrrrz.DiscordChatExporter.CLI version 2.47.3

### DIFF
--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.installer.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: 2.47.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: DiscordChatExporter.Cli.exe
+  PortableCommandAlias: discordchatexporter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+ReleaseDate: 2026-06-26
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.47.3/DiscordChatExporter.Cli.win-x86.zip
+  InstallerSha256: 3C246BEEF59EA317BBE4C579CF55BAEF5785BD130EB4555A063FA4DBBB2ED87C
+- Architecture: x64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.47.3/DiscordChatExporter.Cli.win-x64.zip
+  InstallerSha256: D7C91731E190FC9A59F96275DAE958DFA8102309263F4ACD1CCB946725023A3D
+- Architecture: arm64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.47.3/DiscordChatExporter.Cli.win-arm64.zip
+  InstallerSha256: 1D72943480D5C29D9EAE544167F7087FF59A259E4E8144A61FFE13A544A173BD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.locale.en-US.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: 2.47.3
+PackageLocale: en-US
+Publisher: Tyrrrz
+PublisherUrl: https://github.com/Tyrrrz
+PublisherSupportUrl: https://github.com/Tyrrrz/DiscordChatExporter/issues
+PackageName: DiscordChatExporter.CLI
+PackageUrl: https://github.com/Tyrrrz/DiscordChatExporter
+License: MIT
+LicenseUrl: https://github.com/Tyrrrz/DiscordChatExporter/blob/HEAD/License.txt
+ShortDescription: Exports Discord chat logs to a file
+Tags:
+- archival
+- archiver
+- chat
+- discord
+- export
+- expoter
+- log
+ReleaseNotes: |-
+  <!-- Release notes generated using configuration in .github/release.yml at 2.47.3 -->
+
+  ## What's Changed
+  ### Bugs
+  • Validate output path early to prevent errors when exporting multiple channels by @CanePlayz in https://github.com/Tyrrrz/DiscordChatExporter/pull/1555
+  • Fix output path detection to correctly identify directories and files by @CanePlayz in https://github.com/Tyrrrz/DiscordChatExporter/pull/1556
+  • Catch both old uppercase 5-char hash and newer lowercase 5-char hash when migrating to new hash by @SnowySailor in https://github.com/Tyrrrz/DiscordChatExporter/pull/1552
+  • Check for `media.discordapp.net` in addition to `cdn.discordapp.com` when stripping signature parameters from media URLs by @SnowySailor in https://github.com/Tyrrrz/DiscordChatExporter/pull/1554
+  • Include starter message in thread exports and skip placeholder by @CanePlayz in https://github.com/Tyrrrz/DiscordChatExporter/pull/1557
+
+  ## New Contributors
+  • @SnowySailor made their first contribution in https://github.com/Tyrrrz/DiscordChatExporter/pull/1552
+
+  **Full Changelog**：https://github.com/Tyrrrz/DiscordChatExporter/compare/2.47.2...2.47.3
+ReleaseNotesUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/tag/2.47.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.47.3/Tyrrrz.DiscordChatExporter.CLI.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: 2.47.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Tyrrrz.DiscordChatExporter.CLI to version 2.47.3.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422735)