### PR TITLE
Update version: Urlscan.urlscan-cli version 2026.8.18

### DIFF
--- a/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.installer.yaml
+++ b/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Urlscan.urlscan-cli
+PackageVersion: 2026.8.18
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: urlscan.exe
+  PortableCommandAlias: urlscan
+Commands:
+- urlscan
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/urlscan/urlscan-cli/releases/download/v2026.08.18/urlscan-cli_Windows_x86_64.zip
+  InstallerSha256: DC4E70BC28EDF571A9853C9672CA1EF68A797D831510DA63281B7A865630308D
+- Architecture: x86
+  InstallerUrl: https://github.com/urlscan/urlscan-cli/releases/download/v2026.08.18/urlscan-cli_Windows_i386.zip
+  InstallerSha256: BD47A8D1E8367BF650AA1EFA58C80FC7C83841A4F45144127DCD64446A504D04
+- Architecture: arm64
+  InstallerUrl: https://github.com/urlscan/urlscan-cli/releases/download/v2026.08.18/urlscan-cli_Windows_arm64.zip
+  InstallerSha256: 04F1C6E71961B9B769DEC749CA7C7E76F082F1AC8A05AE4437AEB41D6263862E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.locale.en-US.yaml
+++ b/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Urlscan.urlscan-cli
+PackageVersion: 2026.8.18
+PackageLocale: en-US
+Publisher: urlscan GmbH
+PublisherUrl: https://urlscan.io
+PublisherSupportUrl: https://github.com/urlscan/urlscan-cli/issues
+PrivacyUrl: https://urlscan.io/privacy
+Author: urlscan GmbH
+PackageName: urlscan-cli
+PackageUrl: https://github.com/urlscan/urlscan-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/urlscan/urlscan-cli/blob/v0.0.4/LICENSE
+ShortDescription: The official urlscan CLI.
+Description: |
+  urlscan-cli lets you interact with the urlscan.io API from the command line,
+  including submitting scans, retrieving results, and managing account data.
+Moniker: urlscan
+Tags:
+- cli
+- security
+- urlscan
+ReleaseNotes: "## What's Changed\r\n• Deprecation by @ninoseki in https://github.com/urlscan/urlscan-cli/pull/138\r\n• Update Go and dependencies by @ninoseki in https://github.com/urlscan/urlscan-cli/pull/139\r\n\r\n\r\n**Full Changelog**：https://github.com/urlscan/urlscan-cli/compare/v2026.07.07...v2026.08.18"
+ReleaseNotesUrl: https://github.com/urlscan/urlscan-cli/releases/tag/v2026.08.18
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.yaml
+++ b/manifests/u/Urlscan/urlscan-cli/2026.8.18/Urlscan.urlscan-cli.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Urlscan.urlscan-cli
+PackageVersion: 2026.8.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Urlscan.urlscan-cli to version 2026.8.18.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423182)