### PR TITLE
New package: rugbedbugg.resonanceid-cli version 1.0.0

### DIFF
--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: rugbedbugg.resonanceid-cli
 PackageVersion: 1.0.0
 InstallerType: portable
@@ -7,6 +7,6 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/rugbedbugg/ResonanceID-cli/releases/download/v1.0.0/resonanceid-cli-v1.0.0-x86_64-pc-windows-msvc.exe
-    InstallerSha256: 934F1BCA6A2508CD7179F7BAA711776D045E0D5B751728A2F9F04C9D103D7BB4
+    InstallerSha256: 06737C076C702D9B14E451469E49BFEAEA107A60B3AFAA50B14570A97F2DF127
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: rugbedbugg.resonanceid-cli
+PackageVersion: 1.0.0
+InstallerType: portable
+Commands:
+  - resonanceid-cli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rugbedbugg/ResonanceID-cli/releases/download/v1.0.0/resonanceid-cli-v1.0.0-x86_64-pc-windows-msvc.exe
+    InstallerSha256: 934F1BCA6A2508CD7179F7BAA711776D045E0D5B751728A2F9F04C9D103D7BB4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.installer.yaml
@@ -7,6 +7,6 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/rugbedbugg/ResonanceID-cli/releases/download/v1.0.0/resonanceid-cli-v1.0.0-x86_64-pc-windows-msvc.exe
-    InstallerSha256: 06737C076C702D9B14E451469E49BFEAEA107A60B3AFAA50B14570A97F2DF127
+    InstallerSha256: 0B3CDE620A8E8FAF3B9BC94A20BC51B4C2DD58F558E774E0D1E292081D924F7D
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.locale.en-US.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: rugbedbugg.resonanceid-cli
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: rugbedbugg
+PublisherUrl: https://github.com/rugbedbugg
+PublisherSupportUrl: https://github.com/rugbedbugg/ResonanceID-cli/issues
+PackageName: resonanceid-cli
+PackageUrl: https://github.com/rugbedbugg/ResonanceID-cli
+License: MIT
+LicenseUrl: https://github.com/rugbedbugg/ResonanceID-cli/blob/main/LICENSE
+Copyright: (c) 2026 Partha Pratim Gogoi
+ShortDescription: Shazam-style audio fingerprinting CLI that identifies songs from song clips
+Description: >-
+  ResonanceID-cli is a Rust-based audio fingerprinting CLI inspired by
+  Shazam-style matching. It stores reference tracks as hashed spectral
+  fingerprints in a local SQLite database, then identifies unknown clips or
+  microphone input by voting on the timing offset where the most fingerprints
+  agree. It supports folder-wide import with automatic ffmpeg conversion.
+Moniker: resonanceid-cli
+Tags:
+  - audio
+  - music
+  - shazam
+  - fingerprinting
+  - recognition
+  - cli
+  - rust
+ReleaseNotesUrl: https://github.com/rugbedbugg/ResonanceID-cli/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.locale.en-US.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: rugbedbugg.resonanceid-cli
 PackageVersion: 1.0.0
 PackageLocale: en-US
@@ -28,4 +28,4 @@ Tags:
   - rust
 ReleaseNotesUrl: https://github.com/rugbedbugg/ResonanceID-cli/releases/tag/v1.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: rugbedbugg.resonanceid-cli
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.yaml
+++ b/manifests/r/rugbedbugg/resonanceid-cli/1.0.0/rugbedbugg.resonanceid-cli.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: rugbedbugg.resonanceid-cli
 PackageVersion: 1.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This is a new package submission for resonanceid-cli v1.0.0, a Shazam-style audio fingerprinting CLI written in Rust.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there is not already a package for this program in the repository?
- [x] Have you followed the [manifest authoring guidelines](https://github.com/microsoft/winget-pkgs/blob/master/Authoring.md)?
- [x] Have you validated the manifest with `winget validate`?
- [x] Have you tested the package locally with `winget install`?

The installer is a single portable exe published on the GitHub release: https://github.com/rugbedbugg/ResonanceID-cli/releases/tag/v1.0.0 (verified working via `--help` before upload). The SHA256 in the installer manifest was computed from that exact artifact.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/422982)