### PR TITLE
New package: BlazAlgoSystems.MarkMyVODLite version 1.0.0

### DIFF
--- a/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.installer.yaml
+++ b/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BlazAlgoSystems.MarkMyVODLite
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+UpgradeBehavior: uninstallPrevious
+Commands:
+  - markmyvodlite
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jblaz6335/markmyvod-lite/releases/download/v1.0.0/MarkMyVOD-Lite-1.0-Windows-Final.zip
+    InstallerSha256: 7E904DAF0BAFEB1D60B08A3D9A93A03A501F9A67B6291FEB0DBF054EA2384EA6
+    NestedInstallerFiles:
+      - RelativeFilePath: MarkMyVOD Lite 1.0\MarkMyVODLite.exe
+        PortableCommandAlias: markmyvodlite
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.locale.en-US.yaml
+++ b/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BlazAlgoSystems.MarkMyVODLite
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Blaz Algo Systems
+PublisherUrl: https://blazalgosystems.netlify.app/
+PublisherSupportUrl: https://github.com/jblaz6335/markmyvod-lite/issues
+Author: Joshua Hernandez
+PackageName: MarkMyVOD Lite
+PackageUrl: https://github.com/jblaz6335/markmyvod-lite
+License: Freeware
+LicenseUrl: https://github.com/jblaz6335/markmyvod-lite/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Blaz Algo Systems. All rights reserved.
+ShortDescription: Local Windows hotkey tool for marking stream highlights and exporting editor-ready timestamps.
+Description: MarkMyVOD Lite is a free local Windows tool for marking important moments while recording or streaming. It supports a global Ctrl+Shift+M hotkey, notes, editable timestamps, local session save and restore, CSV export, and YouTube chapter export. It requires no account and contains no advertising or telemetry.
+Moniker: markmyvodlite
+Tags:
+  - chapters
+  - clipping
+  - editing
+  - highlights
+  - markers
+  - streaming
+  - timestamps
+  - video
+ReleaseNotes: Initial release of MarkMyVOD Lite with up to 10 markers per session, local session files, CSV export, and YouTube chapter export.
+ReleaseNotesUrl: https://github.com/jblaz6335/markmyvod-lite/releases/tag/v1.0.0
+ReleaseDate: 2026-08-23
+InstallationNotes: Run markmyvodlite from Windows Terminal, PowerShell, Command Prompt, or the Windows Run dialog. Windows may show an unknown-publisher warning because this independent build is not code-signed.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.yaml
+++ b/manifests/b/BlazAlgoSystems/MarkMyVODLite/1.0.0/BlazAlgoSystems.MarkMyVODLite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BlazAlgoSystems.MarkMyVODLite
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the initial WinGet manifest for MarkMyVOD Lite 1.0.0, a portable x64 Windows tool for marking stream highlights and exporting CSV or YouTube chapter timestamps locally.

The manifest uses the publisher's version-specific GitHub release ZIP and exact SHA-256 checksum. The archive contains one nested portable executable and exposes the `markmyvodlite` command alias.

## Checklist

- [ ] Signed the Contributor License Agreement
- [x] Linked to an issue if applicable. A routine new manifest submission does not require a separate issue.

## Manifest Checklist

- [x] Checked that there are no other open pull requests for this package or version
- [x] This pull request modifies one package version only
- [x] Validated locally with `winget validate --manifest`, with no warnings
- [ ] Tested installation locally. Manifest installation requires administrator privileges to enable `LocalManifestFiles` on this machine. The release ZIP, x64 PE architecture, SHA-256 checksum, archive path, and executable presence were independently verified.
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423074)