### PR TITLE
New version: Netpack.XFB version 3.1421

### DIFF
--- a/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.installer.yaml
+++ b/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1421"
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1421/XFB-3.1421-Setup.exe
+  InstallerSha256: 1B8819D027CED94D4D15000D4CF0F08A041E28C1462337FD55F852DF69E44193
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (x64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+- Architecture: arm64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1421/XFB-3.1421-arm64-Setup.exe
+  InstallerSha256: EDF217D70816B876D7E200F069AFAD8563193D8A96587D9204F25D8B86053ED3
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (arm64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.locale.en-US.yaml
+++ b/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1421"
+PackageLocale: en-US
+Publisher: Netpack - Online Solutions
+PublisherUrl: https://netpack.pt/
+PublisherSupportUrl: https://github.com/netpack/XFB/issues
+Author: Frédéric Bogaerts
+PackageName: XFB
+PackageUrl: https://github.com/netpack/XFB
+License: GPL-3.0
+LicenseUrl: https://github.com/netpack/XFB/blob/main/LICENSE
+ShortDescription: Open-source radio automation software
+Description: |-
+  XFB is an open-source radio automation suite for broadcasters. It provides
+  scheduled playlists, jingles and advertising rotation, a live audio FX
+  engine (10-band equalizer, compressor, 432 Hz retune), DJ decks with
+  scratchable jog wheels, an Icecast/Shoutcast streaming client, playlist
+  waveform views with crossfade preparation and volume automation, and
+  comprehensive accessibility support including screen-reader integration
+  and full keyboard navigation.
+Moniker: xfb
+Tags:
+- accessibility
+- audio
+- automation
+- broadcast
+- open-source
+- radio
+ReleaseNotesUrl: https://github.com/netpack/XFB/releases/tag/v3.1421
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.yaml
+++ b/manifests/n/Netpack/XFB/3.1421/Netpack.XFB.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1421"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Update: Netpack.XFB version 3.1421

Adds version 3.1421 of XFB, an open-source radio automation application.

- Both installers are published on the GitHub release for `v3.1421` and the `InstallerSha256` values were taken from GitHub's own recorded digests for those assets.
- Release notes: https://github.com/netpack/XFB/releases/tag/v3.1421

#### Checklists

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.10.0)?

The two unchecked boxes are deliberate: these manifests were prepared on macOS, where `winget` does not exist, so neither `winget validate` nor `winget install` could honestly be attested to.

#### Note for maintainers

https://github.com/microsoft/winget-pkgs/pull/422725 removes `3.14159265358`, which is still present and which winget ranks above every rounded version this package has published since. Until it merges, `winget upgrade` will keep moving XFB users backwards to it rather than forwards to this release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422937)