### PR TITLE
Fix OpenScreen.OpenScreen 1.10.0 InstallerSha256 mismatch

### DIFF
--- a/manifests/o/OpenScreen/OpenScreen/1.10.0/OpenScreen.OpenScreen.installer.yaml
+++ b/manifests/o/OpenScreen/OpenScreen/1.10.0/OpenScreen.OpenScreen.installer.yaml
@@ -14,6 +14,6 @@ AppsAndFeaturesEntries:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/getopenscreen/openscreen/releases/download/v1.10.0/Openscreen.Setup.1.10.0.exe
-  InstallerSha256: B2D20CD3A8C7F53AA4593A1252AF676E4FC9B46B751D8FA5093B650EA5F9F2DD
+  InstallerSha256: A04BD276C3679B4F1F8D406C9B9A58715F569BA35180FF9E13AFA244787A3C3F
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
This PR corrects the `InstallerSha256` for `OpenScreen.OpenScreen` 1.10.0.

Current manifest records `B2D20CD3A8C7F53AA4593A1252AF676E4FC9B46B751D8FA5093B650EA5F9F2DD`, but the actual installer at `https://github.com/getopenscreen/openscreen/releases/download/v1.10.0/Openscreen.Setup.1.10.0.exe` hashes to `A04BD276C3679B4F1F8D406C9B9A58715F569BA35180FF9E13AFA244787A3C3F` (confirmed via GitHub release asset digest and a local download).

As a result `winget install` / `winget upgrade` fail with installer hash mismatch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423711)