### PR TITLE
Update version: Snesnopic.Flacoutcpp version 1.4.0

### DIFF
--- a/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.installer.yaml
+++ b/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Snesnopic.Flacoutcpp
+PackageVersion: 1.4.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Release/flacoutcpp.exe
+  PortableCommandAlias: flacoutcpp
+ReleaseDate: 2026-08-15
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Snesnopic/flacoutcpp/releases/download/v1.4.0/flacoutcpp-windows-x64.zip
+  InstallerSha256: D0D7000E5F3C3ABF88F16DF07FAEAB0295123D6FFA246D2D09E8E7EB7449E1D7
+- Architecture: x86
+  InstallerUrl: https://github.com/Snesnopic/flacoutcpp/releases/download/v1.4.0/flacoutcpp-windows-x86.zip
+  InstallerSha256: 7C49E75E9A51AF034896239AB3C08662FAFE13E47428572A7607EBB5405864B9
+- Architecture: arm64
+  InstallerUrl: https://github.com/Snesnopic/flacoutcpp/releases/download/v1.4.0/flacoutcpp-windows-arm64.zip
+  InstallerSha256: 2CBF3A1785F0E054443DE8A1FD3C1A8CEC7D14CCA03CADF662F16F82848B95C5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.locale.en-US.yaml
+++ b/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Snesnopic.Flacoutcpp
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Snesnopic
+PublisherUrl: https://github.com/Snesnopic
+PublisherSupportUrl: https://github.com/Snesnopic/flacoutcpp/issues
+PackageName: Flacoutcpp
+PackageUrl: https://github.com/Snesnopic/flacoutcpp
+License: MIT
+ShortDescription: Recompress FLAC files to the smallest possible
+Tags:
+- cli
+- compression
+- cpp
+- recompression
+- windows
+ReleaseNotesUrl: https://github.com/Snesnopic/flacoutcpp/releases/tag/v1.4.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Snesnopic/flacoutcpp/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.yaml
+++ b/manifests/s/Snesnopic/Flacoutcpp/1.4.0/Snesnopic.Flacoutcpp.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Snesnopic.Flacoutcpp
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Snesnopic.Flacoutcpp to version 1.4.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423030)