### PR TITLE
Add dimitree2k.Caffeinate version 0.4.2

### DIFF
--- a/manifests/d/dimitree2k/Caffeinate/0.4.2/dimitree2k.Caffeinate.yaml
+++ b/manifests/d/dimitree2k/Caffeinate/0.4.2/dimitree2k.Caffeinate.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+PackageIdentifier: dimitree2k.Caffeinate
+PackageVersion: 0.4.2
+PackageLocale: en-US
+Publisher: dimitree2k
+PackageName: Caffeinate
+License: MIT
+LicenseUrl: https://github.com/dimitree2k/caffeinate/blob/master/LICENSE
+Copyright: Copyright (c) Dimitry
+ShortDescription: Lightweight system tray app that prevents your PC from sleeping.
+Description: |-
+  Caffeinate is a lightweight system tray utility for Windows that prevents the
+  PC from going to sleep — like macOS caffeinate, but native Win32.
+
+  Features keep-awake toggle, timers (15/30/60/120 min or custom), a screen
+  blackout mode that locks the workstation on dismissal, and a single-instance
+  tray icon. Single portable exe, no runtime dependencies, no installer.
+Moniker: caffeinate
+ReleaseNotesUrl: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.2
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/dimitree2k/caffeinate/releases/download/v0.4.2/caffeinate.exe
+    InstallerSha256: 7F7FDCDE9F5F9211653686F8526EC414F9676C6EA242783E2E530DC4A425ED85
+    Commands:
+      - caffeinate
+ManifestType: singleton
+ManifestVersion: 1.6.0

--- a/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.installer.yaml
+++ b/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: dimitree2k.Caffeinate
+PackageVersion: 0.4.3
+MinimumOSVersion: 10.0.17063.0
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/dimitree2k/caffeinate/releases/download/v0.4.3/caffeinate.exe
+    InstallerSha256: DFF5A89DF9AC3F0B10A3EFAF0F309E02278C5B3A61C37EB894692A4E18D61637
+    Commands:
+      - caffeinate
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.locale.en-US.yaml
+++ b/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: dimitree2k.Caffeinate
+PackageVersion: 0.4.3
+PackageLocale: en-US
+Publisher: dimitree2k
+PublisherUrl: https://github.com/dimitree2k
+Author: Dimitry
+PackageName: Caffeinate
+PackageUrl: https://github.com/dimitree2k/caffeinate
+License: MIT
+LicenseUrl: https://github.com/dimitree2k/caffeinate/blob/master/LICENSE
+Copyright: Copyright (c) Dimitry
+ShortDescription: Lightweight system tray app that prevents your PC from sleeping.
+Description: |-
+  Caffeinate is a lightweight system tray utility for Windows that prevents the
+  PC from going to sleep — like macOS caffeinate, but native Win32.
+
+  Features keep-awake toggle, timers (15/30/60/120 min or custom), a screen
+  blackout mode that locks the workstation on dismissal, and a single-instance
+  tray icon. Single portable exe, no runtime dependencies, no installer.
+Moniker: caffeinate
+ReleaseNotesUrl: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.yaml
+++ b/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.yaml
@@ -1,9 +1,10 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
 PackageIdentifier: dimitree2k.Caffeinate
-PackageVersion: 0.4.2
+PackageVersion: 0.4.3
 PackageLocale: en-US
 Publisher: dimitree2k
 PackageName: Caffeinate
+PackageUrl: https://github.com/dimitree2k/caffeinate
 License: MIT
 LicenseUrl: https://github.com/dimitree2k/caffeinate/blob/master/LICENSE
 Copyright: Copyright (c) Dimitry
@@ -16,13 +17,13 @@ Description: |-
   blackout mode that locks the workstation on dismissal, and a single-instance
   tray icon. Single portable exe, no runtime dependencies, no installer.
 Moniker: caffeinate
-ReleaseNotesUrl: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.2
+ReleaseNotesUrl: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.3
 Installers:
   - Architecture: x64
     InstallerType: portable
-    InstallerUrl: https://github.com/dimitree2k/caffeinate/releases/download/v0.4.2/caffeinate.exe
-    InstallerSha256: 7F7FDCDE9F5F9211653686F8526EC414F9676C6EA242783E2E530DC4A425ED85
+    InstallerUrl: https://github.com/dimitree2k/caffeinate/releases/download/v0.4.3/caffeinate.exe
+    InstallerSha256: DFF5A89DF9AC3F0B10A3EFAF0F309E02278C5B3A61C37EB894692A4E18D61637
     Commands:
       - caffeinate
 ManifestType: singleton
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.yaml
+++ b/manifests/d/dimitree2k/Caffeinate/0.4.3/dimitree2k.Caffeinate.yaml
@@ -1,29 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: dimitree2k.Caffeinate
 PackageVersion: 0.4.3
-PackageLocale: en-US
-Publisher: dimitree2k
-PackageName: Caffeinate
-PackageUrl: https://github.com/dimitree2k/caffeinate
-License: MIT
-LicenseUrl: https://github.com/dimitree2k/caffeinate/blob/master/LICENSE
-Copyright: Copyright (c) Dimitry
-ShortDescription: Lightweight system tray app that prevents your PC from sleeping.
-Description: |-
-  Caffeinate is a lightweight system tray utility for Windows that prevents the
-  PC from going to sleep — like macOS caffeinate, but native Win32.
-
-  Features keep-awake toggle, timers (15/30/60/120 min or custom), a screen
-  blackout mode that locks the workstation on dismissal, and a single-instance
-  tray icon. Single portable exe, no runtime dependencies, no installer.
-Moniker: caffeinate
-ReleaseNotesUrl: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.3
-Installers:
-  - Architecture: x64
-    InstallerType: portable
-    InstallerUrl: https://github.com/dimitree2k/caffeinate/releases/download/v0.4.3/caffeinate.exe
-    InstallerSha256: DFF5A89DF9AC3F0B10A3EFAF0F309E02278C5B3A61C37EB894692A4E18D61637
-    Commands:
-      - caffeinate
-ManifestType: singleton
+DefaultLocale: en-US
+ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
### Description
New package: dimitree2k.Caffeinate 0.4.2 — a lightweight native Win32 system tray app that prevents Windows from sleeping (macOS `caffeinate` equivalent). Single portable exe, MIT licensed, Authenticode-signed release binaries built by public GitHub Actions.

- Source repository: https://github.com/dimitree2k/caffeinate
- Release: https://github.com/dimitree2k/caffeinate/releases/tag/v0.4.2

### Checks
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that the manifest is not already in the repository?
- [x] Have you verified the package installs and uninstalls correctly?
- [x] Have you tested that the app runs correctly? (tested on a Windows machine by the maintainer; no automated test environment available in CI)
- [x] Have you followed the [manifest style guide](https://github.com/microsoft/winget-pkgs/blob/master/DOCUMENTATION.md#manifest-style-guide)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422746)