### PR TITLE
New version: norc.norc-cli version 0.1.9

### DIFF
--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+InstallerType: portable
+Scope: user
+Commands:
+  - norc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/redcoatasher/norc/releases/download/cli-v0.1.9/norc-win-x64.exe
+    InstallerSha256: DF49E5DE39D94F71CE3EF290E347CF91BFD79E8EC4E920885A5D80D7EC20CC66
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
@@ -6,7 +6,7 @@ Commands:
   - norc
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/redcoatasher/norc/releases/download/cli-v0.1.9/norc-win-x64.exe
+    InstallerUrl: https://github.com/RedcoatAsher/norc-cli-releases/releases/download/cli-v0.1.9/norc-win-x64.exe
     InstallerSha256: DF49E5DE39D94F71CE3EF290E347CF91BFD79E8EC4E920885A5D80D7EC20CC66
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.locale.en-US.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.locale.en-US.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+PackageLocale: en-US
+Publisher: norc
+PackageName: norc-cli
+License: Proprietary
+ShortDescription: Headless cron job scheduler for norc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package
- **Identifier**: norc.norc-cli
- **Version**: 0.1.9
- **Publisher**: norc (https://norc.app)
- **License**: Proprietary

## Description
norc-cli is a headless cron job scheduler that installs a per-user Scheduled Task syncing the machine's crontab with the norc web vault (https://norc.app/cli).

Portable installer (single .exe, no bundled installer). Installer is downloaded from a GitHub Release asset: https://github.com/redcoatasher/norc/releases/tag/cli-v0.1.9 (SHA256 verified against the release asset).

## Notes
winget's `portable` installer type has no postinstall-script hook (unlike Chocolatey/Scoop). After `winget install norc.norc-cli`, users need to run `norc service install` once to register the per-user background task — documented in the package's own upstream README.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (no Windows machine available; relying on WinGet Validation CI/moderator review)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (same — untested on-device so far)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423317)