### PR TITLE
New package: TechyGeeksHome.UltimateSettingsPanel version 8.0.0

### DIFF
--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 # Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
@@ -1,0 +1,16 @@
+# Created with the winget manifest schema 1.6.0
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Ultimate Settings Panel.exe
+  PortableCommandAlias: usp
+UpgradeBehavior: install
+ReleaseDate: 2026-08-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/download/v8.0.0/Ultimate-Settings-Panel.zip
+  InstallerSha256: 470D6CAF7C1D7926CFE041F86CD66B255A35B8956084608D8DEFA89929626E7B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
@@ -1,4 +1,4 @@
-# Created with the winget manifest schema 1.6.0
+# Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0
 InstallerType: zip
@@ -13,4 +13,4 @@ Installers:
   InstallerUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/download/v8.0.0/Ultimate-Settings-Panel.zip
   InstallerSha256: 470D6CAF7C1D7926CFE041F86CD66B255A35B8956084608D8DEFA89929626E7B
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
@@ -1,0 +1,42 @@
+# Created with the winget manifest schema 1.6.0
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.0
+PackageLocale: en-GB
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://techygeekshome.info/contact/
+PrivacyUrl: https://techygeekshome.info/privacy-policy/
+Author: TechyGeeksHome
+PackageName: Ultimate Settings Panel
+PackageUrl: https://techygeekshome.info/ultimate-settings-panel-online/
+License: Proprietary
+LicenseUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+ShortDescription: 250+ Windows settings, tools, diagnostics and commands in one fast, searchable panel.
+Description: |-
+  Ultimate Settings Panel puts more than 250 Windows settings, classic tools, network
+  diagnostics and commands into a single searchable window, grouped across 13 categories.
+  It is a ground-up rebuild of the TechyGeeksHome panel that has been around since 2010.
+
+  Windows 11 settings pages open directly. Classic tools that a sandbox cannot launch are
+  shown with their exact command so you can copy it or export a batch file. There is a
+  favourites list, light and dark themes with system detection, and instant search across
+  names, descriptions and the underlying commands.
+
+  It is a single portable executable. Nothing is installed, nothing is left behind, and no
+  administrator rights are needed to run it. The only requirement beyond Windows itself is
+  the Microsoft Edge WebView2 runtime, which ships with Windows 11 and current Windows 10.
+
+  Free at home and at work, with no adverts, no sign-up and no paid tier.
+Moniker: usp
+Tags:
+- control-panel
+- settings
+- shortcuts
+- system
+- tools
+- utilities
+- windows
+ReleaseNotesUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/tag/v8.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
@@ -1,4 +1,4 @@
-# Created with the winget manifest schema 1.6.0
+# Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0
 PackageLocale: en-GB
@@ -39,4 +39,4 @@ Tags:
 - windows
 ReleaseNotesUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/tag/v8.0.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.locale.en-GB.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 # Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
@@ -1,0 +1,6 @@
+# Created with the winget manifest schema 1.6.0
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.0
+DefaultLocale: en-GB
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
@@ -1,6 +1,6 @@
-# Created with the winget manifest schema 1.6.0
+# Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0
 DefaultLocale: en-GB
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.0/TechyGeeksHome.UltimateSettingsPanel.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 # Created with the winget manifest schema 1.12.0
 PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
 PackageVersion: 8.0.0


### PR DESCRIPTION
## Description

New package. **Ultimate Settings Panel 8.0.0** — a portable Windows utility putting 250+ Windows settings, classic tools, network diagnostics and commands into one searchable window across 13 categories.

Distributed as a zip from GitHub releases containing a single self-contained executable, so `InstallerType: zip` with `NestedInstallerType: portable` and a `usp` command alias. Nothing is installed and no admin rights are needed to run it.

- **Publisher:** TechyGeeksHome — https://techygeekshome.info
- **Source:** https://github.com/techygeekshome/Ultimate-Settings-Panel
- **Release:** https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/tag/v8.0.0
- **Licence:** proprietary freeware, free for personal and commercial use

I am the publisher.

## Checklist

- [x] Checked there are no other open pull requests for this package
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.12.0 schema

**Two boxes left unticked rather than ticked untruthfully:**

- [x] Signed the Contributor License Agreement — not yet. I will sign when the bot asks on this PR.
- [ ] Validated locally with `winget validate` / `winget install --manifest` — no Windows machine to hand. The YAML parses and follows the schema, and the hash was computed from the published release asset, but the tooling validation has genuinely not been run. Happy to fix whatever the pipeline flags.

## Verification

```
Ultimate-Settings-Panel.zip   2,904,940 bytes
SHA256  470D6CAF7C1D7926CFE041F86CD66B255A35B8956084608D8DEFA89929626E7B
```

Zip contents: `Ultimate Settings Panel.exe` (6,961,664 bytes), a readme and a shortcut. `ReleaseDate` taken from the release's `published_at`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423439)