### PR TITLE
New package: Neprel.GitA2A version 1.4.0

### DIFF
--- a/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.installer.yaml
+++ b/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Neprel.GitA2A
+PackageVersion: 1.4.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- git-a2a
+ReleaseDate: 2026-08-24
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: git-a2a.exe
+    PortableCommandAlias: git-a2a
+  InstallerUrl: https://github.com/neprel/git-a2a/releases/download/v1.4.0/git-a2a_1.4.0_windows_amd64.zip
+  InstallerSha256: 165FB5CB6CFFF891D17315118B3B6E5ACB72324651523EC4F477BDCF6F407C03
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: git-a2a.exe
+    PortableCommandAlias: git-a2a
+  InstallerUrl: https://github.com/neprel/git-a2a/releases/download/v1.4.0/git-a2a_1.4.0_windows_arm64.zip
+  InstallerSha256: 0C2F76F25789028AE6ACD4CD08996DBC728BADC54968BC06731FA5340089A817
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.locale.en-US.yaml
+++ b/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Neprel.GitA2A
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: neprel
+PublisherUrl: https://github.com/neprel
+PublisherSupportUrl: https://github.com/neprel/git-a2a/issues
+Author: Andrey Neprel
+PackageName: git-a2a
+PackageUrl: https://github.com/neprel/git-a2a
+License: MIT
+LicenseUrl: https://github.com/neprel/git-a2a/blob/v1.4.0/LICENSE
+Copyright: Copyright (c) 2026 neprel
+ShortDescription: Import git modules together with their owning agents
+Description: An open standard and CLI for importing git modules together with the agents that own them.
+Moniker: git-a2a
+Tags:
+- a2a
+- agent
+- cli
+- dependency-management
+- developer-tools
+- git
+- mcp
+ReleaseNotesUrl: https://github.com/neprel/git-a2a/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+

--- a/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.yaml
+++ b/manifests/n/Neprel/GitA2A/1.4.0/Neprel.GitA2A.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Neprel.GitA2A
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
## Description

Adds git-a2a 1.4.0, an open standard and CLI for importing git modules together with the agents that own them.

- Homepage: https://github.com/neprel/git-a2a
- Release: https://github.com/neprel/git-a2a/releases/tag/v1.4.0
- License: MIT
- Installer: portable ZIP, x64 and arm64

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) if requested by the bot
- [x] Checked that there are no other open pull requests for this package version
- [x] This PR modifies one manifest set only
- [x] Validated natively with `winget validate --manifest ./winget-manifests`
- [x] Installed and invoked the portable package from the local manifest
- [x] Manifest conforms to schema 1.12

### Validation detail

Run on `windows-latest` with Windows Package Manager v1.29.290:

```text
Manifest validation succeeded.
Found git-a2a [Neprel.GitA2A] Version 1.4.0
Successfully verified installer hash
Successfully installed
git-a2a 1.4.0 (4810afc2f58af8a1b08001813f753117456ae2f2, windows/amd64, channel=binary)
```

Evidence: https://github.com/neprel/git-a2a/actions/runs/32767798419
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423457)