### PR TITLE
Update: LeoGalli.CharlieRPScreenShareTool to v3.0.0 (zip installer)

### DIFF
--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
@@ -10,11 +10,11 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: 5731BCAE7714FA0248ED6326DEA167A7728DD2A62A0F8819523C699306A310A3
+  InstallerSha256: 0BF298E09735CDC173128AC2FEE7F8A56C1E6107ADA28EA1D6B4E0CEDFFDDA04
   ArchiveBinariesDependOnPath: true
 - Architecture: x86
   InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: 5731BCAE7714FA0248ED6326DEA167A7728DD2A62A0F8819523C699306A310A3
+  InstallerSha256: 0BF298E09735CDC173128AC2FEE7F8A56C1E6107ADA28EA1D6B4E0CEDFFDDA04
   ArchiveBinariesDependOnPath: true
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
@@ -10,8 +10,12 @@ Commands:
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
-  InstallerSha256: DCB021BACBD557CBC5FCA863DE62B436D4D8B1B4393276DED30EFC3240E9EC3C
+  InstallerSha256: 5731BCAE7714FA0248ED6326DEA167A7728DD2A62A0F8819523C699306A310A3
+  ArchiveBinariesDependOnPath: true
+- Architecture: x86
+  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
+  InstallerSha256: 5731BCAE7714FA0248ED6326DEA167A7728DD2A62A0F8819523C699306A310A3
   ArchiveBinariesDependOnPath: true
 ManifestType: installer
 ManifestVersion: 1.12.0
-ReleaseDate: 2026-08-24
+ReleaseDate: 2026-08-24

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: screensharetool.exe
+Commands:
+- screensharetool
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/download/v3.0.0/CharlieRPScreenShareTool-v3.0.0.zip
+  InstallerSha256: DCB021BACBD557CBC5FCA863DE62B436D4D8B1B4393276DED30EFC3240E9EC3C
+  ArchiveBinariesDependOnPath: true
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-24

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.locale.en-US.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+PackageLocale: en-US
+Publisher: LeoGalli
+PublisherUrl: https://github.com/Leo-Galli
+PublisherSupportUrl: https://github.com/Leo-Galli/ScreenShareTool/issues
+PackageName: CharlieRP ScreenShareTool
+PackageUrl: https://github.com/Leo-Galli/ScreenShareTool
+License: MIT
+ShortDescription: Advanced forensic anti-cheat analysis tool for Minecraft server screen shares
+Description: >
+  CharlieRP ScreenShareTool v3.0 — Python rewrite of the PowerShell forensic analysis tool.
+  Detects multi-accounting, cheat self-destruction, registry alterations, suspicious deletions,
+  and account switches across 15+ Minecraft launchers. Includes NTFS Journal analysis,
+  BAM/MuiCache/ShimCache registry checks, Prefetch monitoring, and an interactive HTML dashboard.
+  Designed for mc.charlieroleplay.it server administration.
+Tags:
+- minecraft
+- screenshare
+- anti-cheat
+- forensic
+- ntfs-journal
+- minecraft-launcher
+ReleaseNotesUrl: https://github.com/Leo-Galli/ScreenShareTool/releases/tag/v3.0.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Leo-Galli/ScreenShareTool/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.yaml
+++ b/manifests/l/LeoGalli/CharlieRPScreenShareTool/3.0.0/LeoGalli.CharlieRPScreenShareTool.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LeoGalli.CharlieRPScreenShareTool
+PackageVersion: 3.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Update: LeoGalli.CharlieRPScreenShareTool to v3.0.0

### Changes
- **Version**: 2.0.0 → 3.0.0
- **Installer type**: Changed from raw `portable` exe to `zip` with nested portable
- **Package**: Complete Python + Bash cross-platform rewrite of the forensic anti-cheat tool

### Why zip instead of portable exe
The previous PR (#423511) failed Installation Validation because the raw portable exe requires administrator privileges and interactive console input, which caused the automated installer test to fail. Using `zip` with `NestedInstallerType: portable` extracts the files without executing them, passing validation.

### Files in zip
- `screensharetool.exe` — Standalone executable (8.4MB, no Python required)
- `run.bat` — Auto-elevating launcher
- `README.md` — Documentation

### Verification
- Manifest Validation: ✅ Pass
- URLs Validation: ✅ Pass
- Release: https://github.com/Leo-Galli/ScreenShareTool/releases/tag/v3.0.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423780)