### PR TITLE
Update: LeoGalli.CharlieRPScreenShareTool to v3.0.0

### DIFF
--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: run.bat
+  PortableCommandAlias: screenshare-tool
+Commands:
+- screenshare-tool
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
+  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
+- Architecture: x86
+  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
+  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
+- Architecture: arm64
+  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
+  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-24

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
 PackageVersion: 3.0.0
-MinimumOSVersion: 10.0.17763.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -12,13 +11,10 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
-- Architecture: x86
-  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
-- Architecture: arm64
-  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: d79754246e9bfc7862a5e804fe615fc54fde0681d07371916a3e97838425c3c0
+  InstallerSha256: D79754246E9BFC7862A5E804FE615FC54FDE0681D07371916A3E97838425C3C0
+  InstallerSwitches:
+    Silent: ""
+    SilentWithProgress: ""
 ManifestType: installer
 ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-24

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.locale.en-US.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+PackageLocale: en-US
+Publisher: LeoGalli
+PublisherUrl: https://github.com/Leo-Galli
+PublisherSupportUrl: https://github.com/Leo-Galli/ScreenShareTool/issues
+PackageName: CharlieRP ScreenShareTool
+PackageUrl: https://github.com/Leo-Galli/ScreenShareTool
+License: MIT
+ShortDescription: Advanced forensic anti-cheat analysis tool for Minecraft server screen shares
+Description: >
+  CharlieRP ScreenShareTool v3.0 — Python rewrite of the PowerShell forensic analysis tool.
+  Detects multi-accounting, cheat self-destruction, registry alterations, suspicious deletions,
+  and account switches across 15+ Minecraft launchers. Includes NTFS Journal analysis,
+  BAM/MuiCache/ShimCache registry checks, Prefetch monitoring, and an interactive HTML dashboard.
+  Designed for mc.charlieroleplay.it server administration.
+Tags:
+- minecraft
+- screenshare
+- anti-cheat
+- forensic
+- ntfs-journal
+- minecraft-launcher
+ReleaseNotesUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/tag/v3.0.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Leo-Galli/ScreenShareTool/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Update: LeoGalli.CharlieRPScreenShareTool version 3.0.0

Replaces the PowerShell v2.0.0 with a complete cross-platform Python + Bash rewrite.

### Changes
- **Rewritten in Python 3.8+** (zero external dependencies, stdlib only)
- **Bash script** for macOS/Linux/FreeBSD universal support
- **Modular architecture**: 15 separate Python modules instead of one monolithic script
- **Reduced false positives** with precompiled regex and contextual filtering
- **Modern HTML dashboard** with 9 interactive pages, dark theme
- **26 known cheat clients** monitored for self-destruction
- **15+ Minecraft launchers** supported (Modrinth, Prism, Lunar, CurseForge, etc.)
- **Parallel nickname search** with ThreadPoolExecutor
- **Cross-platform**: Windows, macOS, Linux support

### Checklist
- [x] Signed CLA
- [x] Manifests conform to 1.12 schema
- [x] Only modifies one package manifest
- [x] Installer URL points to valid GitHub release with zip asset

### Release
https://github.com/Leo-Galli/ScreenShareTool/releases/tag/v3.0.0

**Network:** mc.charlieroleplay.it | **Developer:** LeoGalli
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423506)