### PR TITLE
New package: Talkdedsec.Visual version 0.1.0

### DIFF
--- a/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.installer.yaml
+++ b/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 ReleaseDate: 2026-08-13
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Talkdedsec1/tlk-visual/releases/download/v0.1.0/talkdedsec-visual.exe
+    InstallerUrl: https://github.com/Talkdedsec/tlk-visual/releases/download/v0.1.0/talkdedsec-visual.exe
     InstallerSha256: 8BF76C680AD79587A3536CDAFF5DD19763A8A595EB6CAC15C6E5BBE4EE074C25
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.installer.yaml
+++ b/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Talkdedsec.Visual
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - talkdedsec-visual
+ReleaseDate: 2026-08-13
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Talkdedsec1/tlk-visual/releases/download/v0.1.0/talkdedsec-visual.exe
+    InstallerSha256: 8BF76C680AD79587A3536CDAFF5DD19763A8A595EB6CAC15C6E5BBE4EE074C25
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.locale.en-US.yaml
+++ b/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.locale.en-US.yaml
@@ -4,11 +4,11 @@ PackageVersion: 0.1.0
 PackageLocale: en-US
 Publisher: Talkdedsec
 PublisherUrl: https://talkdedsec.com
-PublisherSupportUrl: https://github.com/Talkdedsec1/tlk-visual/issues
+PublisherSupportUrl: https://github.com/Talkdedsec/tlk-visual/issues
 PackageName: Talkdedsec Visual
-PackageUrl: https://github.com/Talkdedsec1/tlk-visual
+PackageUrl: https://github.com/Talkdedsec/tlk-visual
 License: GPL-3.0-or-later
-LicenseUrl: https://github.com/Talkdedsec1/tlk-visual/blob/main/LICENSE
+LicenseUrl: https://github.com/Talkdedsec/tlk-visual/blob/main/LICENSE
 ShortDescription: Whole-screen colour engine for Windows, written to the display gamma ramp.
 Description: |-
   Five sliders - brightness, contrast, gamma, temperature and night vision - are compiled
@@ -30,6 +30,6 @@ Tags:
   - gaming
   - night-vision
   - windows
-ReleaseNotesUrl: https://github.com/Talkdedsec1/tlk-visual/releases/tag/v0.1.0
+ReleaseNotesUrl: https://github.com/Talkdedsec/tlk-visual/releases/tag/v0.1.0
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.locale.en-US.yaml
+++ b/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Talkdedsec.Visual
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Talkdedsec
+PublisherUrl: https://talkdedsec.com
+PublisherSupportUrl: https://github.com/Talkdedsec1/tlk-visual/issues
+PackageName: Talkdedsec Visual
+PackageUrl: https://github.com/Talkdedsec1/tlk-visual
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Talkdedsec1/tlk-visual/blob/main/LICENSE
+ShortDescription: Whole-screen colour engine for Windows, written to the display gamma ramp.
+Description: |-
+  Five sliders - brightness, contrast, gamma, temperature and night vision - are compiled
+  into a gamma ramp and written straight to the display adapter, so everything the panel
+  shows goes through it: games, video and the desktop alike.
+
+  Nothing is injected into a process, no driver is installed and no administrator rights
+  are needed. The correction happens in the display pipeline rather than in the game, so
+  it costs no frame time. A single executable with no installer and no runtime.
+
+  Saturation and hue are not possible on a gamma ramp, HDR displays ignore the ramp on
+  most drivers, and every attached display receives the same curve.
+Moniker: talkdedsec-visual
+Tags:
+  - brightness
+  - color
+  - display
+  - gamma
+  - gaming
+  - night-vision
+  - windows
+ReleaseNotesUrl: https://github.com/Talkdedsec1/tlk-visual/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.yaml
+++ b/manifests/t/Talkdedsec/Visual/0.1.0/Talkdedsec.Visual.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Talkdedsec.Visual
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: Talkdedsec.Visual 0.1.0

A whole-screen colour engine for Windows. Five sliders — brightness, contrast, gamma, temperature and night vision — are compiled into a gamma ramp and written to the display adapter with `SetDeviceGammaRamp`. Single portable executable, no installer, no driver, no administrator rights.

- Repository: https://github.com/Talkdedsec1/tlk-visual
- Release: https://github.com/Talkdedsec1/tlk-visual/releases/tag/v0.1.0
- Licence: GPL-3.0-or-later

The installer SHA-256 in the manifest matches `talkdedsec-visual.exe.sha256`, published alongside the binary by the release workflow.

---

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

`winget validate` passes. I have not run the local `winget install --manifest` test, so please let the pipeline's install validation be the check on that. The CLA box is left unticked until the bot's check runs on this PR.
