### PR TITLE
New package: ZUBOLAND.HONJIN version 0.1.5

### DIFF
--- a/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.installer.yaml
+++ b/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.HONJIN
+PackageVersion: 0.1.5
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: 447cd8ba-57a1-5264-8c33-bc8798ec45cb
+ReleaseDate: 2026-08-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zuboland/honjin/releases/download/v0.1.5/HONJIN-Setup-0.1.5.exe
+  InstallerSha256: D580D4CC128ED6E67ADE4B245DEFD1F5B03F78179802FEDA3E95645057EF400E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.locale.en-US.yaml
+++ b/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.HONJIN
+PackageVersion: 0.1.5
+PackageLocale: en-US
+Publisher: ZUBOLAND Inc.
+PublisherUrl: https://zuboland.jp
+PublisherSupportUrl: https://github.com/zuboland/honjin/issues
+PrivacyUrl: https://hub.uni-core.jp/privacy
+Author: ZUBOLAND Inc.
+PackageName: HONJIN
+PackageUrl: https://github.com/zuboland/honjin
+License: Proprietary
+LicenseUrl: https://hub.uni-core.jp/terms
+Copyright: Copyright (c) 2026 ZUBOLAND Inc.
+CopyrightUrl: https://hub.uni-core.jp/terms
+ShortDescription: A local desk that collects what happened across your own tools into one stream.
+Description: |-
+  HONJIN is a desktop app that gathers events from the tools you already use and puts them
+  into a single time-ordered stream, so you can see what actually moved today without
+  opening ten dashboards.
+  It reads the sources you configure yourself, keeps the collected events in a plain
+  append-only JSONL file on your machine, and can watch sites, folders, APIs, commands,
+  releases and MCP servers for changes. Notes ("cards") can be written from any event, so
+  the numbers and failures you run into become reusable material instead of scrolling away.
+  The extension API is documented and open: a Source (collects events), a Watch (declares
+  what to monitor in YAML) and a View (a sandboxed HTML panel) are plain files in a folder.
+  Nothing is uploaded. The app only talks to the endpoints you configure and to GitHub for
+  update checks. Windows only.
+Tags:
+- dashboard
+- desktop
+- events
+- local
+- monitoring
+- notes
+- productivity
+ReleaseNotesUrl: https://github.com/zuboland/honjin/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.locale.ja-JP.yaml
+++ b/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.locale.ja-JP.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.HONJIN
+PackageVersion: 0.1.5
+PackageLocale: ja-JP
+Publisher: ZUBOLAND株式会社
+PublisherUrl: https://zuboland.jp
+PublisherSupportUrl: https://github.com/zuboland/honjin/issues
+PrivacyUrl: https://hub.uni-core.jp/privacy
+Author: ZUBOLAND株式会社
+PackageName: HONJIN
+PackageUrl: https://github.com/zuboland/honjin
+License: 独自ライセンス
+LicenseUrl: https://hub.uni-core.jp/terms
+Copyright: Copyright (c) 2026 ZUBOLAND株式会社
+ShortDescription: 自分の道具で「何が起きたか」を1本の時系列に集めて見る、手元の作業台。
+Description: |-
+  HONJIN（本陣）は、自分が使っている道具から「出来事」を集めて、1本の時系列にして見る
+  デスクトップアプリです。ダッシュボードを10個開かなくても、今日何が動いたかが分かります。
+  集める先は自分で設定します。集めた出来事は、追記だけのJSONLファイルとして手元に残ります。
+  サイト・フォルダ・API・コマンド・リリース・MCPサーバーの変化を見張ることもできます。
+  どの出来事からでもメモ（カード）を書けるので、その日出た数字や失敗が、流れて消えずに
+  次に使える材料として残ります。
+  拡張の仕様は公開しています。Source（出来事を集める）・Watch（見張る対象をYAMLで書く）・
+  View（サンドボックス内のHTML画面）は、フォルダに置くただのファイルです。
+  外部への送信はありません。通信するのは自分で設定した先と、更新確認だけです。Windows対応。
+Tags:
+- ダッシュボード
+- メモ
+- 作業台
+- 監視
+ReleaseNotesUrl: https://github.com/zuboland/honjin/releases
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.yaml
+++ b/manifests/z/ZUBOLAND/HONJIN/0.1.5/ZUBOLAND.HONJIN.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ZUBOLAND.HONJIN
+PackageVersion: 0.1.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: ZUBOLAND.HONJIN 0.1.5

HONJIN is a Windows desktop app that collects events from the tools the user configures
into a single append-only local stream, and can watch sites, folders, APIs, commands,
releases and MCP servers for changes. Publisher: ZUBOLAND Inc. (ZUBOLAND株式会社).

- Installer: NSIS (electron-builder), per-user scope, `/S` silent install verified in the
  NSIS template (`RUN_AFTER_FINISH` is guarded by `${ifNot} ${Silent}`, so the app does not
  launch during a silent install).
- The installer and every bundled binary are Authenticode signed
  (Azure Trusted Signing, `CN=ZUBOLAND株式会社`). Verified with `signtool verify /pa` and
  `Get-AuthenticodeSignature` on the published asset.
- `InstallerSha256` was computed from the published asset downloaded over HTTPS, not from a
  local build artifact.

#### About the checkboxes

I could not run `winget install --manifest` locally: this machine is Windows 11 **Home**, and
Windows Sandbox is not available on Home (the documented supported editions are Pro,
Enterprise and Education). Rather than tick a box I did not verify, I am leaving the
validation checkbox unchecked and stating this openly. The manifest passes
`winget validate --manifest`.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (see above)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423170)