### PR TITLE
New version: CaptainKillSwitch.CaptainKillSwitch version 0.4.3

### DIFF
--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.3
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{615C2CF8-5716-4943-87E2-32215A4FC504}'
+ReleaseDate: 2026-08-23
+AppsAndFeaturesEntries:
+- Publisher: Captain Kill Switch Team
+  ProductCode: '{615C2CF8-5716-4943-87E2-32215A4FC504}'
+  UpgradeCode: '{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/Captain Kill Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/captainkillswitch/downloads/releases/download/v0.4.3/captain-kill-switch-0.4.3-windows-x64.msi
+  InstallerSha256: 7F37DB07162D32AE675D9C9DF5AAEE80740D440CBD787D551AFD85DAFAC3CB52
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.3
+PackageLocale: en-US
+Publisher: Captain Kill Switch Team
+PublisherUrl: https://captainkillswitch.com/
+PublisherSupportUrl: https://github.com/captainkillswitch/downloads/issues
+Author: Captain Kill Switch Team
+PackageName: Captain Kill Switch
+PackageUrl: https://captainkillswitch.com/
+License: Proprietary (free)
+LicenseUrl: https://captainkillswitch.com/about
+Copyright: Copyright (c) 2026 Captain Kill Switch Team
+ShortDescription: Close every running application in one click from the system tray.
+Description: Captain Kill Switch is a free system-tray utility that closes every running application in one click - a clean close request first, then a firm stop within two seconds. An allowlist model protects Windows system and session processes. Tiny native app, auto-updates, 10 languages. Anonymous usage statistics only; see https://captainkillswitch.com/privacy.
+Moniker: captain-kill-switch
+ReleaseNotes: |-
+  Fixes a Windows auto-update retry loop. A machine that failed to apply an
+  update could relaunch, report the update as installed, come back on the old
+  version and repeat every few seconds.
+  - The automatic check no longer retries the same target version within an
+    hour, and reports the failure instead of a false success.
+  - Manual update checks are never affected.
+  - No change to tray behavior, kill behavior, exclusions or the two-second
+    force floor.
+ReleaseNotesUrl: https://github.com/captainkillswitch/downloads/releases/tag/v0.4.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.3/CaptainKillSwitch.CaptainKillSwitch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package
CaptainKillSwitch.CaptainKillSwitch version 0.4.3

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes

Routine version bump from 0.4.2, submitted by the package maintainer. Built from
the merged 0.4.2 manifests rather than from templates, so the only differences
are the version, URL, hash, ProductCode, release date and release notes.

- `InstallerSha256` computed from the published MSI: `7F37DB07162D32AE675D9C9DF5AAEE80740D440CBD787D551AFD85DAFAC3CB52`
- `ProductCode` regenerates per build, as always. `UpgradeCode` is unchanged
  (`{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}`) so in-place upgrades keep working.
- Release notes rewritten to describe what 0.4.3 actually contains — a fix for a
  Windows auto-update retry loop. The previous manifest had carried 0.4.0's
  notes forward.

The `winget install --manifest` box is deliberately unticked: I have no Windows
machine, so I have not run that step and will not claim it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422823)