### PR TITLE
New package: VKrishna04.dev-prune version 1.6.0

### DIFF
--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.installer.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.installer.yaml
@@ -1,0 +1,36 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.6.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - dev-prune
+  - devp
+ReleaseDate: 2026-08-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.6.0/dev-prune-v1.6.0-windows-x64.zip
+    InstallerSha256: c0da332be8677e3a8824ba6c4c41b0495f706932abd3c0ec035bbeba0c86cf31
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+      - RelativeFilePath: devp.exe
+        PortableCommandAlias: devp
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.6.0/dev-prune-v1.6.0-windows-arm64.zip
+    InstallerSha256: ab48f771d96e5a33474935fc6999a807376e4f5cd38b318b488a1983917e2085
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+      - RelativeFilePath: devp.exe
+        PortableCommandAlias: devp
+  - Architecture: x86
+    InstallerUrl: https://github.com/Life-Experimentalist/dev-prune/releases/download/v1.6.0/dev-prune-v1.6.0-windows-x86.zip
+    InstallerSha256: 42d0488154c2cb5596d0ccc209220d61c87c2339a8ea79721572c8f69011a3c5
+    NestedInstallerFiles:
+      - RelativeFilePath: dev-prune.exe
+        PortableCommandAlias: dev-prune
+      - RelativeFilePath: devp.exe
+        PortableCommandAlias: devp
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.installer.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.6.0
 InstallerType: zip

--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.locale.en-US.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.6.0
 PackageLocale: en-US

--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.locale.en-US.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.locale.en-US.yaml
@@ -1,0 +1,29 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: VKrishna04
+PublisherUrl: https://github.com/Life-Experimentalist
+PublisherSupportUrl: https://github.com/Life-Experimentalist/dev-prune/issues
+PackageName: dev-prune
+PackageUrl: https://devprune.vkrishna04.me
+License: Apache-2.0
+LicenseUrl: https://github.com/Life-Experimentalist/dev-prune/blob/main/LICENSE.md
+ShortDescription: Universal, lockfile-safe workspace pruner and background dependency cleaner
+Description: >-
+  dev-prune reclaims disk space from Git repositories you have stopped working in by
+  deleting the dependency and build directories a lockfile can rebuild — node_modules,
+  .venv, target, vendor and the rest — and refuses to delete anything it cannot prove is
+  recoverable. It verifies the lockfile before it touches a directory, never crosses a
+  .git boundary, never follows a symlink, and records every deletion so devp restore can
+  put it back.
+Moniker: dev-prune
+Tags:
+  - cli
+  - cleanup
+  - disk-space
+  - node-modules
+  - developer-tools
+ReleaseNotesUrl: https://github.com/Life-Experimentalist/dev-prune/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.yaml
@@ -1,0 +1,6 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: VKrishna04.dev-prune
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.yaml
+++ b/manifests/v/VKrishna04/dev-prune/1.6.0/VKrishna04.dev-prune.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: VKrishna04.dev-prune
 PackageVersion: 1.6.0
 DefaultLocale: en-US


### PR DESCRIPTION
New package: `VKrishna04.dev-prune` version 1.6.0.

This supersedes #422665, which submitted 1.5.0 and hit `Validation-Defender-Error`. A
winget-pkgs pull request carries one version, so this is a fresh submission rather than
an update to that one; #422665 is being closed.

### What caused the Defender detection, and what changed

`07. Installers Scan` passed on #422665 — the static multi-engine scan was clean — so the
detection came from the post-install dynamic test. It was a real behavioural signature,
not a false positive, and it is fixed in the binary rather than papered over here.

On first execution, 1.5.0 copied itself to `devp.exe` beside the running executable,
unconditionally, before parsing arguments. A freshly downloaded unsigned executable
writing a second copy of itself is a malware behaviour pattern, and it was also simply
wrong for WinGet: WinGet versions and replaces `…\Microsoft\WinGet\Packages\<id>\` whole
on upgrade, so the copy would be orphaned there at the next `winget upgrade`.

1.5.1 added a guard that detects a package-manager-owned install directory — WinGet,
Scoop and Homebrew, the three that version and replace their package directory — and
skips the self-copy entirely in one. The integration pass that registers a scheduled task
and a PATH entry is separately gated on an interactive terminal, so it does not run under
validation either.

Verified against the published 1.6.0 x64 archive rather than a local build:

- extracted to a path containing `\Microsoft\WinGet\Packages\`, `dev-prune.exe --version`
  writes nothing — no `devp.exe`, no config directory, no task;
- the same executable in an ordinary directory does create `devp.exe`, so the guard is
  discriminating on the location and not merely broken.

### Notes on the manifest

`Commands` lists both `dev-prune` and `devp`, with two `NestedInstallerFiles` entries.
This differs from the last state of #422665, where it listed `dev-prune` alone: the 1.5.0
archive contained one executable, and the 1.6.0 archives ship both, so both can now be
declared honestly by the installer instead of created by the binary at runtime. That
removes the last reason for the program to write an executable at all on a WinGet install.

The three archives are the release assets, hashes taken from the `.sha256` sidecars
published beside them. Build provenance is attested — `gh attestation verify
dev-prune-v1.6.0-windows-x64.zip --repo Life-Experimentalist/dev-prune`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422809)