### PR TITLE
New package: DonislawDev.BeanNetworkTester version 0.5.0

### DIFF
--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
@@ -1,0 +1,28 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# Submitted as manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.5.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BeanNetworkTester/BeanNetworkTester.exe
+# 🔴 Load-bearing. The default for a portable inside an archive is a SYMLINK in the
+# links folder, and this exe cannot be reached through one: it needs its sibling
+# _internal directory, which the symlink leaves behind. Setting this skips the
+# symlink and puts the directory holding the nested file on PATH instead - verified
+# in winget's own source (PortableInstaller.cpp takes the parent of the nested
+# file's path), not inferred from the field's description, which says only
+# "install location".
+ArchiveBinariesDependOnPath: true
+# The program asks for elevation itself when it needs to capture. Saying so here
+# stops winget from running the whole install elevated.
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-08-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/donislawdev/BeanNetworkTester/releases/download/v0.5.0/BeanNetworkTester-v0.5.0-windows-x64.zip
+  InstallerSha256: F6B8BBFEABAB9741B785AB5A0224F13F2DBD090A5A4C94CAE5413AF7D9E67E92
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
@@ -1,6 +1,6 @@
 # Rendered by tools/build_packages.py - do not edit the generated copy.
 # Submitted as manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.installer.yaml
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: DonislawDev.BeanNetworkTester
 PackageVersion: 0.5.0
@@ -25,4 +25,4 @@ Installers:
   InstallerUrl: https://github.com/donislawdev/BeanNetworkTester/releases/download/v0.5.0/BeanNetworkTester-v0.5.0-windows-x64.zip
   InstallerSha256: F6B8BBFEABAB9741B785AB5A0224F13F2DBD090A5A4C94CAE5413AF7D9E67E92
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: DonislawDev
+PublisherUrl: https://github.com/donislawdev/BeanNetworkTester
+PublisherSupportUrl: https://github.com/donislawdev/BeanNetworkTester/issues
+PackageName: Bean Network Tester
+PackageUrl: https://beannetworktester.donislawdev.com
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/donislawdev/BeanNetworkTester/blob/master/LICENSE
+Copyright: Copyright (C) 2026 DonislawDev
+ShortDescription: Simulate a bad network on Windows
+Description: >-
+  Free Windows tool that adds lag, packet loss and speed limits to one app, so you can test how it behaves on a bad connection.
+  It adds latency, jitter, packet loss, corruption, duplication and bandwidth limits
+  to the traffic of a chosen application, and reports every outcome as an exit code
+  so it can run from a pipeline. It needs Administrator rights to capture traffic and
+  asks for them itself. Profiles, window state and CSV exports are kept in
+  %LOCALAPPDATA%\BeanNetworkTester, so upgrading the package leaves them alone.
+Moniker: bean-network-tester
+Tags:
+- bandwidth
+- latency
+- network
+- packet-loss
+- qa
+- testing
+- windivert
+ReleaseNotesUrl: https://github.com/donislawdev/BeanNetworkTester/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Rendered by tools/build_packages.py - do not edit the generated copy.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: DonislawDev.BeanNetworkTester
 PackageVersion: 0.5.0
@@ -31,4 +31,4 @@ Tags:
 - windivert
 ReleaseNotesUrl: https://github.com/donislawdev/BeanNetworkTester/releases/tag/v0.5.0
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.yaml
@@ -1,8 +1,8 @@
 # Rendered by tools/build_packages.py - do not edit the generated copy.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: DonislawDev.BeanNetworkTester
 PackageVersion: 0.5.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.5.0/DonislawDev.BeanNetworkTester.yaml
@@ -1,0 +1,8 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
New package: **DonislawDev.BeanNetworkTester** version 0.5.0

A Windows tool that adds latency, jitter, packet loss, corruption, duplication and
bandwidth limits to the traffic of a chosen application, so its behaviour on a bad
connection can be tested. GPL-3.0, GUI and CLI, x64 only.

### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.x [schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.28.0)?

The Contributor License Agreement will be signed by the repository owner when the bot asks.

### What was tested before submitting

Installed from these manifests and then uninstalled, on **Windows 11** and on
**Windows Server 2025**:

- the installer hash was verified by the client, and independently against the
  release's own `SHA256SUMS.txt`;
- the program starts from the extracted location and reports itself correctly;
- a real capture session runs and impairs traffic, on both systems;
- uninstall removes the package and leaves the user's own files, which live in
  `%LOCALAPPDATA%\BeanNetworkTester`, untouched.

### Two notes on the manifest

- `ArchiveBinariesDependOnPath: true` is deliberate. This is a PyInstaller one-folder
  build, so the executable needs its sibling `_internal` directory; the default
  symlink for a portable inside an archive would separate the two. With this field
  set, the install directory goes on PATH and no symlink is created - verified in the
  extracted layout after a real install.
- `ElevationRequirement: elevatesSelf`. The program needs Administrator rights only
  when it captures traffic, and asks for them itself, so the install does not need to
  run elevated.

The installer URL is the project's own GitHub release, and the release is
Authenticode-signed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423538)