### PR TITLE
New package: GRCSAC.NetVane version 1.2.0

### DIFF
--- a/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.installer.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.0
+# Matches the published requirement ("Windows 10 or 11, 64-bit"). Deliberately not stricter: this
+# field makes winget REFUSE to install below it, so it must not promise less than the website does.
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://netvane.doorvane.com/downloads/NetVane-Setup-1.2.0.exe
+    InstallerSha256: F288AE38EF1BF54387A56141E76FCA6D2B297685449B1C4C7D347D67171A795A
+    # Inno's uninstall key is "{AppId}_is1"; AppId is pinned in installer/netvane.iss and must
+    # never change between versions, since it drives upgrade and uninstall detection.
+    ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+    AppsAndFeaturesEntries:
+      # UninstallDisplayName in the .iss is "NetVane {version}", so the ARP name is NOT the
+      # package name and changes every release. Without this, winget cannot correlate an
+      # existing install and would offer an upgrade that is already applied.
+      - DisplayName: NetVane 1.2.0
+        DisplayVersion: 1.2.0
+        Publisher: GRCSAC
+        ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+        # No UpgradeCode: that is an MSI concept and this is an Inno installer. Putting the Inno
+        # AppId there would look right and mean nothing.
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.locale.en-US.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.locale.en-US.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.0
+PackageLocale: en-US
+# Publisher matches the Authenticode certificate subject (CN=GRCSAC), which is what Windows
+# displays. GRCSAC LLC is the legal entity and appears in Copyright and the EULA. Keeping these
+# distinct is deliberate - see the note in installer/netvane.iss.
+Publisher: GRCSAC
+PublisherUrl: https://netvane.doorvane.com
+PublisherSupportUrl: https://netvane.doorvane.com/support/
+PrivacyUrl: https://netvane.doorvane.com/privacy/
+Author: GRCSAC
+PackageName: NetVane
+PackageUrl: https://netvane.doorvane.com
+License: Proprietary
+LicenseUrl: https://netvane.doorvane.com/eula/
+Copyright: Copyright (c) 2026 GRCSAC LLC
+CopyrightUrl: https://netvane.doorvane.com/eula/
+ShortDescription: Maps the devices on your network and shows what they are exposing, entirely on your own machine
+Description: |-
+  NetVane finds the devices on your network - phones, laptops, cameras, smart-home gadgets -
+  and draws them as a live map: what each device is, how it connects, and what it is exposing,
+  with plain-language fixes.
+
+  Discovered service versions are matched against an NVD and CISA-KEV vulnerability database
+  bundled with the app, so exposure checks work with no internet connection. There is no cloud
+  service, no account and no agent: the app opens a local dashboard at 127.0.0.1:8787 and keeps
+  everything in a local database on the machine it runs on.
+
+  The free edition is not a trial. Discovery, the topology map, device identification, port
+  fingerprinting, CVE and KEV matching, report export and local backups are all perpetual, with
+  no account required, and vulnerability and fingerprint data updates stay free. Optional Pro and
+  Business licences add scheduled and background scanning, multiple subnets, credentialed
+  validation, extended retention, remote alerts, and compliance reporting for teams.
+
+  Installs per-user and needs no administrator rights. A portable build is also available from
+  the website for use without installing.
+Moniker: netvane
+Tags:
+  - cve
+  - device-discovery
+  - inventory
+  - lan
+  - network
+  - network-map
+  - network-monitor
+  - network-scanner
+  - offline
+  - port-scanner
+  - privacy
+  - security
+  - sysadmin
+  - topology
+  - vulnerability-scanner
+ReleaseNotes: |-
+  Adds a Business edition with an evidence pack and compliance report for audits, WAN data-volume
+  tracking that flags changes in how much data leaves the network, and one-click fixes enabled by
+  default.
+
+  Vulnerability and device-fingerprint updates are free in every edition, including the free one.
+ReleaseNotesUrl: https://netvane.doorvane.com/changelog/
+Documentations:
+  - DocumentLabel: User guide
+    DocumentUrl: https://netvane.doorvane.com/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.0/GRCSAC.NetVane.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `GRCSAC.NetVane` version 1.2.0

NetVane is a local network scanner and security monitor for Windows. It maps the devices on a network, fingerprints open ports, and matches discovered service versions against a bundled NVD and CISA-KEV database. It runs entirely on the local machine — no cloud service, no account, no agent.

- Homepage: https://netvane.doorvane.com
- Installer: Inno Setup, per-user (`PrivilegesRequired=lowest`), no UAC prompt
- Signed: Authenticode, `CN=GRCSAC`, via Microsoft Trusted Signing (valid, timestamped)

#### Checklist

- [ ] Contributor License Agreement — the repository owner will respond to the CLA bot.
- [x] I have checked there are no other open pull requests for this package. `manifests/g/GRCSAC/` does not exist upstream; this is a new publisher and a new package.
- [x] Validated locally: `winget validate --manifest ...` → **Manifest validation succeeded** (winget v1.29.290).
- [ ] `winget install --manifest` — see the note below. The install path was tested, but not through this command.
- [x] Conforms to the 1.6.0 schema.

#### On the install test

`winget install --manifest` requires `winget settings --enable LocalManifestFiles`, which needs administrator rights on the machine. Rather than change that setting, the install was verified through the path winget's `inno` handler actually takes:

```
NetVane-Setup-1.2.0.exe /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART
```

The installer URL and SHA256 in this manifest were verified independently against the published artifact — the live URL returns `200` with a `content-length` of 20,688,328 matching the file whose SHA256 is the one declared here — so the download-and-hash step is covered even though it was not exercised through `winget install` itself.

After the install, the ARP entry matched `AppsAndFeaturesEntries` exactly:

| field | manifest | registry (HKCU) |
|---|---|---|
| `DisplayName` | `NetVane 1.2.0` | `NetVane 1.2.0` |
| `DisplayVersion` | `1.2.0` | `1.2.0` |
| `Publisher` | `GRCSAC` | `GRCSAC` |
| `ProductCode` | `{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1` | same |

The application started and responded normally afterwards.

#### Notes on a couple of manifest choices

- **`AppsAndFeaturesEntries` carries a versioned `DisplayName`.** The installer's `UninstallDisplayName` is `NetVane {version}`, so the ARP name is not the package name and changes each release. Without this block winget cannot correlate an existing install and would keep offering an upgrade that is already applied.
- **No `UpgradeCode`.** This is an Inno installer, not MSI; `ProductCode` is Inno's `{AppId}_is1` uninstall key, and `AppId` is fixed across versions.
- **`MinimumOSVersion: 10.0.10240.0`** matches the publisher's stated requirement (Windows 10 or 11, 64-bit) rather than being set higher than the product actually supports.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423491)