### PR TITLE
New version: KopioRapido.KopioRapido version 2026.08.22.1

### DIFF
--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.installer.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.installer.yaml
@@ -1,0 +1,26 @@
+# Winget installer manifest
+# Version and hashes updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22.1
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kp.exe
+    PortableCommandAlias: kp
+Commands:
+  - kp
+  - kopiorapido
+Dependencies:
+  PackageDependencies: []
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.22.1/cli/kopiorapido-cli-win-x64-2026.08.22.1.zip
+    InstallerSha256: 637838a907ed02962f1b348d54a9db89ee92695ecd1e6248dd79da0853ddf3f7
+  - Architecture: arm64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.22.1/cli/kopiorapido-cli-win-arm64-2026.08.22.1.zip
+    InstallerSha256: 33533e90c7b58b1c7f9eab226f1ca0dca16b4dcbd89e809fa7bcc8595cb9ffcf
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.locale.en-US.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Winget locale manifest (en-US)
+# Version updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22.1
+PackageLocale: en-US
+Publisher: KopioRapido
+PublisherUrl: https://kopiorapido.com
+PublisherSupportUrl: https://kopiorapido.com
+PackageName: KopioRapido CLI
+PackageUrl: https://kopiorapido.com
+License: Shareware
+LicenseUrl: https://kopiorapido.com
+Copyright: Copyright (c) 2026 KopioRapido
+ShortDescription: High-performance file copying CLI with delta sync and intelligent transfer
+Description: |-
+  KopioRapido is a high-performance cross-platform file copying CLI with intelligent transfer optimization.
+
+  Features:
+  - Delta synchronization for efficient updates
+  - Smart compression for network transfers
+  - Multiple operation modes: Copy, Move, Sync, Mirror, BiDirectional Sync
+  - Resumable operations
+  - Real-time progress tracking
+  - JSON output for scripting
+  - Intelligent transfer engine that analyzes storage devices
+  - Adaptive performance monitoring
+Moniker: kp
+Tags:
+  - backup
+  - cli
+  - copy
+  - file-management
+  - rsync
+  - sync
+  - robocopy
+ReleaseNotesUrl: https://kopiorapido.com/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.22.1/KopioRapido.KopioRapido.yaml
@@ -1,0 +1,9 @@
+# Winget manifest (main version file)
+# Version and hashes updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.22.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
#### Description

Updates KopioRapido.KopioRapido to 2026.08.22.1 (peer-to-peer transfers extracted into the p2p plugin).

- Two new or updated installer URLs (x64 + arm64), checksums published at releases.kopiorapido.com.
- Version: 2026.08.22.1

###### Microsoft Reviewers: [Open in Codespaces](https://codespaces.new/microsoft/winget-pkgs?quickstart=1&repo=microsoft%2Fwinget-pkgs&ref=master&quickstart=1)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422742)