### PR TITLE
New version: FedeB2160.WinGetStudio version 1.10.1

### DIFF
--- a/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.installer.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.installer.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.1
+InstallerLocale: en-US
+InstallerType: portable
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/FedeB2160/WinGetStudio/releases/download/v1.10.1/WinGetStudio.exe
+  InstallerSha256: F27BF17C45BCEE170C3564E27ED276C4192623115491F1AECC42B487EBDFF7C9
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-25

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.locale.en-US.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.1
+PackageLocale: en-US
+Publisher: FedeB2160
+PublisherUrl: https://github.com/FedeB2160
+PublisherSupportUrl: https://github.com/FedeB2160/WinGetStudio/issues
+PackageName: WinGet Studio
+PackageUrl: https://github.com/FedeB2160/WinGetStudio
+License: MIT
+LicenseUrl: https://github.com/FedeB2160/WinGetStudio/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Federico Borghi
+ShortDescription: 'A desktop front end for winget: update, install, uninstall, pin and export packages.'
+Description: |-
+  A Windows desktop front end for winget. Everything happens in one table with checkboxes:
+  update what has a newer version, install something new by searching as you type, list and
+  uninstall what is already there, pin what must not be touched, and export or import the whole
+  package list to rebuild a machine.
+
+  Light and dark theme, no telemetry, a single executable with nothing to install. Requires
+  administrator rights, which it asks for at startup.
+Moniker: wingetstudio
+Tags:
+- gui
+- package-manager
+- packages
+- winget
+ReleaseNotesUrl: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/FedeB2160/WinGetStudio/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.locale.en-US.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.locale.en-US.yaml
@@ -27,9 +27,16 @@ Tags:
 - package-manager
 - packages
 - winget
+ReleaseNotes: |-
+  Fixes only. Installed with winget, the app no longer replaces its own executable: a
+  portable package is a file winget owns, and rewriting it left winget with a hash that no
+  longer matched, a leftover .exe.old and an uninstall entry naming the old version, so the
+  package could be neither upgraded nor reinstalled. Update now says to use
+  `winget upgrade FedeB2160.WinGetStudio`.
+
+  A tooltip on a tab no longer falls through to every control in the page, the Result column
+  no longer opens an empty one over rows with no result, tooltips follow the theme and wrap,
+  and the Updates section of Settings reads in two labelled lines instead of three stacked.
 ReleaseNotesUrl: https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.1
-Documentations:
-- DocumentLabel: Wiki
-  DocumentUrl: https://github.com/FedeB2160/WinGetStudio/wiki
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.yaml
+++ b/manifests/f/FedeB2160/WinGetStudio/1.10.1/FedeB2160.WinGetStudio.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FedeB2160.WinGetStudio
+PackageVersion: 1.10.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Patch release of an existing package. Publisher and installer type are unchanged:
a single portable executable, `ElevationRequirement: elevatesSelf`, x86 built with
ps2exe and running on x64 through WOW64.

- **Package:** FedeB2160.WinGetStudio 1.10.1 (previous published version: 1.10.0)
- **Installer:** https://github.com/FedeB2160/WinGetStudio/releases/download/v1.10.1/WinGetStudio.exe
- **SHA256:** F27BF17C45BCEE170C3564E27ED276C4192623115491F1AECC42B487EBDFF7C9
- **Release notes:** https://github.com/FedeB2160/WinGetStudio/releases/tag/v1.10.1

This version is a bug-fix release, and one of the fixes concerns winget itself:
1.10.0 could replace its own executable from its Settings page, which corrupted a
portable install done through winget. The app now detects that it is running from
`%LOCALAPPDATA%\Microsoft\WinGet\Packages\` and points the user at
`winget upgrade FedeB2160.WinGetStudio` instead of updating itself. Anyone who
already hit this can recover with `winget uninstall FedeB2160.WinGetStudio --force`
followed by a fresh install.

The remaining fixes are user-interface only: tooltips no longer leak from a tab onto
the controls inside it, an empty tooltip no longer opens over grid rows with no
result yet, tooltips follow the app theme and wrap instead of running off screen, and
the Updates section of Settings is laid out in two labelled rows.

Manifests validated with `winget validate`. The executable is Authenticode-signed
and timestamped, with the same self-signed certificate as the previously published
versions (`CN=WinGet Studio`, thumbprint 139AD24ECA430A310495641A8FBBA66D305FA57D).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.