### PR TITLE
New version: MarcoSburlino.Koinkat version 0.1.1

### DIFF
--- a/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.installer.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/MarcoSburlino/Koinkat/releases/download/v0.1.1/Koinkat_0.1.1_x64-setup.exe
+  InstallerSha256: 5116CFC9291189C7DF5C5490E1A105542BFE82076F65DDE943F41F134295E4AD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.locale.en-US.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Marco Sburlino
+PublisherUrl: https://github.com/MarcoSburlino
+PublisherSupportUrl: https://github.com/MarcoSburlino/Koinkat/issues
+PrivacyUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/docs/privacy-policy.md
+PackageName: Koinkat
+PackageUrl: https://github.com/MarcoSburlino/Koinkat
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Marco Sburlino
+ShortDescription: Local-first multi-currency personal finance manager.
+Description: Koinkat is a local-first desktop app for tracking personal finances across multiple currencies and bank accounts. All data stays on your device. Connect European banks via PSD2 (Enable Banking), or use it manually. No cloud sync, no telemetry, no accounts.
+Moniker: koinkat
+Tags:
+- desktop
+- local-first
+- open-banking
+- personal-finance
+- privacy
+- psd2
+- react
+- rust
+- sqlite
+- tauri
+- typescript
+ReleaseNotesUrl: https://github.com/MarcoSburlino/Koinkat/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.1/MarcoSburlino.Koinkat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Version update for MarcoSburlino.Koinkat: 0.1.0 to 0.1.1. Same package accepted in #410828, including the PrivacyUrl field added there at the reviewer's request. Manifests use the 1.6.0 schema, unchanged from the accepted 0.1.0 submission.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423736)