### PR TITLE
New package: DevPossible.DesktopPossible version 1.3.0

### DIFF
--- a/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.installer.yaml
+++ b/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: DevPossible.DesktopPossible
+PackageVersion: 0.9.1
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DevPossible/DesktopPossible/releases/download/v0.9.1/DesktopPossible-0.9.1-win-x64.msi
+  InstallerSha256: 148AEC83F22683B9845F2535E40151851310DA7848EA03F6DD7FC42227FD40C5
+  ProductCode: '{434B2789-7501-4C21-85AE-8B49F391A99F}'
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{7C1E3B52-8A4D-4F0B-9C7E-5D2A6B9F1E34}'
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2026-08-23

--- a/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.locale.en-US.yaml
+++ b/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.locale.en-US.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 1.12.13.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
-
 PackageIdentifier: DevPossible.DesktopPossible
 PackageVersion: 0.9.1
 PackageLocale: en-US
@@ -13,7 +11,7 @@ License: MIT
 LicenseUrl: https://github.com/DevPossible/DesktopPossible/blob/main/LICENSE
 Copyright: Copyright (c) DevPossible and contributors
 ShortDescription: Free, open-source desktop organizer that groups icons into frames, mirrors folders, and holds notes and images.
-Description: DesktopPossible is a free, open-source Stardock Fences alternative for Windows 10/11. It creates virtual frames on the desktop to group icons, mirror folders (Portal frames), and hold notes and images, with profiles, hotkeys, theming, and a smart auto-sort engine.
+Description: DesktopPossible is a free, open-source Stardock Fences alternative for Windows 10/11. It groups desktop icons into virtual frames, mirrors folders live (Portal frames, with an Explorer-style Details view and filters), and adds Note, Image and live system-info Text frames. Includes workspace profiles with hotkeys and virtual-desktop switching, a one-click desktop categorizer with optional auto-organize, SpotSearch, and theming with a wallpaper-matching Chameleon mode.
 Moniker: desktoppossible
 Tags:
 - desktop

--- a/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.locale.en-US.yaml
+++ b/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: DevPossible.DesktopPossible
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: DevPossible
+PublisherUrl: https://github.com/DevPossible
+PublisherSupportUrl: https://github.com/DevPossible/DesktopPossible/issues
+PackageName: DesktopPossible
+PackageUrl: https://github.com/DevPossible/DesktopPossible
+License: MIT
+LicenseUrl: https://github.com/DevPossible/DesktopPossible/blob/main/LICENSE
+Copyright: Copyright (c) DevPossible and contributors
+ShortDescription: Free, open-source desktop organizer that groups icons into frames, mirrors folders, and holds notes and images.
+Description: DesktopPossible is a free, open-source Stardock Fences alternative for Windows 10/11. It creates virtual frames on the desktop to group icons, mirror folders (Portal frames), and hold notes and images, with profiles, hotkeys, theming, and a smart auto-sort engine.
+Moniker: desktoppossible
+Tags:
+- desktop
+- fences
+- icons
+- organizer
+- productivity
+ReleaseNotesUrl: https://github.com/DevPossible/DesktopPossible/releases/tag/v0.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.yaml
+++ b/manifests/d/DevPossible/DesktopPossible/0.9.1/DevPossible.DesktopPossible.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: DevPossible.DesktopPossible
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package: **DevPossible.DesktopPossible** version **1.3.0**.

DesktopPossible is a free, open-source (MIT) desktop organizer for Windows 10/11 — a Stardock Fences alternative that groups desktop icons into frames, mirrors folders, and holds notes and images. The installer is a per-machine WiX MSI published on the project's GitHub releases: https://github.com/DevPossible/DesktopPossible/releases/tag/v1.3.0

Submitted by the publisher (DevPossible, LLC — the submitting account is an admin of the DevPossible GitHub organisation).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the schema (authored against 1.6.0, which is accepted by the current validator)
