### PR TITLE
New version: Joedsonalves.Vacuon version 0.5.0

### DIFF
--- a/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.installer.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.installer.yaml
@@ -1,0 +1,15 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.5.0
+MinimumOSVersion: 10.0.19044.0
+InstallerType: portable
+Commands:
+- vacuon
+ReleaseDate: 2026-08-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/joedsonalves/vacuon/releases/download/v0.5.0/Vacuon-0.5.0-win-x64.exe
+  InstallerSha256: 1A17D039E055571CF058FA1F894E3E4630134A9057E36FED0EC690B557031AE8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.locale.en-US.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.locale.en-US.yaml
@@ -1,0 +1,57 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Joedson Alves
+PublisherUrl: https://github.com/joedsonalves
+PublisherSupportUrl: https://github.com/joedsonalves/vacuon/issues
+PackageName: Vacuon
+PackageUrl: https://github.com/joedsonalves/vacuon
+License: MIT
+LicenseUrl: https://github.com/joedsonalves/vacuon/blob/main/LICENSE
+ShortDescription: Disk space analyzer that reads the NTFS MFT directly and shows what it is about to delete.
+Description: |-
+  Vacuon finds where the space on a Windows disk went. It reads the NTFS Master File
+  Table straight off the volume, which indexes a million files in seconds instead of
+  minutes, and falls back to the Windows API on volumes where that is not possible.
+
+  Images and videos are shown as thumbnails in six sizes, so you can tell which of five
+  large renders is the final one without opening any of them. Deletion goes to the Recycle
+  Bin by default, and permanently only behind a confirmation you have to tick, with a
+  protection list that refuses the volume root, Windows, System32 and kernel-owned files.
+
+  It also finds files with identical content, draws the volume as a treemap where every
+  box is sized by what it occupies, and can set files aside in a quarantine it can restore
+  them from, instead of deleting them.
+
+  It cleans by rule as well, and where the work belongs inside Windows it calls Microsoft's
+  own tools rather than deleting files by hand. A live monitor reads the NTFS change journal
+  and shows which folders are growing right now. Pictures that look alike are grouped by a
+  perceptual fingerprint, and a preview panel shows media details, text and images without
+  leaving the app.
+
+  Every scan cross-checks the space it attributed to files against what the volume reports
+  as used, and says so when the two disagree.
+
+  The interface is available in English and Portuguese. The fast path needs Administrator;
+  without it the app still works through the slower traversal and says which one it used.
+Moniker: vacuon
+Tags:
+- disk
+- disk-analyzer
+- disk-cleanup
+- disk-space
+- disk-usage
+- duplicate-finder
+- mft
+- ntfs
+- similar-images
+- storage
+- treemap
+ReleaseNotesUrl: https://github.com/joedsonalves/vacuon/releases/tag/v0.5.0
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/joedsonalves/vacuon/blob/main/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
@@ -1,0 +1,36 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.5.0
+PackageLocale: pt-BR
+Publisher: Joedson Alves
+PackageName: Vacuon
+License: MIT
+ShortDescription: Analisador de espaco em disco que le a MFT do NTFS direto e mostra o que voce esta apagando.
+Description: |-
+  O Vacuon encontra para onde foi o espaco de um disco no Windows. Ele le a Master File
+  Table do NTFS direto do volume, o que indexa um milhao de arquivos em segundos em vez de
+  minutos, e cai para a API do Windows nos volumes onde isso nao e possivel.
+
+  Imagens e videos aparecem como miniaturas em seis tamanhos, para voce saber qual de cinco
+  renderizacoes grandes e a final sem abrir nenhuma. A exclusao vai para a Lixeira por
+  padrao, e definitiva so atras de uma confirmacao que voce precisa marcar, com uma lista
+  de protecao que recusa a raiz do volume, Windows, System32 e arquivos do kernel.
+
+  Ele tambem acha arquivos com conteudo identico, desenha o volume como um treemap onde
+  cada caixa tem o tamanho do que ocupa, e guarda arquivos numa quarentena de onde da para
+  restaurar, em vez de apagar de uma vez.
+
+  Limpa por regra tambem, e onde o trabalho fica dentro do Windows chama as ferramentas da
+  propria Microsoft em vez de apagar arquivo na mao. Um monitor ao vivo le o diario de
+  mudancas do NTFS e mostra quais pastas estao crescendo agora. Imagens parecidas sao
+  agrupadas por uma impressao perceptual, e um painel de previa mostra ficha tecnica de
+  midia, texto e imagem sem sair do app.
+
+  Toda varredura confere o espaco atribuido a arquivos contra o que o volume declara em uso,
+  e avisa quando os dois nao batem.
+
+  Interface em ingles e portugues. O caminho rapido exige Administrador; sem ele o app
+  funciona pela travessia mais lenta e diz qual dos dois usou.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.5.0/Joedsonalves.Vacuon.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Version update: **Joedsonalves.Vacuon** from **0.4.0** to **0.5.0**.

Vacuon is a disk space analyzer for Windows. It reads the NTFS Master File Table directly to index a volume in seconds, shows thumbnails of images and videos so you can see what you are about to delete, and deletes to the Recycle Bin by default.

- Repository: https://github.com/joedsonalves/vacuon
- Release: https://github.com/joedsonalves/vacuon/releases/tag/v0.5.0
- Licence: MIT
- `InstallerType: portable` — a single self-contained executable, no installer.

The publisher is the repository owner; the installer is served from that repository's own release assets.

### What changed from 0.4.0

- `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and `ReleaseNotesUrl`.
- **`Tags`: `disk-cleanup` and `similar-images` added.** Both name features that did not exist in 0.4.0 and ship in 0.5.0 — cleanup by rule, and grouping pictures that look alike by a perceptual fingerprint. This is the same rule that removed `duplicate-finder` in 0.3.2 and restored it in 0.4.0, applied the other way round: a tag is a claim, and a claim that became true may be made. Eleven tags total, against a cap of 16.
- **One paragraph added to `Description`** in both locales, covering what this release adds. Every existing paragraph is byte-for-byte unchanged from the wording that has already passed validation three times.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### What was verified

- `winget validate --manifest` passes with **no warnings**.
- **`winget install --manifest` was run against this manifest**, on Windows 11, in a non-elevated session, and completed successfully. This is a change from the last two submissions, and worth spelling out because both carried a caveat here:
  - For **0.3.2** the install was tested against a **loopback HTTP server**, because the release did not exist yet at the time of testing, and the PR said so.
  - For **0.4.0** the box was left **unticked**, because that install was not re-run for that version.
  - For **0.5.0** the release was published *before* this PR was opened, so `winget install --manifest` ran against the real `InstallerUrl` in this manifest, downloading the actual published asset. No caveat this time.
- **The `InstallerSha256` was checked against what winget actually downloads**, twice over: the published asset was fetched from the `InstallerUrl` in this manifest and hashed independently, and the file winget itself placed on disk after the install was hashed as well. Both are `1A17D039E055571CF058FA1F894E3E4630134A9057E36FED0EC690B557031AE8`, matching the manifest.
- The executable was verified to run **standalone**, copied on its own into an empty directory outside its build tree, since a portable package has nothing else beside it. The command-line build from the same source and commit reports `Vacuon 0.5.0`.

Happy to fix anything the review turns up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423046)