### PR TITLE
New version: Rorkai.ASC version 4.9.1

### DIFF
--- a/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.installer.yaml
+++ b/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.installer.yaml
@@ -1,0 +1,12 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 4.9.1
+InstallerType: portable
+Commands:
+  - asc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/download/4.9.1/asc_4.9.1_windows_amd64.exe
+    InstallerSha256: EB97E58BDEB74428657127DE0A471275D13A44CDA2A0E131BFFA313F343874E3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.locale.en-US.yaml
+++ b/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 4.9.1
+PackageLocale: en-US
+Publisher: Rorkai
+PackageName: asc
+PackageUrl: https://github.com/rorkai/App-Store-Connect-CLI
+License: MIT
+LicenseUrl: https://github.com/rorkai/App-Store-Connect-CLI/blob/main/LICENSE
+ShortDescription: Fast, scriptable CLI for the App Store Connect API.
+Moniker: asc
+Tags:
+  - app-store-connect
+  - app-store-connect-api
+  - cli
+  - ios
+  - testflight
+ReleaseNotesUrl: https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/4.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.yaml
+++ b/manifests/r/Rorkai/ASC/4.9.1/Rorkai.ASC.yaml
@@ -1,0 +1,6 @@
+# Created with App-Store-Connect-CLI/scripts/generate_winget_manifests.py
+PackageIdentifier: Rorkai.ASC
+PackageVersion: 4.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds Rorkai.ASC 4.9.1 from https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/4.9.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423351)