### PR TITLE
Update: OlimoffDev.OmenGamingHubUnlocker to 3.3.0.0

### DIFF
--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- ogh-unlocker
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/download/v3.3/OmenGamingHubUnlocker-v3.3-win-x64.exe
+  InstallerSha256: FE2A30C6EF43BF36CBCA3D924326BD9BAB4628BCCAE6606B42B700F9BB14E0B8
+- Architecture: arm64
+  InstallerUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/download/v3.3/OmenGamingHubUnlocker-v3.3-win-arm64.exe
+  InstallerSha256: F635BFF536DD96F7DD4101753F83D21A3468CA4AAFF530913928BFA488EA88D4
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-18

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.bg-BG.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.bg-BG.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: bg-BG
+ShortDescription: Спира автоматичното стартиране, фоновата работа и мрежовия достъп на OMEN Gaming Hub, помага при регионални грешки и изгражда наново правилата на защитната стена след актуализации.
+Description: Omen Gaming Hub Unlocker е безплатен, преносим инструмент с отворен код за Windows, предназначен за потребители, които срещат в OMEN Gaming Hub регионално заключване, грешен регион, неподдържана държава или съобщение „не е налично във вашия регион“. Той блокира достъпа на OMEN Gaming Hub до интернет и предотвратява нежелано стартиране във фонов режим чрез спиране на процеси и услуги на OMEN, изключване на планирани задачи и премахване на записи за автоматично стартиране. Инструментът проверява състоянието на защитата, автоматично изгражда наново правилата на защитната стена след актуализации на Microsoft Store или OMEN, нулира OMEN Gaming Hub и веднага прилага защитата отново или възстановява първоначалните настройки на Windows. Той не деинсталира OMEN, не променя региона на Windows или Microsoft Store, не модифицира файлове на приложението и не премахва драйвери на HP. Проектът не е свързан с HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- отключване-omen-gaming-hub
+- изключване-omen-gaming-hub
+- спиране-автостарт-omen
+- блокиране-интернет-omen
+- фонови-процеси-omen
+- регионално-заключване-omen
+- omen-заключен-по-регион
+- решение-регионално-заключване-omen
+- грешен-регион-omen
+- неподдържана-държава-omen
+- omen-неналично-в-региона
+- нулиране-omen-gaming-hub
+InstallationNotes: Преди деинсталиране отворете инструмента и изберете „Възстановяване на първоначалните настройки“, ако искате да отмените и промените в защитната стена, файла hosts, услугите, задачите и автоматичното стартиране. WinGet премахва само преносимия изпълним файл и псевдонима на командата.
+Documentations:
+- DocumentLabel: Документация на проекта
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.cs-CZ.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.cs-CZ.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: cs-CZ
+ShortDescription: Zastaví automatické spouštění, běh na pozadí a síťový přístup OMEN Gaming Hub, pomáhá s chybami regionu a po aktualizacích OMEN znovu vytvoří pravidla brány firewall.
+Description: Omen Gaming Hub Unlocker je bezplatný, přenosný a open-source nástroj pro Windows určený uživatelům, kteří v OMEN Gaming Hub narážejí na regionální zámek, nesprávný region, nepodporovanou zemi nebo hlášení „není ve vaší oblasti dostupné“. Blokuje přístup OMEN Gaming Hub k internetu a brání nežádoucímu spouštění na pozadí tím, že ukončí procesy a služby OMEN, zakáže naplánované úlohy a odstraní položky po spuštění. Nástroj kontroluje stav ochrany, po aktualizacích Microsoft Store nebo OMEN automaticky znovu vytvoří pravidla brány firewall, resetuje OMEN Gaming Hub a ihned znovu použije ochranu nebo obnoví původní nastavení Windows. Neodinstaluje OMEN, nemění oblast Windows ani Microsoft Store, neupravuje soubory aplikace a neodstraňuje ovladače HP. Tento projekt není spojen se společností HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- odemknout-omen-gaming-hub
+- zakázat-omen-gaming-hub
+- zastavit-autostart-omen
+- zablokovat-internet-omen
+- procesy-na-pozadí-omen
+- regionální-zámek-omen
+- omen-uzamčen-podle-regionu
+- řešení-regionálního-zámku-omen
+- nesprávný-region-omen
+- nepodporovaná-země-omen
+- omen-nedostupný-v-regionu
+- resetovat-omen-gaming-hub
+InstallationNotes: Před odinstalací otevřete nástroj a zvolte „Obnovit původní nastavení“, pokud chcete vrátit také změny brány firewall, souboru hosts, služeb, úloh a automatického spouštění. WinGet odstraní pouze přenosný spustitelný soubor a alias příkazu.
+Documentations:
+- DocumentLabel: Dokumentace projektu
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.da-DK.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.da-DK.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: da-DK
+ShortDescription: Stopper automatisk start, baggrundsaktivitet og netværksadgang for OMEN Gaming Hub, hjælper ved regionsfejl og genopbygger firewallregler efter OMEN-opdateringer.
+Description: Omen Gaming Hub Unlocker er et gratis, bærbart open source-værktøj til Windows for brugere, der oplever regionslås, forkert region, et land der ikke understøttes, eller meddelelsen “ikke tilgængelig i dit område” i OMEN Gaming Hub. Det blokerer OMEN Gaming Hubs internetadgang og forhindrer uønsket baggrundsstart ved at stoppe OMEN-processer og -tjenester, deaktivere planlagte opgaver og fjerne startelementer. Værktøjet kontrollerer beskyttelsesstatus, genopbygger automatisk firewallregler efter Microsoft Store- eller OMEN-opdateringer, nulstiller OMEN Gaming Hub og anvender straks beskyttelsen igen eller gendanner de oprindelige Windows-indstillinger. Det afinstallerer ikke OMEN, ændrer ikke regionen i Windows eller Microsoft Store, redigerer ikke programfiler og fjerner ikke HP-drivere. Projektet er ikke tilknyttet HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- lås-omen-gaming-hub-op
+- deaktiver-omen-gaming-hub
+- stop-omen-autostart
+- blokér-omen-internet
+- omen-baggrundsprocesser
+- omen-regionslås
+- omen-regionslåst
+- løsning-til-regionslås-omen
+- omen-forkert-region
+- omen-land-ikke-understøttet
+- omen-ikke-tilgængelig-i-regionen
+- nulstil-omen-gaming-hub
+InstallationNotes: Åbn værktøjet før afinstallationen, og vælg “Gendan oprindelige indstillinger”, hvis du også vil fortryde ændringer i firewall, hosts-fil, tjenester, opgaver og autostart. WinGet fjerner kun den bærbare eksekverbare fil og kommandoaliaset.
+Documentations:
+- DocumentLabel: Projektdokumentation
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.de-DE.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.de-DE.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: de-DE
+ShortDescription: Verhindert Autostart, Hintergrundaktivität und Netzwerkzugriff von OMEN Gaming Hub, hilft bei Regionsfehlern und erstellt Firewallregeln nach OMEN-Updates neu.
+Description: Omen Gaming Hub Unlocker ist ein kostenloses, portables Open-Source-Windows-Tool für Nutzer, bei denen OMEN Gaming Hub wegen einer Regionssperre, einer falschen Region, eines nicht unterstützten Landes oder der Meldung „in Ihrer Region nicht verfügbar“ nicht funktioniert. Es blockiert den Internetzugriff von OMEN Gaming Hub und verhindert unerwünschte Hintergrundstarts, indem es OMEN-Prozesse und -Dienste beendet, geplante Aufgaben deaktiviert und Autostarteinträge entfernt. Das Tool prüft den Schutzstatus, erstellt Firewallregeln nach Microsoft-Store- oder OMEN-Updates automatisch neu, setzt OMEN Gaming Hub zurück und wendet den Schutz sofort erneut an oder stellt die ursprünglichen Windows-Einstellungen wieder her. Es deinstalliert OMEN nicht, ändert weder die Windows- noch die Microsoft-Store-Region, modifiziert keine Anwendungsdateien und entfernt keine HP-Treiber. Dieses Projekt steht in keiner Verbindung zu HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-entsperren
+- omen-gaming-hub-deaktivieren
+- omen-autostart-stoppen
+- omen-internetzugriff-blockieren
+- omen-hintergrundprozesse
+- omen-regionssperre
+- omen-region-gesperrt
+- omen-regionssperre-lösung
+- omen-falsche-region
+- omen-land-nicht-unterstützt
+- omen-in-region-nicht-verfügbar
+- omen-gaming-hub-zurücksetzen
+InstallationNotes: Öffnen Sie vor der Deinstallation das Tool und wählen Sie „Ursprüngliche Einstellungen wiederherstellen“, wenn auch die Änderungen an Firewall, hosts-Datei, Diensten, Aufgaben und Autostart entfernt werden sollen. WinGet entfernt nur die portable EXE-Datei und den Befehlsalias.
+Documentations:
+- DocumentLabel: Projektdokumentation
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.el-GR.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.el-GR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: el-GR
+ShortDescription: Σταματά την αυτόματη εκκίνηση, τη λειτουργία στο παρασκήνιο και την πρόσβαση δικτύου του OMEN Gaming Hub, βοηθά σε σφάλματα περιοχής και αναδημιουργεί τους κανόνες τείχους προστασίας μετά από ενημερώσεις.
+Description: Το Omen Gaming Hub Unlocker είναι ένα δωρεάν, φορητό και ανοικτού κώδικα εργαλείο Windows για χρήστες που αντιμετωπίζουν στο OMEN Gaming Hub κλείδωμα περιοχής, λανθασμένη περιοχή, μη υποστηριζόμενη χώρα ή το μήνυμα «δεν είναι διαθέσιμο στην περιοχή σας». Αποκλείει την πρόσβαση του OMEN Gaming Hub στο Internet και αποτρέπει ανεπιθύμητες εκκινήσεις στο παρασκήνιο, τερματίζοντας διεργασίες και υπηρεσίες OMEN, απενεργοποιώντας προγραμματισμένες εργασίες και καταργώντας καταχωρίσεις εκκίνησης. Ελέγχει την κατάσταση προστασίας, αναδημιουργεί αυτόματα τους κανόνες τείχους προστασίας μετά από ενημερώσεις του Microsoft Store ή του OMEN, επαναφέρει το OMEN Gaming Hub και εφαρμόζει αμέσως ξανά την προστασία ή αποκαθιστά τις αρχικές ρυθμίσεις των Windows. Δεν καταργεί το OMEN, δεν αλλάζει την περιοχή των Windows ή του Microsoft Store, δεν τροποποιεί αρχεία εφαρμογών και δεν αφαιρεί προγράμματα οδήγησης HP. Το έργο δεν συνδέεται με την HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- ξεκλείδωμα-omen-gaming-hub
+- απενεργοποίηση-omen-gaming-hub
+- διακοπή-αυτόματης-εκκίνησης-omen
+- αποκλεισμός-internet-omen
+- διεργασίες-παρασκηνίου-omen
+- κλείδωμα-περιοχής-omen
+- omen-κλειδωμένο-λόγω-περιοχής
+- λύση-κλειδώματος-περιοχής-omen
+- λανθασμένη-περιοχή-omen
+- μη-υποστηριζόμενη-χώρα-omen
+- omen-μη-διαθέσιμο-στην-περιοχή
+- επαναφορά-omen-gaming-hub
+InstallationNotes: Πριν από την απεγκατάσταση, ανοίξτε το εργαλείο και επιλέξτε «Επαναφορά αρχικών ρυθμίσεων» αν θέλετε να αναιρεθούν και οι αλλαγές σε τείχος προστασίας, αρχείο hosts, υπηρεσίες, εργασίες και εκκίνηση. Το WinGet αφαιρεί μόνο το φορητό εκτελέσιμο αρχείο και το ψευδώνυμο εντολής.
+Documentations:
+- DocumentLabel: Τεκμηρίωση έργου
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: en-US
+Publisher: Olimoff Dev
+PublisherUrl: https://github.com/Avazbek22
+PublisherSupportUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/issues
+PackageName: Omen Gaming Hub Unlocker
+PackageUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker
+License: MIT
+LicenseUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/blob/main/LICENSE
+Copyright: Copyright (c) 2025 Avazbek Olimov
+ShortDescription: Stops OMEN Gaming Hub from auto-starting, running in the background, and accessing the network; helps with region errors and rebuilds firewall rules after OMEN updates.
+Description: Omen Gaming Hub Unlocker is a free, portable, open-source Windows utility for users facing OMEN Gaming Hub region lock, wrong region, country not supported, or not available in your region errors. It blocks OMEN Gaming Hub internet access and prevents unwanted background launches by stopping OMEN processes and services, disabling scheduled tasks, and removing startup entries. The tool can check protection status, automatically rebuild firewall rules after Microsoft Store or OMEN updates, reset OMEN Gaming Hub and immediately reapply protection, or restore the original Windows settings. It does not uninstall OMEN, change the Windows or Microsoft Store region, patch application files, or remove HP drivers. This project is not affiliated with HP.
+Moniker: ogh-unlocker
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- unlock-omen-gaming-hub
+- disable-omen-gaming-hub
+- stop-omen-gaming-hub-autostart
+- omen-gaming-hub-network-blocker
+- omen-gaming-hub-background-process
+- omen-gaming-hub-region-lock
+- omen-gaming-hub-region-locked
+- omen-gaming-hub-region-workaround
+- omen-gaming-hub-wrong-region
+- omen-gaming-hub-country-not-supported
+- omen-gaming-hub-not-available-in-region
+- reset-omen-gaming-hub
+ReleaseNotesUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker/releases/tag/v3.3
+InstallationNotes: Before uninstalling, open the utility and choose Restore original settings if you also want to remove its firewall, hosts, service, task, and startup changes. WinGet uninstall removes only the portable executable and command alias.
+Documentations:
+- DocumentLabel: Project documentation
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.es-ES.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.es-ES.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: es-ES
+ShortDescription: Detiene el inicio automático, la actividad en segundo plano y el acceso a la red de OMEN Gaming Hub, ayuda con errores de región y rehace las reglas tras las actualizaciones.
+Description: Omen Gaming Hub Unlocker es una utilidad gratuita, portátil y de código abierto para Windows, dirigida a usuarios que encuentran en OMEN Gaming Hub errores de bloqueo regional, región incorrecta, país no compatible o «no disponible en tu región». Bloquea el acceso a Internet de OMEN Gaming Hub y evita ejecuciones no deseadas en segundo plano al detener procesos y servicios de OMEN, desactivar tareas programadas y eliminar entradas de inicio. La herramienta comprueba el estado de la protección, rehace automáticamente las reglas del firewall después de actualizaciones de Microsoft Store u OMEN, restablece OMEN Gaming Hub y vuelve a aplicar la protección de inmediato, o restaura la configuración original de Windows. No desinstala OMEN, no cambia la región de Windows ni de Microsoft Store, no modifica archivos de la aplicación y no elimina controladores de HP. Este proyecto no está afiliado a HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- desbloquear-omen-gaming-hub
+- desactivar-omen-gaming-hub
+- detener-inicio-automático-omen
+- bloquear-internet-omen
+- procesos-segundo-plano-omen
+- bloqueo-regional-omen
+- omen-bloqueado-por-región
+- solución-bloqueo-regional-omen
+- región-incorrecta-omen
+- país-no-compatible-omen
+- omen-no-disponible-en-tu-región
+- restablecer-omen-gaming-hub
+InstallationNotes: Antes de desinstalar, abre la utilidad y elige «Restaurar la configuración original» si también quieres deshacer sus cambios en el firewall, el archivo hosts, los servicios, las tareas y el inicio. WinGet solo elimina el ejecutable portátil y el alias de comando.
+Documentations:
+- DocumentLabel: Documentación del proyecto
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.es-MX.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.es-MX.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: es-MX
+ShortDescription: Detiene el inicio automático, la actividad en segundo plano y el acceso a la red de OMEN Gaming Hub, ayuda con errores de región y reconstruye las reglas tras las actualizaciones.
+Description: Omen Gaming Hub Unlocker es una utilidad gratuita, portátil y de código abierto para Windows, pensada para usuarios que encuentran en OMEN Gaming Hub errores de bloqueo regional, región incorrecta, país no admitido o «no disponible en tu región». Bloquea el acceso a Internet de OMEN Gaming Hub y evita ejecuciones no deseadas en segundo plano al detener procesos y servicios de OMEN, deshabilitar tareas programadas y eliminar entradas de inicio. La herramienta comprueba el estado de la protección, reconstruye automáticamente las reglas del firewall después de actualizaciones de Microsoft Store u OMEN, restablece OMEN Gaming Hub y vuelve a aplicar la protección de inmediato, o restaura la configuración original de Windows. No desinstala OMEN, no cambia la región de Windows ni de Microsoft Store, no modifica archivos de la aplicación y no elimina controladores de HP. Este proyecto no está afiliado a HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- desbloquear-omen-gaming-hub
+- deshabilitar-omen-gaming-hub
+- detener-inicio-automático-omen
+- bloquear-internet-omen
+- procesos-segundo-plano-omen
+- bloqueo-regional-omen
+- omen-bloqueado-por-región
+- solución-regional-omen
+- región-incorrecta-omen
+- país-no-admitido-omen
+- omen-no-disponible-en-tu-región
+- restablecer-omen-gaming-hub
+InstallationNotes: Antes de desinstalar, abre la utilidad y selecciona «Restaurar la configuración original» si también deseas deshacer sus cambios en el firewall, el archivo hosts, los servicios, las tareas y el inicio. WinGet solo elimina el ejecutable portátil y el alias de comando.
+Documentations:
+- DocumentLabel: Documentación del proyecto
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.fi-FI.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.fi-FI.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: fi-FI
+ShortDescription: Estää OMEN Gaming Hubin automaattisen käynnistyksen, taustatoiminnan ja verkkoyhteyden, auttaa aluevirheissä ja rakentaa palomuurisäännöt uudelleen OMEN-päivitysten jälkeen.
+Description: Omen Gaming Hub Unlocker on ilmainen, siirrettävä ja avoimen lähdekoodin Windows-työkalu käyttäjille, jotka kohtaavat OMEN Gaming Hubissa aluelukituksen, väärän alueen, maan jota ei tueta tai ilmoituksen ”ei saatavilla alueellasi”. Se estää OMEN Gaming Hubin internetyhteyden ja tarpeettomat taustakäynnistykset pysäyttämällä OMEN-prosessit ja -palvelut, poistamalla ajoitetut tehtävät käytöstä sekä poistamalla käynnistyskohteet. Työkalu tarkistaa suojauksen tilan, rakentaa palomuurisäännöt automaattisesti uudelleen Microsoft Store- tai OMEN-päivitysten jälkeen, palauttaa OMEN Gaming Hubin oletustilaan ja ottaa suojauksen heti uudelleen käyttöön tai palauttaa alkuperäiset Windows-asetukset. Se ei poista OMENia, muuta Windowsin tai Microsoft Storen aluetta, muokkaa sovellustiedostoja eikä poista HP-ajureita. Projekti ei liity HP:hen.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- avaa-omen-gaming-hubin-lukitus
+- poista-omen-gaming-hub-käytöstä
+- pysäytä-omen-automaattikäynnistys
+- estä-omen-internet
+- omen-taustaprosessit
+- omen-aluelukitus
+- omen-lukittu-alueen-vuoksi
+- omen-aluelukituksen-ratkaisu
+- omen-väärä-alue
+- omen-maa-ei-tuettu
+- omen-ei-saatavilla-alueella
+- palauta-omen-gaming-hub
+InstallationNotes: Avaa työkalu ennen asennuksen poistamista ja valitse ”Palauta alkuperäiset asetukset”, jos haluat kumota myös palomuuriin, hosts-tiedostoon, palveluihin, tehtäviin ja käynnistykseen tehdyt muutokset. WinGet poistaa vain siirrettävän suoritustiedoston ja komentoaliaksen.
+Documentations:
+- DocumentLabel: Projektin dokumentaatio
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.fr-FR.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.fr-FR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: fr-FR
+ShortDescription: Bloque le démarrage automatique, l’activité en arrière-plan et l’accès réseau d’OMEN Gaming Hub, aide en cas d’erreur de région et recrée les règles après les mises à jour.
+Description: Omen Gaming Hub Unlocker est un utilitaire Windows gratuit, portable et open source destiné aux utilisateurs confrontés au verrouillage régional d’OMEN Gaming Hub, à une région incorrecte, à un pays non pris en charge ou au message « indisponible dans votre région ». Il bloque l’accès Internet d’OMEN Gaming Hub et empêche les lancements indésirables en arrière-plan en arrêtant les processus et services OMEN, en désactivant les tâches planifiées et en supprimant les entrées de démarrage. L’outil vérifie l’état de la protection, recrée automatiquement les règles du pare-feu après les mises à jour de Microsoft Store ou d’OMEN, réinitialise OMEN Gaming Hub puis réapplique immédiatement la protection, ou restaure les paramètres Windows d’origine. Il ne désinstalle pas OMEN, ne modifie pas la région de Windows ou de Microsoft Store, ne corrige pas les fichiers de l’application et ne supprime pas les pilotes HP. Ce projet n’est pas affilié à HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- débloquer-omen-gaming-hub
+- désactiver-omen-gaming-hub
+- arrêter-démarrage-automatique-omen
+- bloquer-internet-omen
+- processus-arrière-plan-omen
+- verrouillage-régional-omen
+- omen-bloqué-par-région
+- solution-région-omen
+- région-incorrecte-omen
+- pays-non-pris-en-charge-omen
+- omen-indisponible-dans-la-région
+- réinitialiser-omen-gaming-hub
+InstallationNotes: Avant la désinstallation, ouvrez l’utilitaire et choisissez « Restaurer les paramètres d’origine » si vous souhaitez également annuler ses modifications du pare-feu, du fichier hosts, des services, des tâches et du démarrage. WinGet ne supprime que l’exécutable portable et l’alias de commande.
+Documentations:
+- DocumentLabel: Documentation du projet
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.hu-HU.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.hu-HU.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: hu-HU
+ShortDescription: Leállítja az OMEN Gaming Hub automatikus indítását, háttértevékenységét és hálózati hozzáférését, segít a régióhibáknál, és frissítések után újraépíti a tűzfalszabályokat.
+Description: Az Omen Gaming Hub Unlocker ingyenes, hordozható, nyílt forráskódú Windows-segédprogram azoknak, akik az OMEN Gaming Hub használatakor régiózárolással, hibás régióval, nem támogatott országgal vagy „az Ön régiójában nem érhető el” üzenettel találkoznak. Blokkolja az OMEN Gaming Hub internet-hozzáférését, és megakadályozza a nem kívánt háttérindítást az OMEN-folyamatok és -szolgáltatások leállításával, az ütemezett feladatok letiltásával és az automatikus indítási bejegyzések eltávolításával. Ellenőrzi a védelem állapotát, a Microsoft Store vagy az OMEN frissítései után automatikusan újraépíti a tűzfalszabályokat, alaphelyzetbe állítja az OMEN Gaming Hubot és azonnal újra alkalmazza a védelmet, vagy visszaállítja az eredeti Windows-beállításokat. Nem távolítja el az OMEN-t, nem módosítja a Windows vagy a Microsoft Store régióját, nem javítja az alkalmazásfájlokat és nem töröl HP-illesztőprogramokat. A projekt nem áll kapcsolatban a HP-val.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-feloldása
+- omen-gaming-hub-letiltása
+- omen-automatikus-indítás-leállítása
+- omen-internet-blokkolása
+- omen-háttérfolyamatok
+- omen-régiózár
+- omen-régió-miatt-zárolva
+- omen-régiózár-megoldás
+- omen-hibás-régió
+- omen-nem-támogatott-ország
+- omen-nem-érhető-el-a-régióban
+- omen-gaming-hub-alaphelyzet
+InstallationNotes: Eltávolítás előtt nyissa meg a segédprogramot, és válassza az „Eredeti beállítások visszaállítása” lehetőséget, ha a tűzfal, a hosts fájl, a szolgáltatások, a feladatok és az automatikus indítás módosításait is vissza szeretné vonni. A WinGet csak a hordozható futtatható fájlt és a parancsaliast távolítja el.
+Documentations:
+- DocumentLabel: Projektdokumentáció
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.id-ID.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.id-ID.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: id-ID
+ShortDescription: Menghentikan mulai otomatis, aktivitas latar belakang, dan akses jaringan OMEN Gaming Hub, membantu mengatasi kesalahan wilayah, serta membangun ulang aturan firewall setelah pembaruan OMEN.
+Description: Omen Gaming Hub Unlocker adalah utilitas Windows gratis, portabel, dan sumber terbuka untuk pengguna yang mengalami penguncian wilayah, wilayah salah, negara tidak didukung, atau pesan “tidak tersedia di wilayah Anda” pada OMEN Gaming Hub. Utilitas ini memblokir akses internet OMEN Gaming Hub dan mencegah peluncuran latar belakang yang tidak diinginkan dengan menghentikan proses dan layanan OMEN, menonaktifkan tugas terjadwal, serta menghapus entri mulai otomatis. Alat ini memeriksa status perlindungan, otomatis membangun ulang aturan firewall setelah pembaruan Microsoft Store atau OMEN, mengatur ulang OMEN Gaming Hub dan langsung menerapkan kembali perlindungan, atau memulihkan pengaturan Windows asli. Alat ini tidak menghapus instalasi OMEN, mengubah wilayah Windows atau Microsoft Store, memodifikasi file aplikasi, maupun menghapus driver HP. Proyek ini tidak berafiliasi dengan HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- buka-kunci-omen-gaming-hub
+- nonaktifkan-omen-gaming-hub
+- hentikan-mulai-otomatis-omen
+- blokir-internet-omen
+- proses-latar-belakang-omen
+- kunci-wilayah-omen
+- omen-terkunci-karena-wilayah
+- solusi-kunci-wilayah-omen
+- wilayah-salah-omen
+- negara-tidak-didukung-omen
+- omen-tidak-tersedia-di-wilayah
+- atur-ulang-omen-gaming-hub
+InstallationNotes: Sebelum menghapus instalasi, buka utilitas dan pilih “Pulihkan pengaturan asli” jika Anda juga ingin membatalkan perubahan firewall, file hosts, layanan, tugas, dan mulai otomatis. Penghapusan melalui WinGet hanya menghapus file program portabel dan alias perintah.
+Documentations:
+- DocumentLabel: Dokumentasi proyek
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.it-IT.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.it-IT.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: it-IT
+ShortDescription: Blocca l’avvio automatico, l’attività in background e l’accesso alla rete di OMEN Gaming Hub, aiuta con gli errori di area geografica e ricrea le regole dopo gli aggiornamenti.
+Description: Omen Gaming Hub Unlocker è un’utilità Windows gratuita, portatile e open source per chi incontra in OMEN Gaming Hub blocchi geografici, area geografica errata, paese non supportato o il messaggio “non disponibile nella tua area geografica”. Blocca l’accesso a Internet di OMEN Gaming Hub e impedisce avvii indesiderati in background arrestando processi e servizi OMEN, disabilitando le attività pianificate e rimuovendo le voci di avvio. Lo strumento controlla lo stato della protezione, ricrea automaticamente le regole del firewall dopo gli aggiornamenti di Microsoft Store o OMEN, reimposta OMEN Gaming Hub e riapplica subito la protezione oppure ripristina le impostazioni originali di Windows. Non disinstalla OMEN, non modifica l’area geografica di Windows o Microsoft Store, non altera i file dell’applicazione e non rimuove i driver HP. Questo progetto non è affiliato con HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- sbloccare-omen-gaming-hub
+- disattivare-omen-gaming-hub
+- fermare-avvio-automatico-omen
+- bloccare-internet-omen
+- processi-background-omen
+- blocco-regionale-omen
+- omen-bloccato-per-regione
+- soluzione-blocco-regionale-omen
+- regione-errata-omen
+- paese-non-supportato-omen
+- omen-non-disponibile-nella-regione
+- reimpostare-omen-gaming-hub
+InstallationNotes: Prima della disinstallazione, apri l’utilità e scegli “Ripristina impostazioni originali” se vuoi annullare anche le modifiche a firewall, file hosts, servizi, attività e avvio. WinGet rimuove soltanto l’eseguibile portatile e l’alias del comando.
+Documentations:
+- DocumentLabel: Documentazione del progetto
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ja-JP.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ja-JP.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: ja-JP
+ShortDescription: OMEN Gaming Hub の自動起動、バックグラウンド動作、ネットワーク接続を停止し、地域エラーに対応して OMEN 更新後にファイアウォール規則を再構築します。
+Description: Omen Gaming Hub Unlocker は、OMEN Gaming Hub で地域ロック、地域設定の不一致、「国または地域がサポートされていません」「この地域では利用できません」といったエラーが発生するユーザー向けの、無料・ポータブル・オープンソースの Windows ユーティリティです。OMEN Gaming Hub のインターネット接続を遮断し、OMEN のプロセスとサービスの停止、スケジュールされたタスクの無効化、スタートアップ項目の削除によって、不要なバックグラウンド起動を防ぎます。保護状態の確認、Microsoft Store または OMEN の更新後のファイアウォール規則の自動再構築、OMEN Gaming Hub のリセットと保護の即時再適用、元の Windows 設定の復元が可能です。OMEN のアンインストール、Windows や Microsoft Store の地域変更、アプリケーションファイルの改変、HP ドライバーの削除は行いません。本プロジェクトは HP と提携していません。
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-解除
+- omen-gaming-hub-無効化
+- omen-自動起動-停止
+- omen-インターネット-遮断
+- omen-バックグラウンドプロセス
+- omen-地域ロック
+- omen-地域制限
+- omen-地域制限-回避
+- omen-地域エラー
+- omen-国がサポートされていない
+- omen-この地域では利用不可
+- omen-gaming-hub-リセット
+InstallationNotes: アンインストール前に、ファイアウォール、hosts ファイル、サービス、タスク、スタートアップへの変更も元に戻す場合は、ユーティリティを開いて「元の設定を復元」を選択してください。WinGet のアンインストールで削除されるのは、ポータブル実行ファイルとコマンドエイリアスのみです。
+Documentations:
+- DocumentLabel: プロジェクトドキュメント
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ko-KR.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ko-KR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: ko-KR
+ShortDescription: OMEN Gaming Hub의 자동 시작, 백그라운드 실행 및 네트워크 연결을 차단하고 지역 오류를 해결하며 OMEN 업데이트 후 방화벽 규칙을 다시 구성합니다.
+Description: Omen Gaming Hub Unlocker는 OMEN Gaming Hub의 지역 잠금, 잘못된 지역, 지원되지 않는 국가 또는 ‘현재 지역에서 사용할 수 없음’ 오류를 겪는 사용자를 위한 무료 휴대용 오픈 소스 Windows 유틸리티입니다. OMEN Gaming Hub의 인터넷 연결을 차단하고 OMEN 프로세스와 서비스를 중지하며 예약 작업을 비활성화하고 시작 프로그램 항목을 제거하여 원치 않는 백그라운드 실행을 방지합니다. 보호 상태 확인, Microsoft Store 또는 OMEN 업데이트 후 방화벽 규칙 자동 재구성, OMEN Gaming Hub 초기화와 즉시 보호 재적용, 원래 Windows 설정 복원이 가능합니다. OMEN을 제거하거나 Windows 또는 Microsoft Store 지역을 변경하거나 앱 파일을 수정하거나 HP 드라이버를 삭제하지 않습니다. 이 프로젝트는 HP와 관련이 없습니다.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-잠금해제
+- omen-gaming-hub-비활성화
+- omen-자동시작-중지
+- omen-인터넷-차단
+- omen-백그라운드-프로세스
+- omen-지역잠금
+- omen-지역제한
+- omen-지역제한-해결
+- omen-잘못된-지역
+- omen-지원되지-않는-국가
+- omen-현재-지역에서-사용불가
+- omen-gaming-hub-초기화
+InstallationNotes: 제거하기 전에 방화벽, hosts 파일, 서비스, 작업 및 시작 프로그램 변경 사항도 되돌리려면 유틸리티를 열고 ‘원래 설정 복원’을 선택하세요. WinGet 제거는 휴대용 실행 파일과 명령 별칭만 삭제합니다.
+Documentations:
+- DocumentLabel: 프로젝트 문서
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ms-MY.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ms-MY.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: ms-MY
+ShortDescription: Menghentikan mula automatik, aktiviti latar belakang dan akses rangkaian OMEN Gaming Hub, membantu ralat rantau serta membina semula peraturan tembok api selepas kemas kini OMEN.
+Description: Omen Gaming Hub Unlocker ialah utiliti Windows percuma, mudah alih dan sumber terbuka untuk pengguna yang mengalami kunci rantau, rantau yang salah, negara tidak disokong atau mesej “tidak tersedia di rantau anda” dalam OMEN Gaming Hub. Ia menyekat akses internet OMEN Gaming Hub dan menghalang pelancaran latar belakang yang tidak dikehendaki dengan menghentikan proses dan perkhidmatan OMEN, menyahdayakan tugas berjadual serta membuang entri permulaan. Alat ini menyemak status perlindungan, membina semula peraturan tembok api secara automatik selepas kemas kini Microsoft Store atau OMEN, menetapkan semula OMEN Gaming Hub dan terus menggunakan semula perlindungan, atau memulihkan tetapan asal Windows. Ia tidak menyahpasang OMEN, menukar rantau Windows atau Microsoft Store, mengubah suai fail aplikasi atau membuang pemacu HP. Projek ini tidak berkaitan dengan HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- buka-kunci-omen-gaming-hub
+- nyahdaya-omen-gaming-hub
+- hentikan-mula-automatik-omen
+- sekat-internet-omen
+- proses-latar-belakang-omen
+- kunci-rantau-omen
+- omen-dikunci-mengikut-rantau
+- penyelesaian-kunci-rantau-omen
+- rantau-salah-omen
+- negara-tidak-disokong-omen
+- omen-tidak-tersedia-di-rantau
+- tetap-semula-omen-gaming-hub
+InstallationNotes: Sebelum menyahpasang, buka utiliti dan pilih “Pulihkan tetapan asal” jika anda juga mahu membatalkan perubahan tembok api, fail hosts, perkhidmatan, tugas dan permulaan. Nyahpasang WinGet hanya membuang fail boleh laku mudah alih dan alias perintah.
+Documentations:
+- DocumentLabel: Dokumentasi projek
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.nb-NO.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.nb-NO.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: nb-NO
+ShortDescription: Stopper automatisk oppstart, bakgrunnsaktivitet og nettverkstilgang for OMEN Gaming Hub, hjelper ved regionfeil og bygger brannmurregler på nytt etter OMEN-oppdateringer.
+Description: Omen Gaming Hub Unlocker er et gratis, portabelt Windows-verktøy med åpen kildekode for brukere som møter regionlås, feil region, land som ikke støttes, eller meldingen «ikke tilgjengelig i din region» i OMEN Gaming Hub. Det blokkerer internettilgangen til OMEN Gaming Hub og hindrer uønsket bakgrunnsoppstart ved å stoppe OMEN-prosesser og -tjenester, deaktivere planlagte oppgaver og fjerne oppstartsoppføringer. Verktøyet kontrollerer beskyttelsesstatusen, bygger automatisk brannmurregler på nytt etter oppdateringer fra Microsoft Store eller OMEN, tilbakestiller OMEN Gaming Hub og bruker beskyttelsen umiddelbart på nytt, eller gjenoppretter de opprinnelige Windows-innstillingene. Det avinstallerer ikke OMEN, endrer ikke region for Windows eller Microsoft Store, endrer ikke programfiler og fjerner ikke HP-drivere. Prosjektet er ikke tilknyttet HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- lås-opp-omen-gaming-hub
+- deaktiver-omen-gaming-hub
+- stopp-omen-autostart
+- blokker-omen-internett
+- omen-bakgrunnsprosesser
+- omen-regionlås
+- omen-regionlåst
+- løsning-for-regionlås-omen
+- omen-feil-region
+- omen-land-støttes-ikke
+- omen-ikke-tilgjengelig-i-regionen
+- tilbakestill-omen-gaming-hub
+InstallationNotes: Åpne verktøyet før avinstallering og velg «Gjenopprett opprinnelige innstillinger» hvis du også vil angre endringer i brannmur, hosts-fil, tjenester, oppgaver og oppstart. WinGet fjerner bare den portable kjørbare filen og kommandoaliaset.
+Documentations:
+- DocumentLabel: Prosjektdokumentasjon
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.nl-NL.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.nl-NL.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: nl-NL
+ShortDescription: Stopt automatisch starten, achtergrondactiviteit en netwerktoegang van OMEN Gaming Hub, helpt bij regiofouten en bouwt firewallregels na OMEN-updates opnieuw op.
+Description: Omen Gaming Hub Unlocker is een gratis, draagbaar en opensource Windows-hulpprogramma voor gebruikers die in OMEN Gaming Hub te maken krijgen met een regioblokkering, verkeerde regio, niet-ondersteund land of de melding ‘niet beschikbaar in uw regio’. Het blokkeert de internettoegang van OMEN Gaming Hub en voorkomt ongewenst starten op de achtergrond door OMEN-processen en -services te stoppen, geplande taken uit te schakelen en opstartvermeldingen te verwijderen. Het programma controleert de beveiligingsstatus, bouwt firewallregels na updates van Microsoft Store of OMEN automatisch opnieuw op, stelt OMEN Gaming Hub opnieuw in en past de beveiliging direct opnieuw toe, of herstelt de oorspronkelijke Windows-instellingen. Het verwijdert OMEN niet, wijzigt de regio van Windows of Microsoft Store niet, past geen toepassingsbestanden aan en verwijdert geen HP-stuurprogramma’s. Dit project is niet verbonden aan HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-ontgrendelen
+- omen-gaming-hub-uitschakelen
+- omen-automatisch-starten-stoppen
+- omen-internet-blokkeren
+- omen-achtergrondprocessen
+- omen-regioblokkering
+- omen-geblokkeerd-per-regio
+- oplossing-regioblokkering-omen
+- omen-verkeerde-regio
+- omen-land-niet-ondersteund
+- omen-niet-beschikbaar-in-regio
+- omen-gaming-hub-opnieuw-instellen
+InstallationNotes: Open vóór het verwijderen het programma en kies ‘Oorspronkelijke instellingen herstellen’ als u ook de wijzigingen aan firewall, hosts-bestand, services, taken en opstartitems wilt terugdraaien. WinGet verwijdert alleen het draagbare uitvoerbare bestand en de opdrachtalias.
+Documentations:
+- DocumentLabel: Projectdocumentatie
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pl-PL.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pl-PL.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: pl-PL
+ShortDescription: Zatrzymuje autostart, działanie w tle i dostęp sieciowy OMEN Gaming Hub, pomaga przy błędach regionu i odbudowuje reguły zapory po aktualizacjach OMEN.
+Description: Omen Gaming Hub Unlocker to bezpłatne, przenośne narzędzie open source dla systemu Windows, przeznaczone dla użytkowników napotykających w OMEN Gaming Hub blokadę regionalną, nieprawidłowy region, nieobsługiwany kraj lub komunikat „niedostępne w Twoim regionie”. Blokuje dostęp OMEN Gaming Hub do Internetu i zapobiega niepożądanemu uruchamianiu w tle przez zatrzymanie procesów i usług OMEN, wyłączenie zaplanowanych zadań oraz usunięcie wpisów autostartu. Narzędzie sprawdza stan ochrony, automatycznie odbudowuje reguły zapory po aktualizacjach Microsoft Store lub OMEN, resetuje OMEN Gaming Hub i natychmiast ponownie stosuje ochronę albo przywraca oryginalne ustawienia Windows. Nie odinstalowuje OMEN, nie zmienia regionu Windows ani Microsoft Store, nie modyfikuje plików aplikacji i nie usuwa sterowników HP. Projekt nie jest powiązany z HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- odblokuj-omen-gaming-hub
+- wyłącz-omen-gaming-hub
+- zatrzymaj-autostart-omen
+- zablokuj-internet-omen
+- procesy-w-tle-omen
+- blokada-regionalna-omen
+- omen-zablokowany-regionalnie
+- obejście-blokady-regionalnej-omen
+- nieprawidłowy-region-omen
+- kraj-nieobsługiwany-omen
+- omen-niedostępny-w-regionie
+- resetuj-omen-gaming-hub
+InstallationNotes: Przed odinstalowaniem otwórz narzędzie i wybierz „Przywróć oryginalne ustawienia”, jeśli chcesz również cofnąć jego zmiany w zaporze, pliku hosts, usługach, zadaniach i autostarcie. WinGet usuwa tylko przenośny plik wykonywalny i alias polecenia.
+Documentations:
+- DocumentLabel: Dokumentacja projektu
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pt-BR.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pt-BR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: pt-BR
+ShortDescription: Impede a inicialização automática, a atividade em segundo plano e o acesso à rede do OMEN Gaming Hub, ajuda com erros de região e recria as regras após atualizações.
+Description: Omen Gaming Hub Unlocker é um utilitário gratuito, portátil e de código aberto para Windows, destinado a usuários que enfrentam no OMEN Gaming Hub bloqueio regional, região incorreta, país não suportado ou a mensagem “indisponível na sua região”. Ele bloqueia o acesso do OMEN Gaming Hub à Internet e evita inicializações indesejadas em segundo plano ao encerrar processos e serviços do OMEN, desativar tarefas agendadas e remover entradas de inicialização. A ferramenta verifica o status da proteção, recria automaticamente as regras do firewall após atualizações da Microsoft Store ou do OMEN, redefine o OMEN Gaming Hub e reaplica a proteção imediatamente, ou restaura as configurações originais do Windows. Ela não desinstala o OMEN, não altera a região do Windows ou da Microsoft Store, não modifica arquivos do aplicativo e não remove drivers da HP. Este projeto não é afiliado à HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- desbloquear-omen-gaming-hub
+- desativar-omen-gaming-hub
+- impedir-inicialização-omen
+- bloquear-internet-omen
+- processos-segundo-plano-omen
+- bloqueio-regional-omen
+- omen-bloqueado-por-região
+- solução-regional-omen
+- região-incorreta-omen
+- país-não-suportado-omen
+- omen-indisponível-na-região
+- redefinir-omen-gaming-hub
+InstallationNotes: Antes de desinstalar, abra o utilitário e escolha “Restaurar configurações originais” se também quiser desfazer as alterações de firewall, arquivo hosts, serviços, tarefas e inicialização. A desinstalação pelo WinGet remove apenas o executável portátil e o alias de comando.
+Documentations:
+- DocumentLabel: Documentação do projeto
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pt-PT.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.pt-PT.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: pt-PT
+ShortDescription: Impede o arranque automático, a atividade em segundo plano e o acesso à rede do OMEN Gaming Hub, ajuda com erros de região e recria as regras após atualizações.
+Description: Omen Gaming Hub Unlocker é um utilitário gratuito, portátil e de código aberto para Windows, destinado a utilizadores que encontram no OMEN Gaming Hub bloqueio regional, região incorreta, país não suportado ou a mensagem «indisponível na sua região». Bloqueia o acesso do OMEN Gaming Hub à Internet e evita arranques indesejados em segundo plano ao terminar processos e serviços do OMEN, desativar tarefas agendadas e remover entradas de arranque. A ferramenta verifica o estado da proteção, recria automaticamente as regras da firewall após atualizações da Microsoft Store ou do OMEN, repõe o OMEN Gaming Hub e reaplica imediatamente a proteção, ou restaura as definições originais do Windows. Não desinstala o OMEN, não altera a região do Windows ou da Microsoft Store, não modifica ficheiros da aplicação e não remove controladores da HP. Este projeto não está associado à HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- desbloquear-omen-gaming-hub
+- desativar-omen-gaming-hub
+- impedir-arranque-omen
+- bloquear-internet-omen
+- processos-segundo-plano-omen
+- bloqueio-regional-omen
+- omen-bloqueado-por-região
+- solução-regional-omen
+- região-incorreta-omen
+- país-não-suportado-omen
+- omen-indisponível-na-região
+- repor-omen-gaming-hub
+InstallationNotes: Antes de desinstalar, abra o utilitário e escolha «Restaurar definições originais» se também quiser reverter as alterações à firewall, ao ficheiro hosts, aos serviços, às tarefas e ao arranque. O WinGet remove apenas o executável portátil e o alias de comando.
+Documentations:
+- DocumentLabel: Documentação do projeto
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ro-RO.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ro-RO.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: ro-RO
+ShortDescription: Oprește pornirea automată, activitatea în fundal și accesul la rețea pentru OMEN Gaming Hub, ajută la erorile de regiune și reconstruiește regulile firewall după actualizări.
+Description: Omen Gaming Hub Unlocker este un utilitar Windows gratuit, portabil și open-source pentru utilizatorii care întâlnesc în OMEN Gaming Hub blocarea regională, o regiune greșită, o țară neacceptată sau mesajul „indisponibil în regiunea dvs.”. Blochează accesul OMEN Gaming Hub la internet și împiedică pornirile nedorite în fundal prin oprirea proceselor și serviciilor OMEN, dezactivarea activităților programate și eliminarea intrărilor de pornire. Instrumentul verifică starea protecției, reconstruiește automat regulile firewall după actualizări Microsoft Store sau OMEN, resetează OMEN Gaming Hub și reaplică imediat protecția ori restaurează setările Windows originale. Nu dezinstalează OMEN, nu schimbă regiunea Windows sau Microsoft Store, nu modifică fișierele aplicației și nu elimină drivere HP. Acest proiect nu este afiliat cu HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- deblocare-omen-gaming-hub
+- dezactivare-omen-gaming-hub
+- oprire-pornire-automată-omen
+- blocare-internet-omen
+- procese-fundal-omen
+- blocare-regională-omen
+- omen-blocat-după-regiune
+- soluție-blocare-regională-omen
+- regiune-greșită-omen
+- țară-neacceptată-omen
+- omen-indisponibil-în-regiune
+- resetare-omen-gaming-hub
+InstallationNotes: Înainte de dezinstalare, deschideți utilitarul și alegeți „Restaurare setări originale” dacă doriți să anulați și modificările pentru firewall, fișierul hosts, servicii, activități și pornire. WinGet elimină doar executabilul portabil și aliasul de comandă.
+Documentations:
+- DocumentLabel: Documentația proiectului
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ru-RU.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.ru-RU.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: ru-RU
+ShortDescription: Останавливает автозапуск и фоновую работу OMEN Gaming Hub, блокирует доступ к сети, помогает при региональных ошибках и пересоздаёт правила брандмауэра после обновлений OMEN.
+Description: 'Omen Gaming Hub Unlocker — бесплатная портативная утилита с открытым исходным кодом для Windows. Она предназначена для случаев, когда OMEN Gaming Hub сообщает «недоступен в вашем регионе», «неверный регион», «страна не поддерживается», блокируется по региону или перестаёт работать после обновления. Программа блокирует доступ OMEN Gaming Hub в интернет и предотвращает нежелательную фоновую работу: завершает процессы, останавливает службы, отключает задачи планировщика и убирает записи автозагрузки. Утилита проверяет состояние защиты, автоматически пересоздаёт правила брандмауэра после обновлений Microsoft Store или OMEN, умеет сбросить OMEN Gaming Hub и сразу повторно применить защиту, а также восстановить исходные настройки Windows. Она не удаляет OMEN, не меняет регион Windows или Microsoft Store, не патчит файлы приложения и не удаляет драйверы HP. Проект не связан с HP.'
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- разблокировать-omen-gaming-hub
+- отключить-omen-gaming-hub
+- остановить-автозапуск-omen
+- заблокировать-интернет-omen
+- фоновые-процессы-omen
+- региональная-блокировка-omen
+- omen-недоступен-в-регионе
+- неверный-регион-omen
+- страна-не-поддерживается-omen
+- обход-региональной-блокировки-omen
+- сброс-omen-gaming-hub
+- omen-не-работает-после-обновления
+InstallationNotes: Перед удалением откройте утилиту и выберите «Восстановить исходные настройки», если хотите также отменить созданные ею изменения брандмауэра, файла hosts, служб, задач и автозагрузки. WinGet удаляет только портативный EXE-файл и его командный псевдоним.
+Documentations:
+- DocumentLabel: Документация проекта
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.sv-SE.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.sv-SE.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: sv-SE
+ShortDescription: Stoppar automatisk start, bakgrundsaktivitet och nätverksåtkomst för OMEN Gaming Hub, hjälper vid regionfel och återskapar brandväggsregler efter OMEN-uppdateringar.
+Description: Omen Gaming Hub Unlocker är ett kostnadsfritt, portabelt Windows-verktyg med öppen källkod för användare som stöter på regionlås, fel region, land som inte stöds eller meddelandet ”inte tillgängligt i din region” i OMEN Gaming Hub. Det blockerar OMEN Gaming Hubs internetåtkomst och förhindrar oönskad bakgrundsstart genom att stoppa OMEN-processer och -tjänster, inaktivera schemalagda aktiviteter och ta bort autostartposter. Verktyget kontrollerar skyddsstatusen, återskapar automatiskt brandväggsregler efter uppdateringar av Microsoft Store eller OMEN, återställer OMEN Gaming Hub och tillämpar skyddet direkt igen eller återställer de ursprungliga Windows-inställningarna. Det avinstallerar inte OMEN, ändrar inte region för Windows eller Microsoft Store, modifierar inte programfiler och tar inte bort HP-drivrutiner. Projektet är inte anslutet till HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- lås-upp-omen-gaming-hub
+- inaktivera-omen-gaming-hub
+- stoppa-omen-autostart
+- blockera-omen-internet
+- omen-bakgrundsprocesser
+- omen-regionlås
+- omen-regionlåst
+- lösning-för-regionlås-omen
+- omen-fel-region
+- omen-land-stöds-inte
+- omen-inte-tillgängligt-i-regionen
+- återställ-omen-gaming-hub
+InstallationNotes: Öppna verktyget före avinstallationen och välj ”Återställ ursprungliga inställningar” om du även vill återställa ändringar i brandvägg, hosts-fil, tjänster, aktiviteter och autostart. WinGet tar endast bort den portabla körbara filen och kommandoaliaset.
+Documentations:
+- DocumentLabel: Projektdokumentation
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.th-TH.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.th-TH.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: th-TH
+ShortDescription: หยุด OMEN Gaming Hub ไม่ให้เริ่มอัตโนมัติ ทำงานเบื้องหลัง หรือเข้าถึงเครือข่าย ช่วยแก้ข้อผิดพลาดด้านภูมิภาค และสร้างกฎไฟร์วอลล์ใหม่หลังการอัปเดต OMEN
+Description: Omen Gaming Hub Unlocker เป็นยูทิลิตี Windows แบบพกพา ฟรี และโอเพนซอร์ส สำหรับผู้ใช้ที่พบปัญหา OMEN Gaming Hub ถูกล็อกตามภูมิภาค ภูมิภาคไม่ถูกต้อง ประเทศไม่รองรับ หรือข้อความว่า “ไม่พร้อมใช้งานในภูมิภาคของคุณ” โปรแกรมบล็อกการเข้าถึงอินเทอร์เน็ตของ OMEN Gaming Hub และป้องกันการทำงานเบื้องหลังที่ไม่ต้องการ โดยหยุดกระบวนการและบริการของ OMEN ปิดใช้งานงานตามกำหนดเวลา และลบรายการเริ่มต้นระบบ เครื่องมือนี้ตรวจสอบสถานะการป้องกัน สร้างกฎไฟร์วอลล์ใหม่โดยอัตโนมัติหลังการอัปเดต Microsoft Store หรือ OMEN รีเซ็ต OMEN Gaming Hub แล้วใช้การป้องกันอีกครั้งทันที หรือคืนค่าการตั้งค่า Windows เดิม โปรแกรมไม่ถอนการติดตั้ง OMEN ไม่เปลี่ยนภูมิภาคของ Windows หรือ Microsoft Store ไม่แก้ไขไฟล์แอป และไม่ลบไดรเวอร์ HP โครงการนี้ไม่มีความเกี่ยวข้องกับ HP
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- ปลดล็อก-omen-gaming-hub
+- ปิดใช้งาน-omen-gaming-hub
+- หยุด-omen-เริ่มอัตโนมัติ
+- บล็อกอินเทอร์เน็ต-omen
+- กระบวนการเบื้องหลัง-omen
+- ล็อกภูมิภาค-omen
+- omen-ถูกล็อกตามภูมิภาค
+- วิธีแก้ล็อกภูมิภาค-omen
+- ภูมิภาคไม่ถูกต้อง-omen
+- ประเทศไม่รองรับ-omen
+- omen-ไม่พร้อมใช้ในภูมิภาค
+- รีเซ็ต-omen-gaming-hub
+InstallationNotes: ก่อนถอนการติดตั้ง ให้เปิดยูทิลิตีแล้วเลือก “คืนค่าการตั้งค่าเดิม” หากต้องการยกเลิกการเปลี่ยนแปลงไฟร์วอลล์ ไฟล์ hosts บริการ งาน และรายการเริ่มต้นระบบด้วย การถอนการติดตั้งผ่าน WinGet จะลบเฉพาะไฟล์โปรแกรมแบบพกพาและนามแฝงคำสั่งเท่านั้น
+Documentations:
+- DocumentLabel: เอกสารโครงการ
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.tr-TR.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.tr-TR.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: tr-TR
+ShortDescription: OMEN Gaming Hub otomatik başlangıcını, arka plan çalışmasını ve ağ erişimini durdurur; bölge hatalarına yardımcı olur ve güncellemelerden sonra güvenlik duvarı kurallarını yeniler.
+Description: Omen Gaming Hub Unlocker; OMEN Gaming Hub bölge kilidi, yanlış bölge, desteklenmeyen ülke veya “bölgenizde kullanılamıyor” hatalarıyla karşılaşan kullanıcılar için ücretsiz, taşınabilir ve açık kaynaklı bir Windows aracıdır. OMEN Gaming Hub internet erişimini engeller; OMEN işlemlerini ve hizmetlerini durdurarak, zamanlanmış görevleri devre dışı bırakarak ve başlangıç girdilerini kaldırarak istenmeyen arka plan çalışmasını önler. Araç koruma durumunu denetleyebilir, Microsoft Store veya OMEN güncellemelerinden sonra güvenlik duvarı kurallarını otomatik olarak yeniden oluşturabilir, OMEN Gaming Hub’ı sıfırlayıp korumayı hemen yeniden uygulayabilir ya da özgün Windows ayarlarını geri yükleyebilir. OMEN’i kaldırmaz, Windows veya Microsoft Store bölgesini değiştirmez, uygulama dosyalarına yama yapmaz ve HP sürücülerini silmez. Bu proje HP ile bağlantılı değildir.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- omen-gaming-hub-kilidini-aç
+- omen-gaming-hub-devre-dışı-bırak
+- omen-otomatik-başlatmayı-durdur
+- omen-internetini-engelle
+- omen-arka-plan-işlemleri
+- omen-bölge-kilidi
+- omen-bölgesel-olarak-kilitli
+- omen-bölge-kilidi-çözümü
+- omen-yanlış-bölge
+- omen-desteklenmeyen-ülke
+- omen-bölgede-kullanılamıyor
+- omen-gaming-hub-sıfırla
+InstallationNotes: Kaldırmadan önce güvenlik duvarı, hosts dosyası, hizmet, görev ve başlangıç değişikliklerini de geri almak istiyorsanız aracı açıp “Özgün ayarları geri yükle” seçeneğini kullanın. WinGet yalnızca taşınabilir yürütülebilir dosyayı ve komut diğer adını kaldırır.
+Documentations:
+- DocumentLabel: Proje belgeleri
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.uk-UA.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.uk-UA.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: uk-UA
+ShortDescription: Зупиняє автозапуск, фонову роботу й доступ до мережі OMEN Gaming Hub, допомагає з помилками регіону та перебудовує правила брандмауера після оновлень OMEN.
+Description: 'Omen Gaming Hub Unlocker — безкоштовна портативна утиліта з відкритим кодом для Windows, призначена для користувачів, які стикаються в OMEN Gaming Hub із регіональним блокуванням, неправильним регіоном, непідтримуваною країною або повідомленням «недоступно у вашому регіоні». Вона блокує доступ OMEN Gaming Hub до Інтернету та запобігає небажаному фоновому запуску: завершує процеси й служби OMEN, вимикає заплановані завдання та видаляє записи автозапуску. Утиліта перевіряє стан захисту, автоматично перебудовує правила брандмауера після оновлень Microsoft Store або OMEN, скидає OMEN Gaming Hub і відразу повторно застосовує захист або відновлює початкові параметри Windows. Вона не видаляє OMEN, не змінює регіон Windows чи Microsoft Store, не модифікує файли програми та не видаляє драйвери HP. Проєкт не пов’язаний із HP.'
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- розблокувати-omen-gaming-hub
+- вимкнути-omen-gaming-hub
+- зупинити-автозапуск-omen
+- заблокувати-інтернет-omen
+- фонові-процеси-omen
+- регіональне-блокування-omen
+- omen-заблоковано-за-регіоном
+- обхід-регіонального-блокування-omen
+- неправильний-регіон-omen
+- країна-не-підтримується-omen
+- omen-недоступний-у-регіоні
+- скинути-omen-gaming-hub
+InstallationNotes: Перед видаленням відкрийте утиліту й виберіть «Відновити початкові параметри», якщо також потрібно скасувати зміни брандмауера, файлу hosts, служб, завдань і автозапуску. WinGet видаляє лише портативний виконуваний файл і псевдонім команди.
+Documentations:
+- DocumentLabel: Документація проєкту
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.vi-VN.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.vi-VN.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: vi-VN
+ShortDescription: Ngăn OMEN Gaming Hub tự khởi động, chạy nền và truy cập mạng; hỗ trợ lỗi khu vực và tạo lại quy tắc tường lửa sau khi OMEN cập nhật.
+Description: Omen Gaming Hub Unlocker là tiện ích Windows miễn phí, di động và mã nguồn mở dành cho người dùng gặp lỗi khóa khu vực, sai khu vực, quốc gia không được hỗ trợ hoặc thông báo “không khả dụng tại khu vực của bạn” trong OMEN Gaming Hub. Tiện ích chặn OMEN Gaming Hub truy cập Internet và ngăn việc chạy nền ngoài ý muốn bằng cách dừng các tiến trình và dịch vụ OMEN, tắt tác vụ đã lên lịch và xóa mục tự khởi động. Công cụ có thể kiểm tra trạng thái bảo vệ, tự động tạo lại quy tắc tường lửa sau bản cập nhật Microsoft Store hoặc OMEN, đặt lại OMEN Gaming Hub rồi áp dụng lại bảo vệ ngay lập tức, hoặc khôi phục cài đặt Windows ban đầu. Công cụ không gỡ cài đặt OMEN, không thay đổi khu vực Windows hoặc Microsoft Store, không sửa đổi tệp ứng dụng và không xóa trình điều khiển HP. Dự án này không liên kết với HP.
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- mở-khóa-omen-gaming-hub
+- tắt-omen-gaming-hub
+- dừng-omen-tự-khởi-động
+- chặn-internet-omen
+- tiến-trình-nền-omen
+- khóa-khu-vực-omen
+- omen-bị-khóa-theo-khu-vực
+- giải-pháp-khóa-khu-vực-omen
+- sai-khu-vực-omen
+- quốc-gia-không-được-hỗ-trợ-omen
+- omen-không-khả-dụng-tại-khu-vực
+- đặt-lại-omen-gaming-hub
+InstallationNotes: Trước khi gỡ cài đặt, hãy mở tiện ích và chọn “Khôi phục cài đặt ban đầu” nếu bạn cũng muốn hoàn tác các thay đổi đối với tường lửa, tệp hosts, dịch vụ, tác vụ và mục khởi động. WinGet chỉ xóa tệp thực thi di động và bí danh lệnh.
+Documentations:
+- DocumentLabel: Tài liệu dự án
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.zh-CN.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.zh-CN.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: zh-CN
+ShortDescription: 阻止 OMEN Gaming Hub 自动启动、在后台运行和访问网络；帮助解决区域错误，并在 OMEN 更新后重建防火墙规则。
+Description: Omen Gaming Hub Unlocker 是一款免费、便携且开源的 Windows 工具，适用于遇到 OMEN Gaming Hub 区域锁定、区域错误、国家或地区不受支持，以及“你所在的区域不可用”等问题的用户。它会阻止 OMEN Gaming Hub 访问互联网，并通过终止 OMEN 进程和服务、禁用计划任务及移除启动项来防止不必要的后台启动。该工具可以检查保护状态，在 Microsoft Store 或 OMEN 更新后自动重建防火墙规则，重置 OMEN Gaming Hub 并立即重新应用保护，也可以恢复原始 Windows 设置。它不会卸载 OMEN、更改 Windows 或 Microsoft Store 区域、修改应用程序文件或删除 HP 驱动程序。本项目与 HP 无关。
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- 解锁-omen-gaming-hub
+- 禁用-omen-gaming-hub
+- 停止-omen-自动启动
+- 阻止-omen-访问网络
+- omen-后台进程
+- omen-区域锁定
+- omen-区域受限
+- omen-区域限制解决方案
+- omen-区域错误
+- omen-国家不受支持
+- omen-所在区域不可用
+- 重置-omen-gaming-hub
+InstallationNotes: 卸载前，如果还需要移除本工具创建的防火墙、hosts 文件、服务、任务和启动项更改，请打开本工具并选择“恢复原始设置”。WinGet 卸载只会删除便携式可执行文件和命令别名。
+Documentations:
+- DocumentLabel: 项目文档
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.zh-TW.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.locale.zh-TW.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+PackageLocale: zh-TW
+ShortDescription: 阻止 OMEN Gaming Hub 自動啟動、在背景執行及存取網路；協助處理地區錯誤，並在 OMEN 更新後重建防火牆規則。
+Description: Omen Gaming Hub Unlocker 是一款免費、可攜且開放原始碼的 Windows 工具，適合遇到 OMEN Gaming Hub 地區鎖定、地區錯誤、國家或地區不受支援，以及「您所在的地區無法使用」等問題的使用者。它會封鎖 OMEN Gaming Hub 的網際網路存取，並透過終止 OMEN 處理程序與服務、停用排程工作及移除啟動項目，避免不必要的背景啟動。此工具可以檢查保護狀態，在 Microsoft Store 或 OMEN 更新後自動重建防火牆規則，重設 OMEN Gaming Hub 並立即重新套用保護，也能還原原始 Windows 設定。它不會解除安裝 OMEN、變更 Windows 或 Microsoft Store 地區、修改應用程式檔案或移除 HP 驅動程式。本專案與 HP 無關。
+Tags:
+- omen-gaming-hub
+- hp-omen-gaming-hub
+- omen-gaming-hub-unlocker
+- omen-command-center
+- 解鎖-omen-gaming-hub
+- 停用-omen-gaming-hub
+- 停止-omen-自動啟動
+- 封鎖-omen-網路存取
+- omen-背景處理程序
+- omen-地區鎖定
+- omen-地區受限
+- omen-地區限制解決方案
+- omen-地區錯誤
+- omen-國家不受支援
+- omen-此地區無法使用
+- 重設-omen-gaming-hub
+InstallationNotes: 解除安裝前，若也要移除此工具建立的防火牆、hosts 檔案、服務、工作及啟動項目變更，請開啟工具並選擇「還原原始設定」。WinGet 解除安裝只會移除可攜式執行檔與命令別名。
+Documentations:
+- DocumentLabel: 專案文件
+  DocumentUrl: https://github.com/Avazbek22/OmenGamingHubUnlocker#readme
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
+++ b/manifests/o/OlimoffDev/OmenGamingHubUnlocker/3.3.0.0/OlimoffDev.OmenGamingHubUnlocker.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.OmenGamingHubUnlocker
+PackageVersion: 3.3.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `OlimoffDev.OmenGamingHubUnlocker` to `3.3.0.0`.

- Updates the x64 and ARM64 portable installers to the signed-off GitHub release assets.
- Adds localized package metadata for 30 Windows locales.
- Improves localized descriptions and search tags for OMEN Gaming Hub region, network, background activity, autostart, and reset queries.
- Updates the release date and release notes URL for v3.3.

## Validation

- [x] Confirmed there are no other open pull requests for this package update.
- [x] This pull request modifies only one package manifest set.
- [x] Validated locally with `winget validate --manifest <path>`.
- [x] Manifest conforms to schema 1.12.
- [x] Installer URLs are immutable, version-specific GitHub release assets.
- [x] Installer SHA-256 values match the published x64 and ARM64 binaries.
- [ ] Local install test was not run because the `LocalManifestFiles` administrator policy is disabled on the test system.