### PR TITLE
New package: cislunarspace.altgo version 2.6.4

### DIFF
--- a/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.installer.yaml
+++ b/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.installer.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/cislunarspace/altgo/releases/download/v2.6.4/altgo_2.6.4_x64-setup.exe
+    InstallerSha256: 4ccbd0f71c69eff981036aa8eed11cefa49e7013012189a33bcbbbfe1d9f2ac8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.locale.zh-CN.yaml
+++ b/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+PackageLocale: zh-CN
+Publisher: cislunarspace
+PackageName: altgo
+License: MIT
+ShortDescription: 桌面语音转文字工具，按住触发键说话，松开后自动转写并写入剪贴板
+Description: |-
+  altgo 是一款桌面语音转文字工具。按住触发键说话，松开后自动完成录音、
+  本地 SenseVoice 转写和可选的 LLM 润色，结果写入系统剪贴板并显示在悬浮窗中。
+PackageUrl: https://github.com/cislunarspace/altgo
+Tags:
+  - speech-to-text
+  - asr
+  - voice
+  - sensevoice
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.yaml
+++ b/manifests/c/cislunarspace/altgo/2.6.4/cislunarspace.altgo.yaml
@@ -1,0 +1,8 @@
+# Created for altgo
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: cislunarspace.altgo
+PackageVersion: 2.6.4
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
altgo is a desktop speech-to-text tool: hold a trigger key to record, release to transcribe locally with SenseVoice (embedded sherpa-onnx), optionally polish with an LLM, and write the result to the clipboard.

Homepage / releases: https://github.com/cislunarspace/altgo

- Installer: NSIS (nullsoft), x64
- InstallerUrl / Sha256 verified against the release checksums.txt
- Manifest validated locally with `winget validate`

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423325)