### PR TITLE
New version: KopioRapido.KopioRapido version 2026.08.23

### DIFF
--- a/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.installer.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.installer.yaml
@@ -1,0 +1,26 @@
+# Winget installer manifest
+# Version and hashes updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.23
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kp.exe
+    PortableCommandAlias: kp
+Commands:
+  - kp
+  - kopiorapido
+Dependencies:
+  PackageDependencies: []
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.23/cli/kopiorapido-cli-win-x64-2026.08.23.zip
+    InstallerSha256: 114c528c005b6679f6db4a90e2c1051c85d4eb62b8c63f8867fd4aa277dee469
+  - Architecture: arm64
+    InstallerUrl: https://releases.kopiorapido.com/2026.08.23/cli/kopiorapido-cli-win-arm64-2026.08.23.zip
+    InstallerSha256: 622bbaa054dddba86166c193de05bdc32f93077b5b500950b56ba9cf7ddf2c4d
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.locale.en-US.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Winget locale manifest (en-US)
+# Version updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.23
+PackageLocale: en-US
+Publisher: KopioRapido
+PublisherUrl: https://kopiorapido.com
+PublisherSupportUrl: https://kopiorapido.com
+PackageName: KopioRapido CLI
+PackageUrl: https://kopiorapido.com
+License: Shareware
+LicenseUrl: https://kopiorapido.com
+Copyright: Copyright (c) 2026 KopioRapido
+ShortDescription: High-performance file copying CLI with delta sync and intelligent transfer
+Description: |-
+  KopioRapido is a high-performance cross-platform file copying CLI with intelligent transfer optimization.
+
+  Features:
+  - Delta synchronization for efficient updates
+  - Smart compression for network transfers
+  - Multiple operation modes: Copy, Move, Sync, Mirror, BiDirectional Sync
+  - Resumable operations
+  - Real-time progress tracking
+  - JSON output for scripting
+  - Intelligent transfer engine that analyzes storage devices
+  - Adaptive performance monitoring
+Moniker: kp
+Tags:
+  - backup
+  - cli
+  - copy
+  - file-management
+  - rsync
+  - sync
+  - robocopy
+ReleaseNotesUrl: https://kopiorapido.com/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.yaml
+++ b/manifests/k/KopioRapido/KopioRapido/2026.08.23/KopioRapido.KopioRapido.yaml
@@ -1,0 +1,9 @@
+# Winget manifest (main version file)
+# Version and hashes updated by release.yml workflow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: KopioRapido.KopioRapido
+PackageVersion: 2026.08.23
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
#### Description

Updates KopioRapido.KopioRapido to 2026.08.23 (anonymous usage analytics — opt-out telemetry, contact form, privacy page).

- Two new or updated installer URLs (x64 + arm64), checksums published at releases.kopiorapido.com.
- Version: 2026.08.23

###### Microsoft Reviewers: [Open in Codespaces](https://codespaces.new/microsoft/winget-pkgs?quickstart=1&repo=microsoft%2Fwinget-pkgs&ref=master&quickstart=1)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422790)