### PR TITLE
New version: GRCSAC.NetVane version 1.2.1

### DIFF
--- a/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.installer.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.1
+# Matches the published requirement ("Windows 10 or 11, 64-bit"). Deliberately not stricter: this
+# field makes winget REFUSE to install below it, so it must not promise less than the website does.
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-25
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://netvane.doorvane.com/downloads/NetVane-Setup-1.2.1.exe
+    InstallerSha256: 3232C87F9D1FE3C7CA1228F62E06994B2C9206DA61DEC09B8E7FEC19ED858B8F
+    # Inno's uninstall key is "{AppId}_is1"; AppId is pinned in installer/netvane.iss and must
+    # never change between versions, since it drives upgrade and uninstall detection.
+    ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+    AppsAndFeaturesEntries:
+      # UninstallDisplayName in the .iss is "NetVane {version}", so the ARP name is NOT the
+      # package name and changes every release. Without this, winget cannot correlate an
+      # existing install and would offer an upgrade that is already applied.
+      - DisplayName: NetVane 1.2.1
+        DisplayVersion: 1.2.1
+        Publisher: GRCSAC
+        ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+        # No UpgradeCode: that is an MSI concept and this is an Inno installer. Putting the Inno
+        # AppId there would look right and mean nothing.
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.locale.en-US.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.1
+PackageLocale: en-US
+# Publisher matches the Authenticode certificate subject (CN=GRCSAC), which is what Windows
+# displays. GRCSAC LLC is the legal entity and appears in Copyright and the EULA. Keeping these
+# distinct is deliberate - see the note in installer/netvane.iss.
+Publisher: GRCSAC
+PublisherUrl: https://netvane.doorvane.com
+PublisherSupportUrl: https://netvane.doorvane.com/support/
+PrivacyUrl: https://netvane.doorvane.com/privacy/
+Author: GRCSAC
+PackageName: NetVane
+PackageUrl: https://netvane.doorvane.com
+License: Proprietary
+LicenseUrl: https://netvane.doorvane.com/eula/
+Copyright: Copyright (c) 2026 GRCSAC LLC
+CopyrightUrl: https://netvane.doorvane.com/eula/
+ShortDescription: Maps the devices on your network and shows what they are exposing, entirely on your own machine
+Description: |-
+  NetVane finds the devices on your network - phones, laptops, cameras, smart-home gadgets -
+  and draws them as a live map: what each device is, how it connects, and what it is exposing,
+  with plain-language fixes.
+
+  Discovered service versions are matched against an NVD and CISA-KEV vulnerability database
+  bundled with the app, so exposure checks work with no internet connection. There is no cloud
+  service, no account and no agent: the app opens a local dashboard at 127.0.0.1:8787 and keeps
+  everything in a local database on the machine it runs on.
+
+  The free edition is not a trial. Discovery, the topology map, device identification, port
+  fingerprinting, CVE and KEV matching, report export and local backups are all perpetual, with
+  no account required, and vulnerability and fingerprint data updates stay free. Optional Pro and
+  Business licences add scheduled and background scanning, multiple subnets, credentialed
+  validation, extended retention, remote alerts, and compliance reporting for teams.
+
+  Installs per-user and needs no administrator rights. A portable build is also available from
+  the website for use without installing.
+Moniker: netvane
+Tags:
+  - cve
+  - device-discovery
+  - inventory
+  - lan
+  - network
+  - network-map
+  - network-monitor
+  - network-scanner
+  - offline
+  - port-scanner
+  - privacy
+  - security
+  - sysadmin
+  - topology
+  - vulnerability-scanner
+ReleaseNotes: |-
+  A maintenance release. Searching Settings for "licence" now takes you to the licence rather
+  than to Scanning; the uninstaller now discloses the single first-run timestamp it keeps; and
+  the session list of internet requests now names the exact host contacted for a problem
+  report.
+ReleaseNotesUrl: https://netvane.doorvane.com/changelog/
+Documentations:
+  - DocumentLabel: User guide
+    DocumentUrl: https://netvane.doorvane.com/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.2.1/GRCSAC.NetVane.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: `GRCSAC.NetVane` version 1.2.1

Maintenance release of NetVane (local network scanner for Windows). Same publisher, install behaviour and identity as the 1.2.0 submission (#423491, currently in moderation); only the version, installer URL, SHA256, release date and ARP `DisplayName`/`DisplayVersion` change.

- Installer URL (version-pinned, immutable): https://netvane.doorvane.com/downloads/NetVane-Setup-1.2.1.exe — live and verified resolving before this PR was opened
- Authenticode-signed, `CN=GRCSAC`, Microsoft Trusted Signing, timestamped
- SHA256 matches the vendor's Ed25519-signed `version.json`, which is what the app's own updater verifies against

- [x] Validated locally: `winget validate` → succeeded (winget v1.29.290)
- [x] The 1.2.0 URL remains hosted, so the earlier submission keeps resolving
- [x] Install path exercised via the in-app updater (download → SHA256 verify → silent Inno install → relaunch); post-install ARP entry matches `AppsAndFeaturesEntries` exactly (`NetVane 1.2.1` / `1.2.1` / `GRCSAC`)
- [ ] CLA — signed on #423491 (same account)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423778)