### PR TITLE
Add Chromatic.Registry v0.2.2

### DIFF
--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -4,13 +4,12 @@
 PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2
 InstallerType: inno
+Scope: user
 Installers:
   - Architecture: x64
-    Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
     InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
   - Architecture: arm64
-    Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
     InstallerSha256: F5A82896933D37A68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
 ManifestType: installer

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -5,13 +5,13 @@ PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2
 InstallerType: inno
 Installers:
-  - Architecture: arm64
-    Scope: user
-    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
   - Architecture: x64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
+    InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
+  - Architecture: arm64
+    Scope: user
+    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
+    InstallerSha256: F5A82896933D37A68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -9,5 +9,10 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
     InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+InstallModes:
+  - silent
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -8,10 +8,10 @@ Installers:
   - Architecture: x64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
+    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
   - Architecture: arm64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
+    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -9,6 +9,9 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
     InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
+    InstallerSha256: F5A82896933D37B68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
 InstallerSwitches:
   Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
   SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -9,8 +9,5 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
     InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
-  - Architecture: arm64
-    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: F5A82896933D37A68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -1,0 +1,17 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema: https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.2
+InstallerType: inno
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
+    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
+  - Architecture: arm64
+    Scope: user
+    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
+    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -8,10 +8,10 @@ Installers:
   - Architecture: x64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
+    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
   - Architecture: arm64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
+    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -8,10 +8,10 @@ Installers:
   - Architecture: x64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
+    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
   - Architecture: arm64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: F5A82896933D37A68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
+    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -5,13 +5,13 @@ PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2
 InstallerType: inno
 Installers:
-  - Architecture: x64
-    Scope: user
-    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
   - Architecture: arm64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
     InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
+    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema: https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.installer.yaml
@@ -8,10 +8,10 @@ Installers:
   - Architecture: x64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-x64.exe
-    InstallerSha256: 02d90085296bf77f22c8b3659ae5edf1ed2fd31a11c5310fda7b1c31cb7f01af
+    InstallerSha256: 02D90085296BF77F22C8B3659AE5EDF1ED2FD31A11C5310FDA7B1C31CB7F01AF
   - Architecture: arm64
     Scope: user
     InstallerUrl: https://github.com/Has-X/Registry/releases/download/v0.2.2/Registry-Setup-arm64.exe
-    InstallerSha256: f5a82896933d37a68eb92ba4b7c04eb07ee48e2df4e227bab5b3412db35c10ff
+    InstallerSha256: F5A82896933D37A68EB92BA4B7C04EB07EE48E2DF4E227BAB5B3412DB35C10FF
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.locale.en-US.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.locale.en-US.yaml
@@ -1,12 +1,12 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema: https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2
 PackageLocale: en-US
 Publisher: Chromatic
 PublisherUrl: https://chromatic.hu
-PublisherSupportUrl: mailto:feedback@chromatic.hu
+PublisherSupportUrl: https://github.com/Has-X/Registry/issues
 PackageName: Registry
 PackageUrl: https://github.com/Has-X/Registry
 License: AGPL-3.0-or-later

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.locale.en-US.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema: https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Chromatic
+PublisherUrl: https://chromatic.hu
+PublisherSupportUrl: mailto:feedback@chromatic.hu
+PackageName: Registry
+PackageUrl: https://github.com/Has-X/Registry
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Has-X/Registry/blob/main/LICENSE.md
+ShortDescription: Registry is a modern Windows Registry Editor.
+Description: |-
+  Registry is a native Windows registry editor for browsing, editing, importing,
+  exporting, and checking registry data with a familiar Windows feel.
+Tags:
+- registry
+- windows
+- winui3
+- inno-setup
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 Dumplings Mod
-# yaml-language-server: $schema: https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Chromatic.Registry
 PackageVersion: 0.2.2

--- a/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.yaml
+++ b/manifests/c/Chromatic/Registry/0.2.2/Chromatic.Registry.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema: https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Chromatic.Registry
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add Chromatic.Registry package manifests for v0.2.2 x64+arm64 Inno Setup installers from Has-X/Registry. This is generated from release SHA v0.2.2 installers with SHA-256 checksums.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422887)