### PR TITLE
New version: FedeB2160.WinGetStudio version 1.10.0

### DIFF
--- a/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.installer.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.0
+InstallerLocale: en-US
+InstallerType: portable
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/FedeB2160/WinGetStudio/releases/download/v1.10.0/WinGetStudio.exe
+  InstallerSha256: 48A5B5A73FB5AF1CDD7400EA2B4B8A80DFBA75948E6668AEC1E1B875B6ABBF1F
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-24

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.locale.en-US.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.0
+PackageLocale: en-US
+Publisher: FedeB2160
+PublisherUrl: https://github.com/FedeB2160
+PublisherSupportUrl: https://github.com/FedeB2160/WinGetStudio/issues
+PackageName: WinGet Studio
+PackageUrl: https://github.com/FedeB2160/WinGetStudio
+License: MIT
+LicenseUrl: https://github.com/FedeB2160/WinGetStudio/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Federico Borghi
+ShortDescription: 'A desktop front end for winget: update, install, uninstall, pin and export packages.'
+Description: |-
+  A Windows desktop front end for winget. Everything happens in one table with checkboxes:
+  update what has a newer version, install something new by searching as you type, list and
+  uninstall what is already there, pin what must not be touched, and export or import the whole
+  package list to rebuild a machine.
+
+  Light and dark theme, no telemetry, a single executable with nothing to install. Requires
+  administrator rights, which it asks for at startup.
+Moniker: wingetstudio
+Tags:
+- gui
+- package-manager
+- packages
+- winget
+ReleaseNotesUrl: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/FedeB2160/WinGetStudio/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.locale.en-US.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.locale.en-US.yaml
@@ -27,9 +27,14 @@ Tags:
 - package-manager
 - packages
 - winget
+ReleaseNotes: |-
+  Settings and About are tabs at the right of the strip instead of a full-window overlay, so
+  the progress bar and the log stay visible; every tab has an icon, and the strip can show the
+  icon, the name or both. An update queue can be cancelled, finishing the package in flight and
+  stopping there, and Update locks until the next check once anything has altered the machine.
+  The Unknown, MS Store and Scope choices persist between launches, and the startup update check
+  can be turned off. The light theme has real separation between controls and page, the
+  scrollbars follow the theme, and a search can no longer run at the same time as a scan.
 ReleaseNotesUrl: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.0
-Documentations:
-- DocumentLabel: Wiki
-  DocumentUrl: https://github.com/FedeB2160/WinGetStudio/wiki
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.0/FedeB2160.WinGetStudio.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

New version: **WinGet Studio 1.10.0**, a WPF desktop front end for winget.
Update, install, uninstall, pin and export/import packages from a single checkbox table.

Everything below is unchanged from the accepted 1.9.0 manifest. Only the version, the installer URL, the hash and the release date differ.

- Repository: https://github.com/FedeB2160/WinGetStudio
- License: MIT
- Installer: portable, a single signed executable (x86, runs on x64 via WOW64)
- `ElevationRequirement: elevatesSelf`: the exe carries a requireAdministrator manifest, so installing needs no privileges while running asks for them
- The executable is Authenticode-signed with a timestamped self-signed certificate, so Windows will report an unknown publisher

`InstallerSha256` is the SHA-256 that GitHub publishes with the release asset, not a locally computed hash: the build is not reproducible, so a local hash of a local build would not match what the CI downloads.

Validated with `winget validate` and installed locally with `winget install --manifest` on Windows 11 (winget v1.29.290), schema 1.12.

What changed in 1.10.0: Settings and About are tabs instead of a full-window overlay, so the progress bar and the log stay visible; an update queue can be cancelled, finishing the package in flight and stopping there; the light theme has real separation between controls and page; and a search can no longer run at the same time as a scan. Full notes: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.0

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
