### PR TITLE
New package: Adrifer.Sonarctl version 0.1.1

### DIFF
--- a/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.installer.yaml
+++ b/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Adrifer.Sonarctl
+PackageVersion: 0.1.1
+InstallerType: portable
+UpgradeBehavior: uninstallPrevious
+Commands:
+  - sonarctl
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/adrifer/sonarctl/releases/download/v0.1.1/sonarctl.exe
+    InstallerSha256: 3B150C1724B0261AF2B58FEA5E9960902C3C08F28BB1E1563CAA7961E0CC2A48
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.locale.en-US.yaml
+++ b/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Adrifer.Sonarctl
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Adrifer
+PublisherUrl: https://github.com/adrifer
+PublisherSupportUrl: https://github.com/adrifer/sonarctl/issues
+Author: Adrian Fernandez
+PackageName: sonarctl
+PackageUrl: https://github.com/adrifer/sonarctl
+License: MIT
+LicenseUrl: https://github.com/adrifer/sonarctl/blob/v0.1.1/LICENSE
+ShortDescription: Control SteelSeries Sonar device routing from the command line.
+Description: A CLI and terminal UI for inspecting and changing the physical playback and capture devices assigned to SteelSeries Sonar channels.
+Moniker: sonarctl
+Tags:
+  - audio
+  - cli
+  - sonar
+  - steelseries
+  - tui
+ReleaseNotesUrl: https://github.com/adrifer/sonarctl/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.yaml
+++ b/manifests/a/Adrifer/Sonarctl/0.1.1/Adrifer.Sonarctl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Adrifer.Sonarctl
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `Adrifer.Sonarctl` version `0.1.1`.

sonarctl is a portable CLI and terminal UI for inspecting and changing the physical playback and capture devices assigned to SteelSeries Sonar channels.

- x64 portable executable
- MIT licensed
- Published from the immutable `v0.1.1` GitHub release
- Installer SHA-256 verified against the published release checksum
- Successfully installed and executed on Windows using the local WinGet manifest

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this new package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests\a\Adrifer\Sonarctl\0.1.1`
- [x] Tested manifest locally with `winget install --manifest manifests\a\Adrifer\Sonarctl\0.1.1`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## 🧪 Local Installation Result

```text
Found sonarctl [Adrifer.Sonarctl] Version 0.1.1
Successfully verified installer hash
Command line alias added: "sonarctl"
Successfully installed
```

The installed executable was also invoked successfully:

```text
sonarctl 0.1.1
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423452)