### PR TITLE
New package: VitorPamplona.Amethyst version 1.14.0

### DIFF
--- a/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.installer.yaml
+++ b/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VitorPamplona.Amethyst
+PackageVersion: 1.14.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vitorpamplona/amethyst/releases/download/v1.14.0/amethyst-desktop-1.14.0-windows-x64.msi
+  InstallerSha256: '7C1DF303AB3F1018ACF014FE106DDDE131FCED3432CFA7594954A4E5B883928C'
+  ProductCode: '{CBDCB81B-6E50-35EB-BAFC-A88FA8266DE1}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.locale.en-US.yaml
+++ b/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VitorPamplona.Amethyst
+PackageVersion: 1.14.0
+PackageLocale: en-US
+Publisher: Vitor Pamplona
+PublisherUrl: https://github.com/vitorpamplona
+PublisherSupportUrl: https://github.com/vitorpamplona/amethyst/issues
+Author: Vitor Pamplona
+PackageName: Amethyst
+PackageUrl: https://github.com/vitorpamplona/amethyst
+License: MIT
+LicenseUrl: https://github.com/vitorpamplona/amethyst/blob/main/LICENSE
+Copyright: Copyright (c) Vitor Pamplona
+CopyrightUrl: https://github.com/vitorpamplona/amethyst/blob/main/LICENSE
+ShortDescription: The all-in-one Nostr client
+Description: |-
+  A privacy-focused Nostr client. Built-in Tor support, the most configurable relay
+  system, encrypted messaging, zaps, marketplaces, live streams and complete data
+  sovereignty.
+Moniker: amethyst
+Tags:
+- decentralized
+- nostr
+- social
+- social-network
+ReleaseNotesUrl: https://github.com/vitorpamplona/amethyst/releases/tag/v1.14.0
+Documentations:
+- DocumentLabel: Building
+  DocumentUrl: https://github.com/vitorpamplona/amethyst/blob/main/BUILDING.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.yaml
+++ b/manifests/v/VitorPamplona/Amethyst/1.14.0/VitorPamplona.Amethyst.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VitorPamplona.Amethyst
+PackageVersion: 1.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Initial submission of **VitorPamplona.Amethyst** version 1.14.0 — Amethyst Desktop, a privacy-focused Nostr client (MIT). This is a new package; `manifests/v/VitorPamplona/` does not yet exist.

Installer is the x64 MSI produced by jpackage/WiX and published on the project's GitHub release:
`https://github.com/vitorpamplona/amethyst/releases/download/v1.14.0/amethyst-desktop-1.14.0-windows-x64.msi`

The release also ships a `windows-arm64` build, but as a plain `.zip` rather than an MSI, so only x64 is declared here. An arm64 entry can follow once it warrants the `NestedInstallerFiles` treatment.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the two unchecked validation items

I want to be straightforward rather than tick these blind: **this was prepared on macOS, so `winget validate` and `winget install` were not run.** Both are Windows-only, and I would rather say so than claim a check I did not perform. What was verified instead:

- `InstallerSha256` matches the published asset's digest as reported by the GitHub API — `sha256:7c1df303ab3f1018acf014fe106ddde131fced3432cfa7594954a4e5b883928c`.
- All three manifests carry every required field for their `ManifestType`, and agree on `PackageIdentifier`, `PackageVersion: 1.14.0` and `ManifestVersion: 1.12.0`.
- The branch adds exactly 3 files under `manifests/v/VitorPamplona/Amethyst/1.14.0/` and touches nothing else.
- `ProductCode` was read from the MSI's Property table by the project's release automation for this specific build.

If CI validation turns up anything, I will fix it promptly — and I am happy to have someone re-run the sandbox install if that is the normal path for a first-time publisher without a Windows machine to hand.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422752)