### PR TITLE
New package: ZUBOLAND.UNICREW version 0.2.50

### DIFF
--- a/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.installer.yaml
+++ b/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.UNICREW
+PackageVersion: 0.2.50
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: UNICREW
+ReleaseDate: 2026-08-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/takayukiyukii-commits/unicrew/releases/download/v0.2.50/UNICREW_0.2.50_x64-setup.exe
+  InstallerSha256: 71EBA7F1EFE6523B275C0897F96807F2D902B574DFE54678EA4C9ADE7585CE77
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.locale.en-US.yaml
+++ b/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.UNICREW
+PackageVersion: 0.2.50
+PackageLocale: en-US
+Publisher: ZUBOLAND Inc.
+PublisherUrl: https://zuboland.jp
+PublisherSupportUrl: https://github.com/takayukiyukii-commits/unicrew/issues
+PrivacyUrl: https://github.com/takayukiyukii-commits/unicrew/blob/main/PRIVACY.md
+Author: ZUBOLAND Inc.
+PackageName: UNICREW
+PackageUrl: https://zuboland.jp/products/unicrew
+License: Apache-2.0
+LicenseUrl: https://github.com/takayukiyukii-commits/unicrew/blob/main/LICENSE
+Copyright: Copyright (c) 2026 ZUBOLAND Inc.
+ShortDescription: A desktop launcher for running several AI coding agents side by side.
+Description: |-
+  UNICREW is a desktop app for running AI coding agents. It does not try to be an editor:
+  it starts sessions, runs several of them at once, and lets you switch between them.
+  It drives the vendors' own command line tools, so you keep using whatever plan or API key
+  you already have.
+  Claude, Codex, Gemini, Goose, OpenCode, Codex-ACP, Kiro, Qwen and Kimi are supported through
+  one interface, and it speaks the Agent Client Protocol (ACP) so further agents can be added.
+  Two agents can be run in parallel to compare their answers, or given roles so they review
+  each other. A setup helper can install Ollama and OpenCode locally if you would rather not
+  use an API key at all.
+  Free to use, Apache-2.0. Windows, macOS and Linux.
+Tags:
+- acp
+- agent
+- ai
+- claude
+- cli
+- developer-tools
+- llm
+- ollama
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/takayukiyukii-commits/unicrew#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.locale.ja-JP.yaml
+++ b/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.locale.ja-JP.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.UNICREW
+PackageVersion: 0.2.50
+PackageLocale: ja-JP
+Publisher: ZUBOLAND株式会社
+PublisherUrl: https://zuboland.jp
+PublisherSupportUrl: https://github.com/takayukiyukii-commits/unicrew/issues
+PrivacyUrl: https://github.com/takayukiyukii-commits/unicrew/blob/main/PRIVACY.md
+Author: ZUBOLAND株式会社
+PackageName: UNICREW
+PackageUrl: https://zuboland.jp/products/unicrew
+License: Apache-2.0
+LicenseUrl: https://github.com/takayukiyukii-commits/unicrew/blob/main/LICENSE
+Copyright: Copyright (c) 2026 ZUBOLAND株式会社
+ShortDescription: 複数のAIコーディングエージェントを並べて動かすデスクトップアプリ。
+Description: |-
+  UNICREWは、AIを動かすことに特化したデスクトップアプリです。エディタにはなりません。
+  セッションを起動し、複数を同時に走らせ、切り替えるところを受け持ちます。
+  各社のコマンドラインツールをそのまま動かすので、いま持っているプランやAPIキーを使えます。
+  Claude / Codex / Gemini / Goose / OpenCode / Codex-ACP / Kiro / Qwen / Kimi を同じ画面から
+  扱え、ACP（Agent Client Protocol）に対応しているので、あとからエージェントを足せます。
+  2社以上を並列で走らせて回答を見比べたり、役割を与えて相互にレビューさせたりできます。
+  APIキーを使いたくない場合は、OllamaとOpenCodeをローカルに自動導入する手順も用意しています。
+  無料・Apache-2.0。Windows / macOS / Linux 対応。
+Tags:
+- ai
+- エージェント
+- 開発ツール
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.yaml
+++ b/manifests/z/ZUBOLAND/UNICREW/0.2.50/ZUBOLAND.UNICREW.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.UNICREW
+PackageVersion: 0.2.50
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `ZUBOLAND.UNICREW` version `0.2.50`.

UNICREW is a desktop launcher for running several AI coding agents (Claude, Codex, Gemini,
Goose, OpenCode, Kiro, Qwen, Kimi) side by side. It is free and Apache-2.0 licensed, and is
distributed from our own GitHub Releases.

- Homepage: https://zuboland.jp/products/unicrew
- Source & releases: https://github.com/takayukiyukii-commits/unicrew (Apache-2.0)
- Installer: our own release location (publisher's GitHub Releases), per policy 1.1.4
- Authenticode signed as `CN=ZUBOLAND株式会社`
  (issuer: `Microsoft ID Verified CS EOC CA 04`, via Microsoft Artifact Signing, RSA)
- Tauri v2 NSIS installer, `installMode: currentUser`, so `Scope: user`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
      (agreed on #423057 as ZUBOLAND株式会社)
- [ ] Linked to an issue (if applicable) — n/a, new package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (winget 1.29.290 — validation succeeded)
- [ ] Tested manifest locally with `winget install --manifest <path>`
      — **not done, and I would rather say so than tick the box.** Windows Sandbox is not
      available on the edition of Windows on our build machine, and the only other Windows
      machine here is in daily use. The values that a local install would have confirmed were
      instead derived from the Tauri NSIS template at the exact version used to build this
      release (`tauri-v2.11.1`), see below.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### How the installer values were verified

| Value | How it was established |
|---|---|
| `InstallerSha256` | computed from the published asset downloaded over HTTPS |
| `Scope: user` | `bundle.windows.nsis.installMode = "currentUser"` in `tauri.conf.json` |
| `ProductCode: UNICREW` | `tauri-v2.11.1` `installer.nsi`: `!define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"`, and `productName` is `UNICREW` |
| silent install does not launch the app | same template, `.onInstSuccess` only runs the binary when `/R` is passed in silent/passive mode |
| no interactive prompts | `displayLanguageSelector: false`; the only custom installer hooks create/remove a desktop shortcut |
| All linked URLs | HTTP 200 checked |

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423110)