### PR TITLE
New version: nzbfast.nzbfast version 1.2.3

### DIFF
--- a/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.installer.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.installer.yaml
@@ -16,7 +16,6 @@ ReleaseDate: 2026-08-25
 AppsAndFeaturesEntries:
 - DisplayName: nzbfast
   Publisher: nzbfast
-  DisplayVersion: 1.2.3
   ProductCode: '{72B5B673-54D7-46ED-BDDC-C7D3E571D242}_is1'
 Installers:
 - Architecture: x64

--- a/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.installer.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.2.3
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-25
+AppsAndFeaturesEntries:
+- DisplayName: nzbfast
+  Publisher: nzbfast
+  DisplayVersion: 1.2.3
+  ProductCode: '{72B5B673-54D7-46ED-BDDC-C7D3E571D242}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nzbfast/nzbfast/releases/download/v1.2.3/nzbfast-1.2.3-windows-x64-setup.exe
+  InstallerSha256: 0D60DD86486C549579EA80B7FE3F669B641405ABC51E3E00962636CE0FF87B06
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.locale.en-US.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.2.3
+PackageLocale: en-US
+Publisher: nzbfast
+PublisherUrl: https://github.com/nzbfast/nzbfast
+PublisherSupportUrl: https://github.com/nzbfast/nzbfast/issues
+PackageName: nzbfast
+PackageUrl: https://nzbfast.github.io/nzbfast/
+License: GPL-3.0
+LicenseUrl: https://github.com/nzbfast/nzbfast/blob/main/LICENSE
+ShortDescription: The fast Usenet downloader
+Description: |-
+  One self-contained executable: line-rate downloads, one-pass verify and
+  extract, a poster wall, and a built-in indexer. Speaks the SABnzbd and
+  NZBGet APIs, so Sonarr and Radarr connect unmodified.
+Moniker: nzbfast
+Tags:
+- downloader
+- nzb
+- nzbget
+- sabnzbd
+- usenet
+ReleaseNotesUrl: https://github.com/nzbfast/nzbfast/releases/tag/v1.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.yaml
+++ b/manifests/n/nzbfast/nzbfast/1.2.3/nzbfast.nzbfast.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nzbfast.nzbfast
+PackageVersion: 1.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of nzbfast, a speed-focused Usenet downloader.

Installer: Inno Setup exe from the project's GitHub release, hash verified against the release's own `SHA256SUMS.txt`.

This supersedes my two earlier open PRs for this package (#417149 for 1.1.1 and #423063 for 1.2.2), which I am closing in favour of this one so there is a single New-Package PR at the current version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423649)