### PR TITLE
New package: Erryb95.VideoDownloaderConverter version 0.3.3

### DIFF
--- a/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.installer.yaml
+++ b/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.installer.yaml
@@ -1,0 +1,27 @@
+# Created with the winget schema 1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Erryb95.VideoDownloaderConverter
+PackageVersion: 0.3.3
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Erryb95/video-downloader-converter/releases/download/v0.3.3/Video.Downloader_0.3.3_x64-setup.exe
+    InstallerSha256: 2eb64d925d14cdd64eecbe464914194377b573e9e6255ba183f7068a0ad15218
+    # Verified by installing it here: the NSIS bundle registers under HKCU as
+    # "Video Downloader", which is shorter than the package name, so winget
+    # needs telling or it cannot match an installed copy to this package.
+    AppsAndFeaturesEntries:
+      - DisplayName: Video Downloader
+        DisplayVersion: 0.3.3
+        Publisher: Erryb95
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.locale.en-US.yaml
+++ b/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with the winget schema 1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Erryb95.VideoDownloaderConverter
+PackageVersion: 0.3.3
+PackageLocale: en-US
+Publisher: Erryb95
+PublisherUrl: https://github.com/Erryb95
+PublisherSupportUrl: https://github.com/Erryb95/video-downloader-converter/issues
+PackageName: Video Downloader + Converter
+PackageUrl: https://github.com/Erryb95/video-downloader-converter
+License: MIT
+LicenseUrl: https://github.com/Erryb95/video-downloader-converter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Erryb95
+ShortDescription: Download video and audio from YouTube and 1000+ other sites, and convert files you already have.
+Description: |-
+  A deliberately small desktop app that does two things: download and convert.
+
+  Downloads one link at a time or many at once, expanding a playlist link into
+  its videos. Every stream the site offers is listed with its size and bitrate,
+  preferring H.264/MP4 so the result plays everywhere. Subtitles can be printed
+  onto the picture, muxed in as a selectable track, or saved beside the video.
+  The converter re-encodes files you already have, using a hardware encoder
+  when that is genuinely faster.
+
+  yt-dlp and FFmpeg are bundled, so there is nothing else to install. The app
+  updates itself, and the yt-dlp engine updates separately - each verified
+  before installation.
+Moniker: video-downloader
+Tags:
+  - converter
+  - downloader
+  - ffmpeg
+  - media
+  - video
+  - youtube
+  - yt-dlp
+ReleaseNotesUrl: https://github.com/Erryb95/video-downloader-converter/releases/tag/v0.3.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.yaml
+++ b/manifests/e/Erryb95/VideoDownloaderConverter/0.3.3/Erryb95.VideoDownloaderConverter.yaml
@@ -1,0 +1,8 @@
+# Created with the winget schema 1.6.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Erryb95.VideoDownloaderConverter
+PackageVersion: 0.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

`Erryb95.VideoDownloaderConverter` 0.3.3 — a desktop app that downloads video
and audio from the sites yt-dlp supports and converts files you already have.
yt-dlp and FFmpeg ship with it, so it has no external dependencies.

- Repository: https://github.com/Erryb95/video-downloader-converter
- Release: https://github.com/Erryb95/video-downloader-converter/releases/tag/v0.3.3

### Checklist

- [x] Manifest validated locally: `winget validate --manifest .` → *Manifest validation succeeded.*
- [x] Conforms to the 1.6.0 schema.
- [x] No other open pull request for this package — it is a new one.
- [x] `InstallerSha256` verified by downloading the asset and recomputing the
      hash, not by copying it from the release page. It also matches the
      `SHA256SUMS` the release publishes.
- [ ] **Not** tested with `winget install --manifest`: `LocalManifestFiles` is
      disabled on the machine used and enabling it needs elevation. Instead the
      installer itself was run with `/S`, which is what the silent install
      modes resolve to.

### What was verified by hand

The NSIS installer is per-user and installs unattended: `setup.exe /S` returned
exit code 0 and registered under
`HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall`. The installed copy
was then run and downloaded a video successfully. `uninstall.exe /S` returned 0
and left neither the directory nor the registry entry behind.

That test is also why `AppsAndFeaturesEntries` is present: the bundle registers
its `DisplayName` as **Video Downloader**, shorter than the package name, so
without it winget cannot match an installed copy back to this package.

### Notes for reviewers

- The installer is **not code-signed**. Individual developers cannot currently
  obtain a Microsoft Artifact Signing certificate outside the US and Canada.
- Every release publishes `SHA256SUMS` and a GitHub build attestation, so the
  artifact can be traced to the commit and workflow that produced it:
  `gh attestation verify <file> --repo Erryb95/video-downloader-converter`
- The app bundles FFmpeg under **GPLv3**. The licence text and the written
  offer for corresponding source ship inside the installer, and the FFmpeg
  build is pinned to a specific tagged artifact rather than a rolling one.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423242)