### PR TITLE
New version: LeeSoft.ViStart version 8.1.0.5344

### DIFF
--- a/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.installer.yaml
+++ b/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViStart
+PackageVersion: 8.1.0.5344
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK
+UpgradeBehavior: install
+ReleaseDate: 2026-08-24
+Installers:
+- Architecture: x86
+  InstallerUrl: https://lee-soft.com/bin/windows-start-menu-vistart-8105344.exe
+  InstallerSha256: 6BDEBE7FD370685BA4EC182D4F0F57889D1A0E4FD78EB28738F1D311F38E434B
+  ProductCode: '{D4837ABF-9483-4945-A490-2FE854E11259}}_is1'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{D4837ABF-9483-4945-A490-2FE854E11259}}_is1'
+    DisplayVersion: 8.1.0.5344
+    Publisher: Lee-Soft.com
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.locale.en-US.yaml
+++ b/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViStart
+PackageVersion: 8.1.0.5344
+PackageLocale: en-US
+Publisher: Lee-Soft.com
+PublisherUrl: https://lee-soft.com
+PublisherSupportUrl: https://lee-soft.com/vistart/
+PrivacyUrl: https://lee-soft.com/privacy-policy/
+Author: Lee Chantrey
+PackageName: ViStart
+PackageUrl: https://lee-soft.com/vistart/
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/lee-soft/ViStart/blob/main/LICENSE.md
+Copyright: Copyright (C) Lee-Soft.com
+ShortDescription: The fully customisable start menu replacement
+Description: |-
+  ViStart replaces the Windows Start menu with a fully skinnable Windows 7-style
+  menu, on every version of Windows from XP through 11. It lists your installed
+  programs, jump lists and Microsoft Store apps, searches files and settings, and
+  takes over the Start button so the menu opens where you expect it.
+
+  Thirteen skins ship with it and the skin format is open, so the menu can be made
+  to look like almost anything. It installs per-user, needs no administrator
+  rights, carries no adverts and asks for no account. Free and open source,
+  written in Visual Basic 6 and maintained since 2009.
+Moniker: vistart
+Tags:
+- customization
+- launcher
+- open-source
+- shell
+- skinning
+- start-button
+- start-menu
+- startmenu
+- taskbar
+- windows-11
+- windows-7
+ReleaseNotes: |-
+  Runs alongside ViFind now.
+
+  ViFind keeps a decoy Shell_TrayWnd window to host the notification area, and
+  ViStart's taskbar lookup took whichever Shell_TrayWnd the shell handed back
+  first - so on a machine running both, ViStart adopted ViFind's window as the
+  taskbar and put its Start orb on ViFind's bar at the top of the screen. It now
+  walks every Shell_TrayWnd and takes the first one owned by explorer.exe. An
+  unidentifiable owner still passes, so Windows XP keeps its taskbar.
+ReleaseNotesUrl: https://lee-soft.com/vistart/whats-new/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.yaml
+++ b/manifests/l/LeeSoft/ViStart/8.1.0.5344/LeeSoft.ViStart.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViStart
+PackageVersion: 8.1.0.5344
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **LeeSoft.ViStart 8.1.0.5344**. I maintain ViStart (lee-soft.com); this package's only existing version is `1.0`, submitted by a third party, which points at `windows-start-menu-vistart-8105311.exe` — 33 revisions behind and predating the app's Windows 11 support.

Beyond the version bump, this manifest carries things the existing one could not:

- **`Scope: user`** — ViStart is a per-user install (`PrivilegesRequired=lowest`, into `%APPDATA%\ViStart`), so winget need not elevate.
- **`ProductCode` / `AppsAndFeaturesEntries`** — the Inno uninstall key is `{D4837ABF-9483-4945-A490-2FE854E11259}}_is1`, with a doubled closing brace produced by the script's `{{...}}` escaping. Correlation has to be by ProductCode because the ARP `DisplayName` carries the version ("ViStart version 8.1.0.5344"). Without this `winget upgrade` cannot see the package.
- **`/NOVIDECK` in the silent switches.** The interactive installer offers an optional companion updater on its own wizard page, ticked by default. A silent install would take that default and lay down a second program the user never saw offered — and anyone installing through a package manager already has an update mechanism. `/NOVIDECK` is the installer's documented escape hatch for scripted deployments, so `winget install` puts down ViStart and nothing else. Interactive installs are unchanged and still ask.
- Publisher, licence, privacy and support URLs, description, tags and a moniker; the existing manifest has none of these.

Leaving `1.0` in place rather than removing it in the same PR, so this touches one manifest only.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the one unticked box

`winget install --manifest` needs `LocalManifestFiles` enabled by an administrator, which I could not do on the build machine. Instead I ran the exact command line winget would issue —

```
windows-start-menu-vistart-8105344.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK
```

— and confirmed a clean exit, the app relaunching itself as the installer's silent path intends, and the resulting ARP entry:

```
Key            : {D4837ABF-9483-4945-A490-2FE854E11259}}_is1
DisplayName    : ViStart version 8.1.0.5344
DisplayVersion : 8.1.0.5344
Publisher      : Lee-Soft.com
```

`InstallerSha256` was taken from the live URL and matches the build artefact byte for byte (2,418,951 bytes).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423728)