### PR TITLE
Update: NeuralNomadsAI.CodeNomad to 0.19.0

### DIFF
--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.installer.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.installer.yaml
@@ -1,0 +1,24 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.19.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: nsis/CodeNomad_0.19.0_x64-setup.exe
+Scope: user
+ProductCode: CodeNomad
+ReleaseDate: 2026-08-24
+AppsAndFeaturesEntries:
+- Publisher: neuralnomads
+  ProductCode: CodeNomad
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\CodeNomad'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NeuralNomadsAI/CodeNomad/releases/download/v0.19.0/CodeNomad-Tauri-windows-x64-0.19.0.zip
+  InstallerSha256: 5BBE4423B266469DA6EC56410ED75CBD7C8C93139119448DF1E8880CB4597AE9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.locale.en-US.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.19.0
+PackageLocale: en-US
+Publisher: NeuralNomadsAI
+PublisherUrl: https://github.com/NeuralNomadsAI
+PublisherSupportUrl: https://github.com/NeuralNomadsAI/CodeNomad/issues
+PackageName: CodeNomad
+PackageUrl: https://github.com/NeuralNomadsAI/CodeNomad
+License: MIT
+LicenseUrl: https://github.com/NeuralNomadsAI/CodeNomad/blob/HEAD/LICENSE
+ShortDescription: CodeNomad is the command center that puts AI coding on steroids.
+Description: CodeNomad is the command center that puts AI coding on steroids.
+Tags:
+- ai
+- code
+- coding
+- development
+ReleaseNotes: |-
+  CodeNomad v0.19.0 adds persistent desktop workspaces, server-side Yolo permission handling, provider quota usage, model visibility controls, customizable panels, recursive nested sessions, and stronger mobile reconnect recovery.
+  It also adds native workspace actions, separate STT/TTS providers, OpenCode and WinGet update actions, improved Markdown and file search, and broad desktop reliability fixes.
+ReleaseNotesUrl: https://github.com/NeuralNomadsAI/CodeNomad/releases/tag/v0.19.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.yaml
+++ b/manifests/n/NeuralNomadsAI/CodeNomad/0.19.0/NeuralNomadsAI.CodeNomad.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NeuralNomadsAI.CodeNomad
+PackageVersion: 0.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `NeuralNomadsAI.CodeNomad` to version `0.19.0` using the published Windows Tauri archive and its nested NSIS installer.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there are no other open pull requests for this manifest update
- [x] This PR only modifies one manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [ ] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423225)