### PR TITLE
New version: AurelioAvila.PCTweaker version 1.2.2

### DIFF
--- a/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.installer.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.installer.yaml
@@ -13,7 +13,7 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/download/v1.2.2/pc-tweaker-app_1.2.2_x64-setup.exe
-  InstallerSha256: A9BBE821D9C99C17B42F9CAD5739351FF5AA48550A235CE2F7CD84EB07F4234
+  InstallerSha256: A9BBE821D9C99C17B42F9CAD5739351FF5AA48550A235CE2F7CD84EB07F4234F
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-24

--- a/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.installer.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.2.2
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/download/v1.2.2/pc-tweaker-app_1.2.2_x64-setup.exe
+  InstallerSha256: A9BBE821D9C99C17B42F9CAD5739351FF5AA48550A235CE2F7CD84EB07F4234
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-24

--- a/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.locale.en-US.yaml
@@ -19,6 +19,6 @@ Tags:
 - optimizer
 - gaming
 - privacy
-ReleaseNotesUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.2.0
+ReleaseNotesUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.2.2
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.2.2
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/pc-tweaker-app/issues
+PackageName: PC Tweaker
+PackageUrl: https://github.com/AurelioAvila/pc-tweaker-app
+License: Proprietary
+ShortDescription: Desktop app for Windows that applies performance, privacy, gaming and maintenance tweaks with automatic one-click rollback.
+Description: PC Tweaker applies real Windows system tweaks (registry, power plan, network DNS, temp file cleanup) across Performance, Privacy, Gaming and Maintenance categories. Every change saves a snapshot of the previous value before it's applied, so any tweak can be reverted with one click. Includes in-app auto-update.
+Tags:
+- windows
+- performance
+- tweak
+- optimizer
+- gaming
+- privacy
+ReleaseNotesUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.2.2/AurelioAvila.PCTweaker.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates AurelioAvila.PCTweaker to 1.2.2.

- Fixed an authentication issue affecting account sign-in
- Pro subscribers can now manage their subscription directly from the app

Installer hash verified against the published GitHub release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423113)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423113)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423113)