### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.0.8

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.0.8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.8
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{E7391C65-9E38-4808-95DE-17E6798762DD}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{E7391C65-9E38-4808-95DE-17E6798762DD}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.0.8/GestureSign-V2-18.0.8-x64.msi
+  InstallerSha256: F1DC0C42B59656663DFA04A817058C5A4421A9C07038809A03B165639EE0F990
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-23

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created for GestureSign V2 18.0.8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.8
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and bundled Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Fixed trail opacity values below 75% being forced to roughly 75%; the complete 5%–100% slider range now maps directly to rendering opacity.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.0.8
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.0.8/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created for GestureSign V2 18.0.8
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.0.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- Updates `Tomclanc.GestureSignV2` to version `18.0.8`.
- Uses the x64 WiX MSI published in the official GitHub Release.
- Fixes trail opacity values below 75% being forced to roughly 75%.

Installer SHA256: `F1DC0C42B59656663DFA04A817058C5A4421A9C07038809A03B165639EE0F990`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422874)