### PR TITLE
Update metadata: RobertasTa.SmartDuplicateFinder version 1.3 (License: MIT -> GPL-3.0-only)

### DIFF
--- a/manifests/r/RobertasTa/SmartDuplicateFinder/1.3/RobertasTa.SmartDuplicateFinder.locale.en-US.yaml
+++ b/manifests/r/RobertasTa/SmartDuplicateFinder/1.3/RobertasTa.SmartDuplicateFinder.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/RobertasTa
 PublisherSupportUrl: https://github.com/RobertasTa/smart-duplicate-finder/issues
 PackageName: Smart Duplicate Finder
 PackageUrl: https://robertasta.github.io/smart-duplicate-finder/
-License: MIT
+License: GPL-3.0-only
 LicenseUrl: https://github.com/RobertasTa/smart-duplicate-finder/blob/master/LICENSE
 Copyright: (c) Robertas & Claude
 ShortDescription: Safe, portable duplicate file finder that never deletes your files.


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Metadata-only correction: `License` changes from `MIT` to `GPL-3.0-only`.

The package ships PyQt6 inside a single executable, and PyQt6 is licensed
`GPL-3.0-only` by Riverbank Computing, so the upstream project has corrected
its own licence accordingly (see the linked LicenseUrl). The MIT value in the
manifest was inherited from that earlier mistake. No installer change - the
InstallerUrl and InstallerSha256 are identical to the merged 1.3 manifest.
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423152)
