### PR TITLE
Update OlimoffDev.BluetoothHandsFreeToggle to 2.2.0.0

### DIFF
--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.installer.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- bhft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/download/v2.2/BluetoothHandsFreeToggle-v2.2-win-x64.exe
+  InstallerSha256: 5D644544289C5CB0948259EBDE825BB175E98CAF24553B6E3992CE500BAFD828
+- Architecture: arm64
+  InstallerUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/download/v2.2/BluetoothHandsFreeToggle-v2.2-win-arm64.exe
+  InstallerSha256: A58DAAA7D3E2356E3F686BBC92941E327B6851A11D52782EFB20C3592A768C59
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-23

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.bg-BG.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.bg-BG.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: bg-BG
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Поправя нискокачествения звук на Bluetooth слушалки в Windows 11 чрез нулиране или деактивиране на режима за обаждания Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle поправя проблема с Bluetooth слушалки и геймърски слушалки, заседнали в режим на нискокачествени разговори чрез Hands-Free (HFP) след спиране на игри като Call of Duty, гласов чат, браузъри или приложения за записване на използването на микрофона. Мек рестарт запазва наличността на микрофона. Принудителен режим деактивира HFP системно, за да принуди възпроизвеждането на висококачествен стерео звук чрез A2DP. Възстановяване връща предишната конфигурация на услугите на Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Добавя 30 интерфейсни езика с интелигентно разпознаване на езика на Windows и цялостно меню за избор на език. Подобрява подравняването на мултиезичната конзолна таблица. Добавя локализирани метаданни WinGet за всеки поддържан език.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Режимите за смяна на услугите изискват Администратор. Стартирайте с Мек рестарт, за да запазите микрофона на Bluetooth слушалката; Принудителен режим деактивира HFP системно.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.cs-CZ.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.cs-CZ.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: cs-CZ
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Opravuje nízkou kvalitu zvuku Bluetooth sluchátek ve Windows 11 resetováním nebo deaktivací režimu hands-free (HFP) hovoru.
+Description: BluetoothHandsFreeToggle opravuje sluchátka Bluetooth a herní headsety zaseknuté v režimu hovorů nízké kvality Hands-Free (HFP) poté, co hry jako Call of Duty, hlasový chat, prohlížeče nebo nahrávací aplikace přestanou používat mikrofon. Měkký reset zachovává dostupnost mikrofonu. Vynucený režim zakáže HFP systémově, aby vynutil přehrávání ve vysoké kvalitě A2DP stereo. Obnovení vrátí předchozí konfiguraci služby Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Přidává 30 uživatelských jazyků s inteligentním detekováním jazyka ve Windows a kompletním menu výběru jazyka. Zlepšuje zarovnání vícejazyčné konzolové tabulky. Přidává lokalizovaná metadata WinGet pro každý podporovaný jazyk.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Režimy měnící služby vyžadují administrátora. Začněte s Měkký reset pro zachování mikrofonu Bluetooth sluchátek; Vynucený režim vypíná HFP systémově.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.da-DK.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.da-DK.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: da-DK
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Løser lavkvalitetslyd på Bluetooth-headset på Windows 11 ved at nulstille eller deaktivere håndfri (HFP) opkaldstilstand.
+Description: BluetoothHandsFreeToggle løser problemer med Bluetooth-hovedtelefoner og gaming-headsets, der sidder fast i lavkvalitets Hands-Free (HFP) opkaldstilstand efter spil som Call of Duty, stemmechat, browsere eller optageprogrammer stopper med at bruge mikrofonen. Blød nulstilling bevarer mikrofontilgængelighed. Hård tilstand deaktiverer HFP systemomfattende for at tvinge høj-kvalitets A2DP stereoafspilning. Gendan returnerer den tidligere Windows servicekonfiguration.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Tilføjer 30 grænsefladesprog med smart Windows-sprogsdetektion og en komplet sprogvalgmenu. Forbedrer flersproget konsolbordjustering. Tilføjer lokaliseret WinGet-metadata for hvert understøttet sprog.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Service-ændringsmåder kræver Administrator. Start med Blød nulstilling for at bevare Bluetooth-headsettets mikrofon; Hård tilstand deaktiverer HFP systemomfattende.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.de-DE.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.de-DE.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: de-DE
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Behebt die Audioqualität von Bluetooth-Headsets unter Windows 11, indem der Freisprechmodus (HFP) zurückgesetzt oder deaktiviert wird.
+Description: BluetoothHandsFreeToggle behebt Bluetooth-Kopfhörer und Gaming-Headsets, die nach Spielen wie Call of Duty, Sprach-Chat, Browsern oder Aufnahmeanwendungen im niederqualitativen Freisprechmodus (HFP) hängen bleiben. Soft-Reset erhält die Verfügbarkeit des Mikrofons. Hard-Modus deaktiviert HFP systemweit, um hochwertige A2DP-Stereo-Wiedergabe zu erzwingen. Wiederherstellen stellt die vorherige Windows-Dienstkonfiguration wieder her.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Fügt 30 Schnittstellensprachen mit intelligenter Windows-Spracherkennung und einem vollständigen Sprachwahlmenü hinzu. Verbessert die mehrsprachige Ausrichtung der Konsolentabelle. Fügt für jede unterstützte Sprache lokalisierte WinGet-Metadaten hinzu.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Service-Änderungsmodi erfordern Administratorrechte. Starten Sie mit Soft-Reset, um das Bluetooth-Headset-Mikrofon zu erhalten; Hard-Modus deaktiviert HFP systemweit.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.el-GR.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.el-GR.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: el-GR
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Επιδιορθώνει τον ήχο χαμηλής ποιότητας ακουστικών Bluetooth σε Windows 11 επαναφέροντας ή απενεργοποιώντας τη λειτουργία κλήσης Hands-Free (HFP).
+Description: Η επιλογή BluetoothHandsFreeToggle διορθώνει τα ακουστικά Bluetooth και τα gaming headsets που κολλάνε σε χαμηλής ποιότητας λειτουργία κλήσης Hands-Free (HFP) μετά από παιχνίδια όπως Call of Duty, φωνητική συνομιλία, προγράμματα περιήγησης ή εφαρμογές εγγραφής που σταματούν να χρησιμοποιούν το μικρόφωνο. Το Απαλή επαναφορά διατηρεί τη διαθεσιμότητα του μικροφώνου. Το Εξαναγκασμένη λειτουργία απενεργοποιεί το HFP σε ολόκληρο το σύστημα για να επιβάλει αναπαραγωγή υψηλής ποιότητας στερεοφωνικού ήχου A2DP. Η λειτουργία Επαναφορά επιστρέφει την προηγούμενη διαμόρφωση υπηρεσίας των Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Προσθέτει 30 γλώσσες διεπαφής με έξυπνη ανίχνευση γλώσσας των Windows και πλήρες μενού επιλογής γλώσσας. Βελτιώνει την ευθυγράμμιση του πίνακα της κονσόλας σε πολλές γλώσσες. Προσθέτει τοπικά μεταδεδομένα WinGet για κάθε υποστηριζόμενη γλώσσα.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Οι λειτουργίες αλλαγής υπηρεσίας απαιτούν Διαχειριστή. Ξεκινήστε με Απαλή επαναφορά για να διατηρήσετε το μικρόφωνο του ακουστικού Bluetooth· το Εξαναγκασμένη λειτουργία απενεργοποιεί το HFP σε όλο το σύστημα.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.en-US.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: en-US
+Publisher: Olimoff Dev
+PublisherUrl: https://github.com/Avazbek22
+PublisherSupportUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/issues
+PackageName: BluetoothHandsFreeToggle
+PackageUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle
+License: MIT
+LicenseUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Avazbek Olimov
+ShortDescription: Fixes low-quality Bluetooth headset audio on Windows 11 by resetting or disabling Hands-Free (HFP) call mode.
+Description: BluetoothHandsFreeToggle fixes Bluetooth headphones and gaming headsets stuck in low-quality Hands-Free (HFP) call mode after games such as Call of Duty, voice chat, browsers, or recording applications stop using the microphone. Soft Reset preserves microphone availability. Hard Mode disables HFP system-wide to force high-quality A2DP stereo playback. Restore returns the previous Windows service configuration.
+Moniker: bhft
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Adds 30 interface languages with smart Windows language detection and a full language selection menu. Improves multilingual console table alignment. Adds localized WinGet metadata for every supported language.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Service-changing modes require Administrator. Start with Soft Reset to preserve the Bluetooth headset microphone; Hard Mode disables HFP system-wide.
+Documentations:
+- DocumentLabel: Project documentation
+  DocumentUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.es-ES.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.es-ES.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: es-ES
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Corrige el audio de baja calidad de los auriculares Bluetooth en Windows 11 reiniciando o deshabilitando el modo de llamada de manos libres (HFP).
+Description: BluetoothHandsFreeToggle soluciona los auriculares Bluetooth y los auriculares para juegos que quedan atascados en el modo de llamada de manos libres de baja calidad (HFP) después de que juegos como Call of Duty, el chat de voz, los navegadores o las aplicaciones de grabación dejen de usar el micrófono. Reinicio suave preserva la disponibilidad del micrófono. Modo estricto desactiva HFP en todo el sistema para forzar la reproducción estéreo A2DP de alta calidad. Restaurar vuelve a la configuración anterior del servicio de Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Agrega 30 idiomas de interfaz con detección inteligente del idioma de Windows y un menú completo de selección de idioma. Mejora la alineación de la tabla de consola multilingüe. Agrega metadatos de WinGet localizados para cada idioma compatible.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Los modos que cambian el servicio requieren Administrador. Comience con Reinicio suave para preservar el micrófono del auricular Bluetooth; Modo estricto desactiva HFP en todo el sistema.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.es-MX.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.es-MX.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: es-MX
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Corrige el audio de baja calidad de los audífonos Bluetooth en Windows 11 reiniciando o desactivando el modo de llamada de manos libres (HFP).
+Description: BluetoothHandsFreeToggle soluciona los audífonos Bluetooth y los audífonos para juegos que quedan atascados en el modo de llamada de manos libres (HFP) de baja calidad después de que juegos como Call of Duty, el chat de voz, los navegadores o las aplicaciones de grabación dejen de usar el micrófono. Reinicio suave preserva la disponibilidad del micrófono. Modo estricto desactiva HFP en todo el sistema para forzar la reproducción estéreo A2DP de alta calidad. Restaurar vuelve a la configuración anterior del servicio de Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Agrega 30 idiomas de interfaz con detección inteligente del idioma de Windows y un menú completo de selección de idioma. Mejora la alineación de la tabla de consola multilingüe. Agrega metadatos de WinGet localizados para cada idioma compatible.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Los modos que cambian el servicio requieren Administrador. Comience con Reinicio suave para preservar el micrófono del auricular Bluetooth; Modo estricto desactiva HFP en todo el sistema.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.fi-FI.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.fi-FI.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: fi-FI
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Korjaa huonolaatuisen Bluetooth-kuulokkeen äänen Windows 11:ssä palauttamalla tai poistamalla käytöstä Hands-Free (HFP) -puhelutila.
+Description: BluetoothHandsFreeToggle korjaa Bluetooth-kuulokkeet ja pelikuulokkeet, jotka juuttuvat matalan laadun Hands-Free (HFP) -puhelutilaan pelien, kuten Call of Duty, äänichatin, selainten tai äänityssovellusten lopetettua mikrofonin käytön. Pehmeä uudelleenkäynnistys säilyttää mikrofonin saatavuuden. Pakotettu tila poistaa HFP:n käytöstä koko järjestelmässä pakottaakseen korkean laadun A2DP-stereotoiston. Palauta palauttaa aiemman Windows-palvelukonfiguraation.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Lisää 30 käyttöliittymäkieltä älykkäällä Windows-kielen tunnistuksella ja täydellisen kielivalikon. Parantaa monikielisen konsolitaulukon kohdistusta. Lisää paikallistetut WinGet-metadata kaikille tuetuille kielille.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Palvelutilojen muuttaminen vaatii järjestelmänvalvojan. Aloita Pehmeä uudelleenkäynnistys säilyttääksesi Bluetooth-kuulokemikrofonin; Pakotettu tila poistaa HFP:n käytöstä koko järjestelmässä.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.fr-FR.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.fr-FR.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: fr-FR
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Corrige l'audio de mauvaise qualité des casques Bluetooth sur Windows 11 en réinitialisant ou en désactivant le mode appel mains libres (HFP).
+Description: BluetoothHandsFreeToggle corrige le problème des casques Bluetooth et des casques de jeu bloqués en mode appel mains-libres de faible qualité (HFP) après que des jeux tels que Call of Duty, la discussion vocale, les navigateurs ou les applications d'enregistrement cessent d'utiliser le microphone. Réinitialisation douce préserve la disponibilité du microphone. Mode forcé désactive HFP au niveau du système pour forcer la lecture stéréo A2DP de haute qualité. Restaurer rétablit la configuration précédente du service Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Ajoute 30 langues d'interface avec détection intelligente de la langue de Windows et un menu complet de sélection de la langue. Améliore l'alignement des tableaux de console multilingues. Ajoute des métadonnées WinGet localisées pour chaque langue prise en charge.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Les modes de changement de service nécessitent un administrateur. Commencez par Réinitialisation douce pour préserver le microphone du casque Bluetooth ; Mode forcé désactive le HFP à l'échelle du système.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.hu-HU.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.hu-HU.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: hu-HU
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Javítja az alacsony minőségű Bluetooth fejhallgató hangját Windows 11 rendszeren azáltal, hogy visszaállítja vagy letiltja a Hands-Free (HFP) hívás módot.
+Description: A BluetoothHandsFreeToggle kijavítja a Bluetooth fülhallgatók és játék fejhallgatók alacsony minőségű Hands-Free (HFP) hívás módba ragadását olyan játékok, mint a Call of Duty, hangcsevegés, böngészők vagy hangrögzítő alkalmazások után, miután a mikrofon használata megszűnik. A Szoft reset megőrzi a mikrofon elérhetőségét. A Kényszerített mód rendszerszinten letiltja az HFP-t, hogy kényszerítse a nagy felbontású A2DP sztereó lejátszást. A Visszaállítás visszaállítja az előző Windows szolgáltatás konfigurációt.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: 30 felhasználói felület nyelvet ad hozzá az intelligens Windows nyelvészlelés és a teljes nyelvválasztó menü segítségével. Javítja a többnyelvű konzolasztal igazítását. Hozzáadja az lokalizált WinGet metaadatokat minden támogatott nyelvhez.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: A szolgáltatás-váltó módokhoz rendszergazdai jogosultság szükséges. Indítsa a Szoft reset-et a Bluetooth headset mikrofon megőrzéséhez; a Kényszerített mód rendszerszinten letiltja a HFP-t.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.id-ID.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.id-ID.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: id-ID
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Memperbaiki audio headset Bluetooth berkualitas rendah di Windows 11 dengan mereset atau menonaktifkan mode panggilan Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle memperbaiki headphone Bluetooth dan headset gaming yang terjebak dalam mode panggilan Hands-Free (HFP) kualitas rendah setelah game seperti Call of Duty, obrolan suara, browser, atau aplikasi perekaman berhenti menggunakan mikrofon. Reset ringan mempertahankan ketersediaan mikrofon. Mode paksa menonaktifkan HFP di seluruh sistem untuk memaksa pemutaran stereo A2DP berkualitas tinggi. Pulihkan mengembalikan konfigurasi layanan Windows sebelumnya.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Menambahkan 30 bahasa antarmuka dengan deteksi bahasa Windows yang cerdas dan menu pilihan bahasa lengkap. Meningkatkan penyelarasan tabel konsol multibahasa. Menambahkan metadata WinGet yang dilokalkan untuk setiap bahasa yang didukung.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Mode perubahan layanan memerlukan Administrator. Mulai dengan Reset ringan untuk mempertahankan mikrofon headset Bluetooth; Mode paksa menonaktifkan HFP secara sistem-wide.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.it-IT.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.it-IT.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: it-IT
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Risolve l'audio di bassa qualità degli auricolari Bluetooth su Windows 11 reimpostando o disattivando la modalità di chiamata Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle risolve il problema delle cuffie Bluetooth e degli headset da gioco bloccati in modalità chiamata a bassa qualità Hands-Free (HFP) dopo che giochi come Call of Duty, chat vocali, browser o applicazioni di registrazione smettono di usare il microfono. Reset soft preserva la disponibilità del microfono. Modalità forzata disabilita HFP a livello di sistema per forzare la riproduzione stereo ad alta qualità A2DP. Ripristina ritorna alla configurazione precedente del servizio Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Aggiunge 30 lingue dell'interfaccia con rilevamento intelligente della lingua di Windows e un menu completo di selezione della lingua. Migliora l'allineamento multilingue delle tabelle della console. Aggiunge metadata WinGet localizzati per ogni lingua supportata.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Le modalità che cambiano il servizio richiedono l'Amministratore. Avviare con Reset soft per preservare il microfono dell'auricolare Bluetooth; Modalità forzata disabilita HFP a livello di sistema.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ja-JP.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ja-JP.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: ja-JP
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Hands-Free（HFP）通話モードをリセットまたは無効にすることで、Windows 11の低品質なBluetoothヘッドセットの音声を修正します。
+Description: BluetoothHandsFreeToggleは、Call of Dutyなどのゲーム、ボイスチャット、ブラウザ、または録音アプリケーションがマイクの使用を停止した後に、Bluetoothヘッドフォンやゲーミングヘッドセットが低品質のハンズフリー（HFP）通話モードに固定される問題を修正します。ソフトリセットはマイクの使用可能状態を保持します。ハードモードはシステム全体でHFPを無効にして高品質なA2DPステレオ再生を強制します。Restoreは以前のWindowsサービス構成を復元します。
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: スマートなWindows言語検出と完全な言語選択メニューで30のインターフェイス言語を追加します。多言語コンソールテーブルの整列を改善します。サポートされているすべての言語に対してローカライズされたWinGetメタデータを追加します。
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: サービス変更モードには管理者権限が必要です。ソフトリセットで開始するとBluetoothヘッドセットのマイクを保持できます；ハードモードはHFPをシステム全体で無効にします。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ko-KR.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ko-KR.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: ko-KR
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: 핸즈프리(HFP) 통화 모드를 재설정하거나 비활성화하여 Windows 11에서 저품질 블루투스 헤드셋 오디오를 수정합니다.
+Description: BluetoothHandsFreeToggle은 Call of Duty와 같은 게임, 음성 채팅, 브라우저 또는 녹음 애플리케이션이 마이크 사용을 중단한 후 저품질 핸즈프리(HFP) 통화 모드에 갇힌 블루투스 헤드폰 및 게임 헤드셋을 수정합니다. 소프트 리셋는 마이크 사용 가능성을 유지합니다. 하드 모드는 HFP를 시스템 전체에서 비활성화하여 고품질 A2DP 스테레오 재생을 강제합니다. 복원은 이전 Windows 서비스 구성을 반환합니다.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: 스마트 Windows 언어 감지 및 전체 언어 선택 메뉴와 함께 30개의 인터페이스 언어를 추가합니다. 다국어 콘솔 테이블 정렬을 개선합니다. 지원되는 모든 언어에 대해 로컬라이즈된 WinGet 메타데이터를 추가합니다.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: 서비스 변경 모드는 관리자 권한이 필요합니다. Bluetooth 헤드셋 마이크를 유지하려면 소프트 리셋로 시작하십시오; 하드 모드는 HFP를 시스템 전체에서 비활성화합니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ms-MY.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ms-MY.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: ms-MY
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Memperbaiki kualiti audio fon kepala Bluetooth yang rendah pada Windows 11 dengan menetapkan semula atau mematikan mod panggilan Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle membetulkan fon kepala Bluetooth dan fon kepala permainan yang tersekat dalam mod panggilan Hands-Free (HFP) berkualiti rendah selepas permainan seperti Call of Duty, sembang suara, pelayar, atau aplikasi rakaman berhenti menggunakan mikrofon. Reset lembut mengekalkan ketersediaan mikrofon. Mod paksa mematikan HFP secara menyeluruh untuk memaksa main balik stereo A2DP berkualiti tinggi. Pulihkan mengembalikan konfigurasi perkhidmatan Windows sebelumnya.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Menambah 30 bahasa antara muka dengan pengesanan bahasa Windows pintar dan menu pemilihan bahasa penuh. Meningkatkan penjajaran jadual konsol pelbagai bahasa. Menambah metadata WinGet yang dilokalkan untuk setiap bahasa yang disokong.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Mod mod menukar perkhidmatan memerlukan Pentadbir. Mulakan dengan Reset lembut untuk mengekalkan mikrofon fon kepala Bluetooth; Mod paksa mematikan HFP di seluruh sistem.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.nb-NO.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.nb-NO.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: nb-NO
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Løser lavkvalitetslyd på Bluetooth-headset i Windows 11 ved å tilbakestille eller deaktivere handsfree (HFP)-samtalemodus.
+Description: BluetoothHandsFreeToggle fikser Bluetooth-hodetelefoner og gaming-headset som sitter fast i lavkvalitets Hands-Free (HFP) samtalemodus etter at spill som Call of Duty, talechat, nettlesere eller opptaksapplikasjoner slutter å bruke mikrofonen. Myk tilbakestilling bevarer mikrofontilgjengelighet. Hard modus deaktiverer HFP systemomfattende for å tvinge høykvalitets A2DP stereoplayback. Gjenopprett returnerer den forrige Windows-tjenestekonfigurasjonen.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Legger til 30 grensesnittspråk med smart Windows-språkgjenkjenning og en full språkutvalgmeny. Forbedrer flerspråklig konsolltabelljustering. Legger til lokaliserte WinGet-metadata for hvert støttet språk.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Tjenesteendringsmoduser krever Administrator. Start med Myk tilbakestilling for å bevare Bluetooth-headsettets mikrofon; Hard modus deaktiverer HFP systemomfattende.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.nl-NL.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.nl-NL.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: nl-NL
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Lost lage kwaliteit Bluetooth-headsetaudio op Windows 11 door de Hands-Free (HFP) belmodus te resetten of uit te schakelen.
+Description: BluetoothHandsFreeToggle repareert Bluetooth-hoofdtelefoons en gaming-headsets die vastzitten in de laagwaardige Hands-Free (HFP) belmodus nadat spellen zoals Call of Duty, spraakchat, browsers of opname-applicaties zijn gestopt met het gebruik van de microfoon. Zachte reset behoudt de beschikbaarheid van de microfoon. Harde modus schakelt HFP systeembreed uit om hoogwaardige A2DP-stereoweergave af te dwingen. Herstellen zet de vorige Windows-serviceconfiguratie terug.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Voegt 30 interface-talen toe met slimme Windows-taaldetectie en een volledig talenkeuzemenu. Verbetert multilingual console-tabeluitlijning. Voegt gelokaliseerde WinGet-metadata toe voor elke ondersteunde taal.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Service-veranderende modi vereisen Administrator. Begin met Zachte reset om de microfoon van de Bluetooth-headset te behouden; Harde modus schakelt HFP systeembreed uit.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pl-PL.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pl-PL.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: pl-PL
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Naprawia niską jakość dźwięku w zestawach słuchawkowych Bluetooth w systemie Windows 11 poprzez zresetowanie lub wyłączenie trybu połączeń Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle naprawia słuchawki Bluetooth i zestawy słuchawkowe do gier utkwione w trybie połączenia niskiej jakości Hands-Free (HFP) po zakończeniu korzystania z mikrofonu w grach takich jak Call of Duty, czatach głosowych, przeglądarkach lub aplikacjach do nagrywania. Miękki reset zachowuje dostępność mikrofonu. Tryb wymuszony wyłącza HFP w całym systemie, aby wymusić odtwarzanie stereo wysokiej jakości A2DP. Opcja Przywróć przywraca poprzednią konfigurację usług Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Dodaje 30 języków interfejsu z inteligentnym wykrywaniem języka Windows i pełnym menu wyboru języka. Poprawia wyrównanie tabeli konsoli w wielu językach. Dodaje zlokalizowane metadane WinGet dla każdego obsługiwanego języka.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Tryby zmiany usług wymagają uprawnień Administratora. Uruchom Miękki reset, aby zachować mikrofon zestawu słuchawkowego Bluetooth; Tryb wymuszony wyłącza HFP w całym systemie.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pt-BR.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pt-BR.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: pt-BR
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Corrige o áudio de baixa qualidade de fones de ouvido Bluetooth no Windows 11 redefinindo ou desativando o modo de chamada Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle corrige fones de ouvido Bluetooth e headsets de jogos presos no modo de chamadas de baixa qualidade Hands-Free (HFP) após jogos como Call of Duty, chats de voz, navegadores ou aplicativos de gravação deixarem de usar o microfone. Reinicialização suave preserva a disponibilidade do microfone. Modo rígido desativa o HFP em todo o sistema para forçar a reprodução estéreo de alta qualidade A2DP. Restaurar retorna à configuração anterior do serviço do Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Adiciona 30 idiomas de interface com detecção inteligente de idioma do Windows e um menu completo de seleção de idioma. Melhora o alinhamento da tabela do console multilíngue. Adiciona metadados WinGet localizados para cada idioma suportado.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Modos que alteram o serviço requerem Administrador. Comece com Reinicialização suave para preservar o microfone do fone de ouvido Bluetooth; Modo rígido desativa o HFP em todo o sistema.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pt-PT.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.pt-PT.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: pt-PT
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Corrige o áudio de baixa qualidade de auriculares Bluetooth no Windows 11 ao reiniciar ou desativar o modo de chamada Mão-Livre (HFP).
+Description: BluetoothHandsFreeToggle corrige auscultadores Bluetooth e headsets de jogo presos no modo de chamada Hands-Free (HFP) de baixa qualidade após jogos como Call of Duty, chat de voz, navegadores ou aplicações de gravação deixarem de usar o microfone. Reinício suave preserva a disponibilidade do microfone. Modo rígido desativa o HFP a nível do sistema para forçar a reprodução estéreo de alta qualidade A2DP. Restaurar devolve a configuração anterior do serviço do Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Adiciona 30 idiomas de interface com deteção inteligente de idioma do Windows e um menu completo de seleção de idioma. Melhora o alinhamento da tabela da consola multilingue. Adiciona metadados WinGet localizados para cada idioma suportado.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Os modos de alteração de serviço exigem Administrador. Comece com Reinício suave para preservar o microfone do auscultador Bluetooth; Modo rígido desativa o HFP em todo o sistema.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ro-RO.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ro-RO.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: ro-RO
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Remediază calitatea scăzută a sunetului la headset-urile Bluetooth în Windows 11 prin resetarea sau dezactivarea modului de apel Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle remediază problemele cu căștile Bluetooth și seturile de căști pentru jocuri blocate în modul de apel Hands-Free (HFP) de calitate scăzută după ce jocuri precum Call of Duty, chat-ul vocal, browserele sau aplicațiile de înregistrare încetează să mai folosească microfonul. Resetare soft păstrează disponibilitatea microfonului. Mod forțat dezactivează HFP la nivel de sistem pentru a forța redarea stereo A2DP de înaltă calitate. Restaurare readuce configurația anterioară a serviciului Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Adaugă 30 de limbi de interfață cu detectare inteligentă a limbii în Windows și un meniu complet de selecție a limbii. Îmbunătățește alinierea tabelelor consolei multilingve. Adaugă metadate WinGet localizate pentru fiecare limbă acceptată.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Modurile care schimbă serviciul necesită Administrator. Începeți cu Resetare soft pentru a păstra microfonul căștii Bluetooth; Mod forțat dezactivează HFP la nivel de sistem.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ru-RU.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.ru-RU.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: ru-RU
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Исправляет низкое качество звука Bluetooth-гарнитуры в Windows 11, сбрасывая или отключая режим звонка Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle исправляет Bluetooth-наушники и игровые гарнитуры, застрявшие в режиме звонка Hands-Free (HFP) с низким качеством после того, как Call of Duty, голосовой чат, браузер или приложение записи перестали использовать микрофон. Мягкий сброс сохраняет доступность микрофона. Жёсткий режим отключает HFP во всей системе, принудительно возвращая качественное стереовоспроизведение A2DP. Восстановление возвращает предыдущую конфигурацию служб Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Добавлены 30 языков интерфейса, умное определение языка Windows и полный список выбора языка. Улучшено выравнивание многоязычных таблиц в консоли. Добавлены локализованные метаданные WinGet для всех поддерживаемых языков.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Для режимов, изменяющих службы, нужны права администратора. Сначала используйте мягкий сброс, чтобы сохранить микрофон Bluetooth-гарнитуры; жёсткий режим отключает HFP во всей системе.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.sv-SE.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.sv-SE.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: sv-SE
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Åtgärdar lågkvalitativ ljud från Bluetooth-headset på Windows 11 genom att återställa eller inaktivera Hands-Free (HFP) samtalsläge.
+Description: BluetoothHandsFreeToggle fixar Bluetooth-hörlurar och gamingheadsets som fastnat i lågkvalitativt Hands-Free (HFP) samtalsläge efter spel som Call of Duty, röstchatt, webbläsare eller inspelningsprogram slutar använda mikrofonen. Mjuk återställning bevarar mikrofontillgängligheten. Hårt läge inaktiverar HFP systemomfattande för att tvinga högkvalitativ A2DP-stereouppspelning. Återställ återställer den tidigare Windows-tjänstkonfigurationen.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Lägger till 30 gränssnittsspråk med smart Windows-språkdetection och en fullständig språkvalmeny. Förbättrar flerspråkig konsoltabelljustering. Lägger till lokaliserad WinGet-metadata för alla stödda språk.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Tjänstförändrande lägen kräver Administratör. Starta med Mjuk återställning för att bevara Bluetooth-headsetets mikrofon; Hårt läge inaktiverar HFP systemomfattande.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.th-TH.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.th-TH.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: th-TH
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: แก้ไขเสียงหูฟังบลูทูธคุณภาพต่ำบน Windows 11 โดยการรีเซ็ตหรือปิดโหมดโทรศัพท์มือถือแบบแฮนด์ฟรี (HFP)
+Description: BluetoothHandsFreeToggle แก้ไขปัญหาหูฟัง Bluetooth และชุดหูฟังเล่นเกมที่ติดอยู่ในโหมดการโทรคุณภาพต่ำ Hands-Free (HFP) หลังจากเกมเช่น Call of Duty การแชทด้วยเสียง เบราว์เซอร์ หรือแอปพลิเคชันบันทึกเสียงหยุดใช้งานไมโครโฟน รีเซ็ตซอฟต์แวร์ รักษาการเข้าถึงไมโครโฟน โหมดฮาร์ด ปิดใช้งาน HFP ทั่วระบบเพื่อบังคับให้เล่นเสียง A2DP สเตอริโอคุณภาพสูง การเรียกคืนจะกลับไปยังการกำหนดค่าบริการ Windows ก่อนหน้านี้
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: เพิ่ม 30 ภาษาสำหรับอินเตอร์เฟซ พร้อมการตรวจจับภาษาของ Windows อย่างชาญฉลาดและเมนูการเลือกภาษาครบถ้วน ปรับปรุงการจัดเรียงตารางคอนโซลหลายภาษา เพิ่มเมทาดาต้า WinGet ที่มีการแปลสำหรับทุกภาษาที่รองรับ
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: โหมดการเปลี่ยนบริการต้องใช้ผู้ดูแลระบบ เริ่มต้นด้วย รีเซ็ตซอฟต์แวร์ เพื่อรักษาไมโครโฟนของหูฟังบลูทูธ; โหมดฮาร์ด ปิดการทำงาน HFP ทั่วทั้งระบบ
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.tr-TR.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.tr-TR.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: tr-TR
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Windows 11'de düşük kaliteli Bluetooth kulaklık sesini, Eller-Serbest (HFP) arama modunu sıfırlayarak veya devre dışı bırakarak düzeltir.
+Description: BluetoothHandsFreeToggle, Call of Duty gibi oyunlar, sesli sohbet, tarayıcılar veya kayıt uygulamaları mikrofon kullanmayı bıraktıktan sonra Bluetooth kulaklıklar ve oyun kulaklıklarının düşük kaliteli Eller Serbest (HFP) arama modunda takılı kalmasını düzeltir. Yazılım sıfırlama mikrofon kullanılabilirliğini korur. Zorunlu mod, yüksek kaliteli A2DP stereo oynatmayı zorlamak için HFP'yi sistem genelinde devre dışı bırakır. Geri Yükle, önceki Windows hizmeti yapılandırmasını geri getirir.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Akıllı Windows dil algılama ve tam dil seçimi menüsü ile 30 arayüz dili ekler. Çok dilli konsol tablo hizalamasını iyileştirir. Desteklenen her dil için yerelleştirilmiş WinGet meta verilerini ekler.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Servis değiştirme modları Yönetici gerektirir. Bluetooth kulaklık mikrofonunu korumak için Yazılım sıfırlama ile başlatın; Zorunlu mod, HFP sistemini genel olarak devre dışı bırakır.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.uk-UA.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.uk-UA.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: uk-UA
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Виправляє низьку якість звуку Bluetooth-гарнітури у Windows 11 шляхом скидання або вимкнення режиму дзвінків Hands-Free (HFP).
+Description: BluetoothHandsFreeToggle виправляє ситуацію, коли Bluetooth-навушники та ігрові гарнітури застрягають у низькоякісному режимі виклику Hands-Free (HFP) після того, як такі ігри, як Call of Duty, голосовий чат, браузери або програми для запису перестають використовувати мікрофон. М'яке скидання зберігає доступність мікрофона. Жорсткий режим вимикає HFP по всій системі, щоб примусово включити високоякісне стерео A2DP. Відновлення повертає попередню конфігурацію служб Windows.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Додає 30 мов інтерфейсу з розумним визначенням мови Windows та повним меню вибору мови. Покращує вирівнювання багатомовних консолей. Додає локалізовані метадані WinGet для кожної підтримуваної мови.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Режими зміни сервісу потребують прав адміністратора. Запустіть з М'яке скидання, щоб зберегти мікрофон Bluetooth-гарнітури; Жорсткий режим відключає HFP по всій системі.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.vi-VN.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.vi-VN.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: vi-VN
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: Sửa âm thanh tai nghe Bluetooth chất lượng kém trên Windows 11 bằng cách đặt lại hoặc tắt chế độ gọi rảnh tay (HFP).
+Description: BluetoothHandsFreeToggle sửa lỗi tai nghe Bluetooth và tai nghe chơi game bị kẹt ở chế độ gọi Chất lượng Thấp (HFP) sau khi các trò chơi như Call of Duty, trò chuyện bằng giọng nói, trình duyệt hoặc ứng dụng ghi âm ngừng sử dụng micro. Khởi động mềm giữ quyền sử dụng micro. Chế độ cưỡng bức vô hiệu hóa HFP trên toàn hệ thống để buộc phát nhạc stereo chất lượng cao A2DP. Khôi phục trả lại cấu hình dịch vụ Windows trước đó.
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: Thêm 30 ngôn ngữ giao diện với khả năng phát hiện ngôn ngữ Windows thông minh và menu chọn ngôn ngữ đầy đủ. Cải thiện căn chỉnh bảng bảng điều khiển đa ngôn ngữ. Thêm siêu dữ liệu WinGet được bản địa hóa cho mọi ngôn ngữ được hỗ trợ.
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: Các chế độ thay đổi dịch vụ yêu cầu quyền Quản trị viên. Bắt đầu với Khởi động mềm để giữ nguyên micro của tai nghe Bluetooth; Chế độ cưỡng bức vô hiệu hóa HFP trên toàn hệ thống.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.zh-CN.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.zh-CN.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: zh-CN
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: 通过重置或禁用免提（HFP）通话模式来修复 Windows 11 上低质量的蓝牙耳机音频。
+Description: BluetoothHandsFreeToggle 修复了在游戏（如 Call of Duty）、语音聊天、浏览器或录音应用停止使用麦克风后，蓝牙耳机和游戏耳机卡在低质量的免提（HFP）通话模式的问题。软重置保留麦克风的可用性。硬模式全系统禁用 HFP，以强制高质量 A2DP 立体声播放。恢复 会恢复先前的 Windows 服务配置。
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: 添加了 30 种界面语言，具有智能 Windows 语言检测和完整的语言选择菜单。改进了多语言控制台表格对齐。为每种支持的语言添加了本地化的 WinGet 元数据。
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: 更改服务模式需要管理员权限。使用软重置可以保留蓝牙耳机麦克风；硬模式则在整个系统范围内禁用 HFP。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.zh-TW.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.locale.zh-TW.yaml
@@ -1,0 +1,33 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+PackageLocale: zh-TW
+Publisher: Olimoff Dev
+PackageName: BluetoothHandsFreeToggle
+License: MIT
+ShortDescription: 透過重置或禁用免提 (HFP) 通話模式，在 Windows 11 上修復低品質的藍牙耳機音訊。
+Description: BluetoothHandsFreeToggle 修復在像 Call of Duty 遊戲、語音聊天、瀏覽器或錄音應用程式停止使用麥克風後，藍牙耳機和遊戲耳機卡在低品質的免提 (HFP) 通話模式的問題。軟重置保留麥克風的可用性。硬模式在系統範圍內禁用 HFP，以強制高品質 A2DP 立體聲播放。還原 可恢復先前的 Windows 服務配置。
+Tags:
+- a2dp
+- bluetooth
+- bluetooth-audio
+- bluetooth-audio-fix
+- bluetooth-hands-free
+- bluetooth-headset
+- call-mode
+- call-of-duty
+- gaming-audio-fix
+- gaming-headset
+- hands-free
+- headset-microphone
+- hfp
+- low-quality-audio
+- stereo-audio
+- windows-11
+ReleaseNotes: 新增 30 種介面語言，具備智能 Windows 語言檢測和完整語言選擇選單。改善多語言控制台表格對齊。為所有支援的語言新增 WinGet 本地化元資料。
+ReleaseNotesUrl: https://github.com/Avazbek22/BluetoothHandsFreeToggle/releases/tag/v2.2
+InstallationNotes: 變更服務模式需要管理員權限。請從軟重置開始以保留藍牙耳機麥克風；硬模式則會在整個系統中停用 HFP。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.yaml
+++ b/manifests/o/OlimoffDev/BluetoothHandsFreeToggle/2.2.0.0/OlimoffDev.BluetoothHandsFreeToggle.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OlimoffDev.BluetoothHandsFreeToggle
+PackageVersion: 2.2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates OlimoffDev.BluetoothHandsFreeToggle from 2.0.0.0 to 2.2.0.0.

- Adds x64 and ARM64 portable installers from the published v2.2 release.
- Adds localized package metadata for all 30 languages supported by the application.
- Updates descriptions, release notes, and search tags for Bluetooth headset, HFP, A2DP, and gaming-audio use cases.

## Validation

- Confirmed there is no other open pull request for this package version.
- Validated the complete manifest set with winget validate.
- Verified the published installer sizes and SHA-256 digests against the manifest.