### PR TITLE
Add: 20090106-520.Deepseek-Harness-EAC version 4.6.0

### DIFF
--- a/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.installer.yaml
+++ b/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 20090106-520.Deepseek-Harness-EAC
+PackageVersion: 4.6.0
+Installers:
+  # 安装版：NSIS 用户级向导（oneClick: false，可选安装目录）
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/20090106-520/Deepseek-Harness-EAC/releases/download/v4.6.0/Deepseek-Harness-EAC-Setup-v4.6.0-x64.exe
+    InstallerSha256: F977D4C9A869281A192CA5272C4A36800F5F3CED88DA7AEEEAEEED1253F10BFE
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+      Interactive: ""
+      InstallLocation: /D=<INSTALLPATH>
+    UpgradeBehavior: install
+    ProductCode: '"Deepseek Harness EAC"'
+  # 便携版：单文件免安装 exe，winget 仅负责下载到固定位置并创建入口
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/20090106-520/Deepseek-Harness-EAC/releases/download/v4.6.0/Deepseek-Harness-EAC-Portable-v4.6.0-x64.exe
+    InstallerSha256: 0E370F214A49017A8F4D2B61EC759979B036D8BD04447379A09EF57A417381BA
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.locale.zh-CN.yaml
+++ b/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.locale.zh-CN.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 20090106-520.Deepseek-Harness-EAC
+PackageVersion: 4.6.0
+# 本清单为「默认区域设置」清单（zh-CN）。
+# 完整提交还需同目录另外两份：20090106-520.Deepseek-Harness-EAC.yaml（version）
+# 与 20090106-520.Deepseek-Harness-EAC.installer.yaml（installer）。
+PackageLocale: zh-CN
+Publisher: 20090106-520
+PublisherUrl: https://github.com/20090106-520
+PublisherSupportUrl: https://github.com/20090106-520/Deepseek-Harness-EAC/issues
+PackageName: Deepseek Harness EAC
+PackageUrl: https://github.com/20090106-520/Deepseek-Harness-EAC
+License: MIT
+LicenseUrl: https://github.com/20090106-520/Deepseek-Harness-EAC/blob/main/LICENSE
+Copyright: Copyright (c) 2026 20090106-520; original desktop wrapper by zouyuxuan122 (MIT)
+ShortDescription: DeepSeek Harness (dsh) 的 Windows 桌面客户端，开箱即用
+Description: |-
+  把 @deepseek-ai/dsh（DeepSeek Harness）封装成开箱即用的 Windows 桌面客户端：
+  内置独立 Node 运行时与完整 dsh CLI，免装 Node.js；无边框玻璃窗口、系统托盘、
+  多窗口分屏、会话完成通知、DeepSeek 余额小部件、文件更改追踪与一键还原、
+  AI 变更审核、插件市场与 20+ 内置社区插件、10 款界面皮肤；支持官方 dsh 跟随更新
+  与客户端自更新（SHA-256 强校验）。本包为安装版（NSIS 向导）；另有便携版资产。
+Tags:
+  - deepseek
+  - ai
+  - agent
+  - chatbot
+  - electron
+  - dsh
+  - llm
+ReleaseNotesUrl: https://github.com/20090106-520/Deepseek-Harness-EAC/releases/tag/v4.6.0
+InstallationNotes: 建议安装到纯英文路径；启动后如未配置 API Key，请在界面内完成配置。
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.yaml
+++ b/manifests/2/20090106-520/Deepseek-Harness-EAC/4.6.0/20090106-520.Deepseek-Harness-EAC.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 20090106-520.Deepseek-Harness-EAC
+PackageVersion: 4.6.0
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
This is a new package submission for Deepseek Harness EAC, the Windows desktop client wrapping @deepseek-ai/dsh (DeepSeek Harness).

- Source repository: https://github.com/20090106-520/Deepseek-Harness-EAC
- Installer URLs point to the GitHub Release v4.6.0 assets; SHA-256 values were taken from the released SHA256SUMS.txt and verified locally with Get-FileHash.
- Manifests validated with `winget validate` (success, no warnings).
- Package was tested locally: installed and uninstalled successfully.

- [x] Have you signed your commits? (git commit -s)
- [x] Have you checked that the package does not already exist in the repository?
- [x] Have you followed the [manifest authoring instructions](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423675)