### PR TITLE
New package: LokeshGovindu.PasteJump version 2026.1.0.229

### DIFF
--- a/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.installer.yaml
+++ b/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+# The portable ZIP, not the unpacked one and not the framework-dependent one. winget installs into its own
+# per-user directory and adds an alias, so the fast-start argument for the unpacked shape does not apply
+# here, and the net10 shape would add a runtime prerequisite for no benefit.
+PackageIdentifier: LokeshGovindu.PasteJump
+PackageVersion: 2026.1.0.229
+MinimumOSVersion: 10.0.14393.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  # Verified against the real archive rather than assumed: pack-release.ps1 calls Compress-Archive on the
+  # staging DIRECTORY, so every archive carries a top-level folder named after itself. Getting this path
+  # wrong is not a validation error - it is an install that succeeds and produces no working command.
+  - RelativeFilePath: PasteJump-2026.1.0.229-win-x64\PasteJump.exe
+    PortableCommandAlias: pastejump
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/lokeshgovindu/PasteJump/releases/download/2026.1/PasteJump-2026.1.0.229-win-x64.zip
+    InstallerSha256: 33BA0351DD8B8CB6C00BA2FE64362EA210CC3FB9BB19E5F6A976E05F33569940
+ReleaseDate: 2026-08-23
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.locale.en-US.yaml
+++ b/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: LokeshGovindu.PasteJump
+PackageVersion: 2026.1.0.229
+PackageLocale: en-US
+Publisher: Lokesh Govindu
+PublisherUrl: https://lokeshgovindu.github.io/
+PublisherSupportUrl: https://github.com/lokeshgovindu/PasteJump/issues
+Author: Lokesh Govindu
+PackageName: PasteJump
+PackageUrl: https://lokeshgovindu.github.io/PasteJump/
+License: MIT
+LicenseUrl: https://github.com/lokeshgovindu/PasteJump/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Lokesh Govindu
+CopyrightUrl: https://github.com/lokeshgovindu/PasteJump/blob/master/LICENSE
+ShortDescription: Keyboard-driven multiple-clipboard manager. Hold Ctrl, tap V to walk back through what you copied, release to paste.
+Description: |-
+  PasteJump keeps everything you copy - text with all its clipboard formats, images and file lists - in a
+  searchable store, and puts the clip you want under the cursor without a window or a mouse.
+
+  Hold Ctrl and tap V to step back through the clip stack, with a small overlay showing what is about to be
+  pasted; release Ctrl and it pastes. Press F mid-gesture to search the stack, pin the clips you reach for,
+  filter by kind, or mark several and paste them joined. A history window gives full-text search over
+  everything you have copied, with image previews.
+
+  Every clipboard format is kept, so a paste into Word or Excel arrives as it left. Nineteen themes ship, and
+  a theme is a small file of named colours you can write yourself. Nothing is sent anywhere: the only network
+  access is the update check, and only when you ask for it.
+
+  PasteJump is a ground-up reimplementation of Avi Aryan's Clipjump, written from observed behaviour, in C#
+  on .NET 10. The builds are not signed with a paid certificate.
+Moniker: pastejump
+Tags:
+  - clipboard
+  - clipboard-history
+  - clipboard-manager
+  - clipjump
+  - copy-paste
+  - keyboard
+  - paste
+  - portable
+  - productivity
+  - tray
+ReleaseNotesUrl: https://github.com/lokeshgovindu/PasteJump/releases/tag/2026.1
+Documentations:
+  - DocumentLabel: Manual
+    DocumentUrl: https://lokeshgovindu.github.io/PasteJump/help/overview.html
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.yaml
+++ b/manifests/l/LokeshGovindu/PasteJump/2026.1.0.229/LokeshGovindu.PasteJump.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: LokeshGovindu.PasteJump
+PackageVersion: 2026.1.0.229
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: **LokeshGovindu.PasteJump** version **2026.1.0.229**

PasteJump is a keyboard-driven multiple-clipboard manager for Windows: hold <kbd>Ctrl</kbd>, tap <kbd>V</kbd> to walk back through what you have copied, release to paste. MIT-licensed, open source, and I am its author.

- Homepage: https://lokeshgovindu.github.io/PasteJump/
- Repository: https://github.com/lokeshgovindu/PasteJump
- Release: https://github.com/lokeshgovindu/PasteJump/releases/tag/2026.1

### Manifest notes

- **Portable, installed from the ZIP.** `InstallerType: zip` with `NestedInstallerType: portable` and a `pastejump` command alias. The project also ships an unpacked archive and a framework-dependent one; the single-file portable archive is the right shape here, since winget installs into its own directory and the framework-dependent build would add a .NET runtime prerequisite.
- **`RelativeFilePath` was read out of the published archive**, not assumed: the archive carries a top-level folder named after itself, so the path is `PasteJump-2026.1.0.229-win-x64\PasteJump.exe`.
- **`InstallerSha256` matches the hash published in the release notes**, verified by downloading the asset and re-hashing it: `33BA0351DD8B8CB6C00BA2FE64362EA210CC3FB9BB19E5F6A976E05F33569940`.
- `MinimumOSVersion: 10.0.14393.0` — Windows 10 1607, x64 only, which is the real floor for the .NET 10 build.
- `winget validate --manifest` passes locally.

### One thing worth knowing before you test it

The release is **not signed with a code-signing certificate**, so SmartScreen reports an unknown publisher on a first run. That is deliberate on the project's side rather than an oversight — a self-signed certificate that fails validation looks worse than none — and a SHA256 for every file is published with each release instead.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422927)