### PR TITLE
New package: MbasonAI.Copilot version 0.2.0

### DIFF
--- a/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.installer.yaml
+++ b/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MbasonAI.Copilot
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/JPmbagwu/mbason-copilot-downloads/releases/download/copilot-v0.2.0/Mbason-Copilot-Setup.exe
+    InstallerSha256: 1D6285E91369B459735B308B69659457BB0474B3D227D951F86776B643083B59
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.locale.en-US.yaml
+++ b/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MbasonAI.Copilot
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Mbason AI LLC
+PublisherUrl: https://www.mbason-ai.com
+PublisherSupportUrl: https://www.mbason-ai.com/copilot
+PackageName: Mbason Copilot
+PackageUrl: https://www.mbason-ai.com/copilot
+License: Proprietary
+Copyright: Copyright (c) 2026 Mbason AI LLC
+ShortDescription: Live interview copilot overlay that answers questions in real time and stays invisible in screen shares.
+Description: >-
+  Mbason Copilot is a desktop overlay for live interviews. It listens to the
+  interview, answers questions in real time grounded in your resume, and is
+  excluded from Zoom, Teams, and Meet screen shares at the OS level. Requires a
+  Mbason AI account.
+Moniker: mbason-copilot
+Tags:
+  - interview
+  - copilot
+  - career
+  - jobs
+  - ai
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.yaml
+++ b/manifests/m/MbasonAI/Copilot/0.2.0/MbasonAI.Copilot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MbasonAI.Copilot
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds MbasonAI.Copilot (Mbason Copilot) version 0.2.0.

- Publisher: Mbason AI LLC
- Installer: NSIS (nullsoft), x64, per-user
- Installer URL is SHA256-pinned to a public GitHub release asset.

Checklist:
- [x] Have you signed the Contributor License Agreement?
- [x] This PR only modifies one (1) manifest
- [x] Manifest validated locally with the schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422843)