### PR TITLE
New: Chromatic.Registry version 0.2.0

### DIFF
--- a/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.0
+InstallerType: inno
+InstallerSwitches:
+  Silent: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: 1D6E095B-75F1-4CFB-9B12-2E42CD60DFE1_is1
+ReleaseDate: 2026-08-23
+AppsAndFeaturesEntries:
+- DisplayName: Registry
+  Publisher: Chromatic
+  ProductCode: 1D6E095B-75F1-4CFB-9B12-2E42CD60DFE1_is1
+ElevationRequirement: elevationProhibited
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.0/Registry-Setup-x64.exe
+  InstallerSha256: 02F65749CAA8E2C5E95AA85BFE8B8D6F01A6A6AA72729AC3A65F0957F64B9EAD
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.0/Registry-Setup-arm64.exe
+  InstallerSha256: B96681C631A60C56DB4632759CA2A052263E16B4B26FBFC577FCB5B9981741E8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.locale.en-US.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Chromatic
+PublisherUrl: https://chromatic.hu
+PublisherSupportUrl: https://chromatic.hu/contact
+PackageName: Registry
+PackageUrl: https://github.com/Has-X/Registry
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Has-X/Registry/blob/main/LICENSE.md
+Copyright: Copyright (c) 2026 Chromatic
+ShortDescription: Modern Windows Registry editor and command-line companion.
+Description: A modern registry editor for browsing, editing, importing, exporting, and checking registry data with a familiar Windows feel.
+Moniker: chromatic-registry
+Tags:
+- registry
+- regedit
+- winui
+- windows
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.0/Chromatic.Registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Registry 0.2.0

Adds Chromatic.Registry, a native WinUI 3 registry editor and CLI.

- Inno Setup installers for x64 and ARM64
- Per-user installation; no elevation required
- Installer SHA-256 values are from the immutable GitHub Release assets
- Manifest validated locally with `winget validate`

Release: https://github.com/Has-X/Registry/releases/tag/v0.2.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422784)