### PR TITLE
Update version: flyingpie.windows-terminal-quake.prerelease version 2.2.0-pre2

### DIFF
--- a/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.installer.yaml
+++ b/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: flyingpie.windows-terminal-quake.prerelease
+PackageVersion: 2.2.0-pre2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: wtq.exe
+  PortableCommandAlias: wtq
+Commands:
+- wtq
+ReleaseDate: 2026-04-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/flyingpie/windows-terminal-quake/releases/download/v2.2.0-pre2/win-x64_self-contained.zip
+  InstallerSha256: 4FC81D74B4FFFFFA3D03604B0A527D10E6B66CC984B1B83B3BC1DB5E42BB5736
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.locale.en-US.yaml
+++ b/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: flyingpie.windows-terminal-quake.prerelease
+PackageVersion: 2.2.0-pre2
+PackageLocale: en-US
+Publisher: Flyingpie
+PublisherUrl: https://flyingpie.nl/
+PublisherSupportUrl: https://github.com/flyingpie/windows-terminal-quake/issues
+PackageName: windows-terminal-quake-prerelease
+PackageUrl: https://github.com/flyingpie/windows-terminal-quake
+License: MIT
+LicenseUrl: https://github.com/flyingpie/windows-terminal-quake/blob/HEAD/LICENSE
+ShortDescription: Simple program that adds Quake-style drop down to user-specified applications.
+Moniker: windows-terminal-quake-prerelease
+Tags:
+- dropdown
+- linux
+- quake
+- terminal
+- toggle
+- windows
+ReleaseNotesUrl: https://github.com/flyingpie/windows-terminal-quake/releases/tag/v2.2.0-pre2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.yaml
+++ b/manifests/f/flyingpie/windows-terminal-quake/prerelease/2.2.0-pre2/flyingpie.windows-terminal-quake.prerelease.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: flyingpie.windows-terminal-quake.prerelease
+PackageVersion: 2.2.0-pre2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update flyingpie.windows-terminal-quake.prerelease to version 2.2.0-pre2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423497)