### PR TITLE
New version: LeeSoft.ViPad version 2.0.0.44

### DIFF
--- a/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.installer.yaml
+++ b/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViPad
+PackageVersion: 2.0.0.44
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK
+UpgradeBehavior: install
+ReleaseDate: 2026-08-09
+Installers:
+- Architecture: x86
+  InstallerUrl: https://lee-soft.com/bin/vipad-open-source-desktop-launcher-20044e.exe
+  InstallerSha256: E5EC20014E9DFDE32776D93A54D1455D2607248BEE7EB8B42B3423A5639C0C4D
+  ProductCode: '{713C751C-D744-491C-86FF-5A667B33F71E}_is1'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{713C751C-D744-491C-86FF-5A667B33F71E}_is1'
+    DisplayVersion: 2.0.0.44
+    Publisher: Lee-Soft.com
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.locale.en-US.yaml
+++ b/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViPad
+PackageVersion: 2.0.0.44
+PackageLocale: en-US
+Publisher: Lee-Soft.com
+PublisherUrl: https://lee-soft.com
+PublisherSupportUrl: https://lee-soft.com/vipad/
+PrivacyUrl: https://lee-soft.com/privacy-policy/
+Author: Lee Chantrey
+PackageName: ViPad
+PackageUrl: https://lee-soft.com/vipad/
+License: AGPL-3.0-only
+Copyright: Copyright (C) Lee-Soft.com
+ShortDescription: A free desktop organiser that groups your icons into labelled pads
+Description: |-
+  ViPad groups your desktop icons into labelled areas laid over your wallpaper,
+  so a cluttered desktop becomes a few tidy pads you can name. One right-click
+  pulls in every shortcut already on the desktop, and the icons underneath can be
+  hidden entirely once they live in a pad.
+
+  The pads are real Windows 11 glass rather than a painted imitation, they follow
+  the desktop rather than floating over your work, and the whole thing is under a
+  megabyte. It installs per-user, needs no administrator rights, and there is no
+  licence key, no trial and no account. Free and open source.
+Moniker: vipad
+Tags:
+- desktop
+- desktop-organizer
+- fences-alternative
+- icons
+- launcher
+- open-source
+- organizer
+- productivity
+- shortcuts
+- windows-11
+ReleaseNotes: |-
+  Real Windows 11 glass for your pads.
+
+  The first ViPad built from the public repository, which could not be compiled
+  before this release. The pads now use the system's own acrylic material instead
+  of an imitation drawn underneath them.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.yaml
+++ b/manifests/l/LeeSoft/ViPad/2.0.0.44/LeeSoft.ViPad.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LeeSoft.ViPad
+PackageVersion: 2.0.0.44
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **LeeSoft.ViPad 2.0.0.44**. I maintain ViPad (lee-soft.com). The package's only existing version is `1.0`, submitted by a third party, pointing at `vipad-open-source-desktop-launcher-setup.exe` — which is **ViPad 2.0.0.17 from March 2023**, 27 revisions behind and predating the Windows 11 acrylic work that is the current release's headline feature.

Same shape as [#423728](https://github.com/microsoft/winget-pkgs/pull/423728) (ViStart, merged this morning), and it adds what the existing manifest lacks:

- **`Scope: user`** — ViPad is a per-user install (`PrivilegesRequired=lowest`, into `%APPDATA%\ViPad`), so winget need not elevate.
- **`ProductCode` / `AppsAndFeaturesEntries`** — `{713C751C-D744-491C-86FF-5A667B33F71E}_is1`, read back off a real installation rather than derived from the script. Without it winget cannot correlate the install and `winget upgrade` never sees the package. Correlation must be by ProductCode because the ARP `DisplayName` carries the version ("ViPad version 2.0.0.44").
- **`/NOVIDECK` in the silent switches.** The interactive installer offers an optional companion updater on its own wizard page, ticked by default. A silent install would take that default and lay down a second program the user was never shown — and anyone installing through a package manager already has an update mechanism. `/NOVIDECK` is the installer's documented escape hatch for scripted deployments, so `winget install` puts down ViPad and nothing else. Interactive installs are unchanged and still ask.
- **A real licence.** The existing manifest records `License: Uninown`. ViPad is AGPL-3.0.
- Publisher, privacy and support URLs, description, tags and a moniker.

Leaving `1.0` in place rather than removing it here, so this touches one manifest only.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### On the one unticked box

`winget install --manifest` needs `LocalManifestFiles` enabled by an administrator, which I could not do on the build machine. The ProductCode above was instead read directly out of the registry from a real 2.0.0.44 installation:

```
Key            : {713C751C-D744-491C-86FF-5A667B33F71E}_is1
DisplayName    : ViPad version 2.0.0.44
DisplayVersion : 2.0.0.44
Publisher      : Lee-Soft.com
```

The silent switch line is shared with ViStart, whose identical `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /NOVIDECK` passed installation validation in #423728.

`InstallerSha256` was taken from the live URL and matches the build artefact byte for byte (1,376,016 bytes).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423797)