### PR TITLE
Update: maze-mei.DXManager to 2.0.1

### DIFF
--- a/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.installer.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.1
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: install
+Commands:
+- dxmanager
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: DX Manager\DXManager.exe
+  PortableCommandAlias: dxmanager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/maze-mei/DX-Manager/releases/download/v2.0.1/DX-Manager-v2.0.1-win-x64.zip
+  InstallerSha256: 5F9C5A6AF6199D38458F6266869DDBACC58722A3A915696FF02935CF8965B2C1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.locale.en-US.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.1
+PackageLocale: en-US
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v2.0.1/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Manage Samsung DeX virtual displays and scrcpy app windows on Windows.
+Description: DX Manager creates and manages Samsung DeX virtual displays and separately configured Android app windows for multiple Galaxy phones over USB or wireless ADB. It also includes DX Companion for recovery and bidirectional file transfer.
+Moniker: dxmanager
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v2.0.1
+InstallationNotes: DX Manager requires .NET Framework 4.6.2 or later, Android Developer options, and USB debugging. Initial ADB authorization requires a data-capable USB connection. DX Companion is bundled but is installed only when the user requests it.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.locale.ko-KR.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.locale.ko-KR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.1
+PackageLocale: ko-KR
+Publisher: maze-mei
+PublisherUrl: https://github.com/maze-mei
+PublisherSupportUrl: https://github.com/maze-mei/DX-Manager/issues
+Author: maze
+PackageName: DX Manager
+PackageUrl: https://github.com/maze-mei/DX-Manager
+License: MIT
+LicenseUrl: https://github.com/maze-mei/DX-Manager/blob/v2.0.1/LICENSE
+Copyright: Copyright (c) 2026 maze
+ShortDescription: Windows에서 Samsung DeX 가상 디스플레이와 scrcpy 앱 창을 관리합니다.
+Description: DX Manager는 여러 Galaxy 휴대폰의 Samsung DeX 가상 디스플레이와 서로 다르게 설정한 Android 앱 창을 USB 또는 무선 ADB로 동시에 관리합니다. 복구와 양방향 파일 전송을 위한 DX Companion도 포함합니다.
+Tags:
+- adb
+- android
+- samsung-dex
+- screen-mirroring
+- scrcpy
+- wireless-adb
+ReleaseNotesUrl: https://github.com/maze-mei/DX-Manager/releases/tag/v2.0.1
+InstallationNotes: DX Manager를 사용하려면 .NET Framework 4.6.2 이상, Android 개발자 옵션, USB 디버깅이 필요합니다. 최초 ADB 인증에는 데이터 통신이 가능한 USB 연결이 필요합니다. DX Companion은 번들에 포함되지만 사용자가 요청할 때만 설치됩니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.yaml
+++ b/manifests/m/maze-mei/DXManager/2.0.1/maze-mei.DXManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: maze-mei.DXManager
+PackageVersion: 2.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates DX Manager from 2.0.0 to 2.0.1.

This maintenance release fixes DeX settings controls not refreshing their displayed values after changes. The settings were saved and applied correctly; the issue was limited to the displayed values.

Local validation result: `winget validate --manifest manifests/m/maze-mei/DXManager/2.0.1` succeeded.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest update
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The local install test was not run to avoid modifying the existing installed copy. The release asset URL and SHA-256 digest were verified against the published GitHub Release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422924)