### PR TITLE
Update version: TrellisLab.Trellis version 1.6.0

### DIFF
--- a/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.installer.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.6.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/trellis-lab/trellis/releases/download/v1.6.0/trellis-v1.6.0-windows-x86_64.exe
+  InstallerSha256: 9501DEB0D4C4BC12F0DE4F70A05BBD5278EFF87C62F90220183550872442D97B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.locale.en-US.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Trellis Lab
+PublisherUrl: https://github.com/trellis-lab
+PublisherSupportUrl: https://github.com/trellis-lab/trellis/issues
+PackageName: Trellis
+PackageUrl: https://github.com/trellis-lab/trellis
+License: Commercial License
+LicenseUrl: https://github.com/trellis-lab/trellis/blob/HEAD/EULA.md
+Copyright: Copyright (c) Zoran Vukoszavlyev (TrellisLab)
+ShortDescription: Mermaid-compatible diagram renderer with overlap-free orthogonal edge routing
+Description: |-
+  Trellis is a Mermaid-compatible diagram renderer that uses custom routing
+  to produce overlap-free orthogonal SVG layouts. Supports flowchart, class, ER, C4 and architecture diagram types.
+Tags:
+- cli
+- diagram
+- mermaid
+- renderer
+- svg
+ReleaseNotes: "## New features\r\n\r\n• Added an \"Inspect Diagram\" command to the VS Code extension — render the current diagram to an interactive view and explore it directly in a webview panel.\r\n• VS Code preview now has a pan/zoom viewport：cursor-anchored zoom, drag-to-pan, and a sharper re-render as you zoom in. Your zoom/pan position is remembered per document.\r\n• VS Code preview now falls back to Mermaid.js rendering for diagram types Trellis doesn't yet support (e.g. sequence, gantt, pie), instead of showing broken or blank output.\r\n\r\n## Fixes\r\n\r\n• Deploy-built CLI binaries and Docker images now report the correct version number instead of \"0.0.0\".\r\n• Fixed the diagram inspector so nodes nested inside multiple levels of boundaries (e.g. a C4 deployment node inside another) correctly show their full boundary breadcrumb, and boundary counts in the legend are now accurate.\r\n• Fixed labels containing a semicolon or `%%` being incorrectly split during parsing, which could break C4 diagrams and corrupt flowchart labels.\r\n• Fixed C4 diagrams not rendering an inline `title` directive, and fixed diagram titles being silently dropped in other diagram types when no frontmatter title was set.\r\n• Fixed class diagrams with quoted edge multiplicity (e.g. `\"1\" *-- \"0..1\"`) corrupting node names instead of attaching the label to the edge; multiplicity labels now render correctly in SVG, ASCII, and drawio export.\r\n• Fixed the VS Code preview going blank when a diagram fell back to Mermaid.js rendering.\r\n• Fixed VS Code Marketplace publishing failures caused by an Azure Authentication changes.\r\n\r\n## Documentation\r\n\r\n• Updated the VS Code extension README to point to the correct subscribe page.\r\n• Documented recent changes to the VS Code Marketplace deployment process.\r\n• Updated release documentation and changelog generation process."
+ReleaseNotesUrl: https://github.com/trellis-lab/trellis/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.yaml
+++ b/manifests/t/TrellisLab/Trellis/1.6.0/TrellisLab.Trellis.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: TrellisLab.Trellis
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update TrellisLab.Trellis to version 1.6.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422825)