### PR TITLE
Update version: Dystroy.broot version 1.59.0

### DIFF
--- a/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.installer.yaml
+++ b/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Dystroy.broot
+PackageVersion: 1.59.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: x86_64-pc-windows-gnu/broot.exe
+ReleaseDate: 2026-08-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Canop/broot/releases/download/v1.59.0/broot_1.59.0.zip
+  InstallerSha256: F89462CC883D79B548E207A4B2EC34B3736604D0CC54C86F59BE5B4F1570A2FD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.locale.en-US.yaml
+++ b/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Dystroy.broot
+PackageVersion: 1.59.0
+PackageLocale: en-US
+Publisher: Dystroy
+PublisherUrl: https://dystroy.org/broot/
+PublisherSupportUrl: https://github.com/Canop/broot/issues
+PackageName: Broot
+PackageUrl: https://github.com/Canop/broot
+License: MIT
+LicenseUrl: https://github.com/Canop/broot/blob/HEAD/LICENSE
+ShortDescription: A new way to see and navigate directory trees.
+Tags:
+- cli
+- command-line
+- rust
+ReleaseNotes: "• new `shell_command` verb attribute：run a command through a shell (`sh -c` / `cmd /C`) so `&&`, `;` and pipes work, without leaving broot - Fix #1145\r\n• fix invalid official Mac binary (duplicate linked dylib) with new build chain - Fix #1194\r\n• Sixel graphics support for image preview, auto-detected：works in iterm2, Windows Terminal 1.22+ and Sixel-capable Unix terminals (foot, mlterm, xterm built with Sixel, recent WezTerm). Kitty remains the preferred protocol when available. Note: this requires broot to be compiled with sixel feature (eg `cargo install broot --features sixel`) - Fix #568 - Thanks @jamison-wilde\r\n• High-Res images in Rio terminal (detect it to enable the Kitty image protocol) - Fix #1179\r\n• fix content-exact match line number off-by-one when the match starts at the first byte of a line (broot jumped to the line above) - Thanks @YuriNachos\r\n• new `:no_action` internal, doing nothing, which can be used to disable a key - Fix #328\r\n• fix：detect a duplicate broot server name instead of silently overtaking the running server - Fix #1065 - Thanks @YuriNachos\r\n• fix preview transformers extension matching not working with double extensions such as `.tar.gz` - Fix #1195\r\n• strip escape sequences from displayed names to prevent OSC injections - Fix #1188 - Thanks @carfeii\r\n• fall back to numeric uid/gid instead of `????` when the user or group name can't be resolved, which is always the case on statically linked musl builds - Fix #1075\r\n• fix panic on a content regex matching the empty string at the end of a line ending with a control char (eg `cr/$/` on a CRLF file)\r\n• fix Windows paths (containing backslashes) being mangled by the launcher's eval when using `:cd` and similar; also fixes escaping of paths containing a single quote - Fix #1100 - Thanks @Cyrus580529\r\n• fix `br` failing on Windows/PowerShell when the temp path contains a space (e.g. a space in the Windows username) - Fix #788 - Thanks @chinhkrb113\r\n• JPEG XL images are no longer previewed：the decoder had out-of-bounds bugs and the fix needs a more recent rustc (if you need it, tell me and I'll try to make it opt-in)\r\n• rustc minimal version changed from 1.83 to 1.85, and edition 2024"
+ReleaseNotesUrl: https://github.com/Canop/broot/releases/tag/v1.59.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.yaml
+++ b/manifests/d/Dystroy/broot/1.59.0/Dystroy.broot.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Dystroy.broot
+PackageVersion: 1.59.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Dystroy.broot to version 1.59.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423699)