### PR TITLE
New package: Tyroger.Capiory version 0.4.1

### DIFF
--- a/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.installer.yaml
+++ b/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tyroger.Capiory
+PackageVersion: 0.4.1
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-21
+AppsAndFeaturesEntries:
+- DisplayName: Capiory
+  Publisher: tyroger
+  DisplayVersion: 0.4.1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tyroger/Suivora-releases/releases/download/v0.4.1/Capiory_0.4.1_x64-setup.exe
+  InstallerSha256: EF45755C5FC0593132D4ACF286D8E9DD6AB79247D1C1C7C08E2211B7CBE4DD4F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.locale.fr-FR.yaml
+++ b/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.locale.fr-FR.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tyroger.Capiory
+PackageVersion: 0.4.1
+PackageLocale: fr-FR
+Publisher: tyroger
+PublisherUrl: https://capiory.fr
+PublisherSupportUrl: https://github.com/tyroger/Suivora-releases/issues
+PackageName: Capiory
+PackageUrl: https://capiory.fr
+License: Propriétaire (gratuit)
+Copyright: Copyright (c) 2026 tyroger
+ShortDescription: Poste de pilotage personnel et local pour vos projets, priorités, blocages et charge de travail.
+Description: |-
+  Capiory est un poste de pilotage personnel 100 % local pour garder le cap sur l'essentiel :
+  projets, priorités, blocages et charge de travail réunis dans une seule application de bureau.
+  Aucun compte, aucun cloud : les données restent sur votre machine, avec des sauvegardes chiffrées.
+Moniker: capiory
+Tags:
+- local
+- organisation
+- pilotage
+- priorités
+- productivité
+- projets
+ReleaseNotesUrl: https://github.com/tyroger/Suivora-releases/releases/tag/v0.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.yaml
+++ b/manifests/t/Tyroger/Capiory/0.4.1/Tyroger.Capiory.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tyroger.Capiory
+PackageVersion: 0.4.1
+DefaultLocale: fr-FR
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema)?

---

New package: **Tyroger.Capiory** version 0.4.1 — Capiory is a local-first personal steering desktop app (projects, priorities, blockers, workload). Built with Tauri (NSIS installer, per-user scope). Installer is published on GitHub Releases; SHA256 taken from the GitHub release asset digest.

Note: manifest authored on macOS, so `winget install --manifest` could not be run locally; relying on pipeline validation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423150)