### PR TITLE
New package: FlightCatcher.VELA version 2.5.0-beta.4

### DIFF
--- a/manifests/f/FlightCatcher/VELA/2.5.0-beta.4/FlightCatcher.VELA.yaml
+++ b/manifests/f/FlightCatcher/VELA/2.5.0-beta.4/FlightCatcher.VELA.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.10.0.schema.json
+# Prepared for microsoft/winget-pkgs. First publication remains subject to
+# Microsoft's automated validation and moderator review.
+PackageIdentifier: FlightCatcher.VELA
+PackageVersion: 2.5.0-beta.4
+PackageLocale: en-US
+Publisher: FlightCatcher
+PackageName: VELA
+PackageUrl: https://github.com/FlightCatcher/VELA
+License: MIT
+LicenseUrl: https://github.com/FlightCatcher/VELA/blob/main/LICENSE
+ShortDescription: Local-first modular AI agent desktop application
+Description: >-
+  VELA is a local-first AI agent desktop application with local and API model
+  routing, task planning, tools, memory, image generation, diagnostics, and data export.
+Tags:
+  - ai
+  - agent
+  - llm
+  - local-ai
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/FlightCatcher/VELA/releases/download/v2.5.0-beta.4/VELA-Setup-2.5.0-beta.4.exe
+    InstallerSha256: 7F4F0A045A3EC9CD3BB015592DF07FB262D15FAAAA34773B39B120D3698A7D11
+ManifestType: singleton
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Public beta submission for VELA. The NSIS installer is hosted in the official VELA GitHub Release, supports silent installation, and has been validated on a clean Windows GitHub runner.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423803)