### PR TITLE
fix: incorrect dependencies

### DIFF
--- a/manifests/p/PCLCommunity/PCL2-CE/2.15.0/PCLCommunity.PCL2-CE.installer.yaml
+++ b/manifests/p/PCLCommunity/PCL2-CE/2.15.0/PCLCommunity.PCL2-CE.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 - pcl2-ce
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 ReleaseDate: 2026-07-14
 Installers:
 - Architecture: x64

--- a/manifests/p/PCLCommunity/PCL2-CE/Beta/2.15.0-beta.7/PCLCommunity.PCL2-CE.Beta.installer.yaml
+++ b/manifests/p/PCLCommunity/PCL2-CE/Beta/2.15.0-beta.7/PCLCommunity.PCL2-CE.Beta.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 - pcl2-ce-beta
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
 ReleaseDate: 2026-07-09
 Installers:
 - Architecture: x64

--- a/manifests/p/PCLCommunity/PCL2-CE/Beta/2.15.0-beta.7/PCLCommunity.PCL2-CE.Beta.installer.yaml
+++ b/manifests/p/PCLCommunity/PCL2-CE/Beta/2.15.0-beta.7/PCLCommunity.PCL2-CE.Beta.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 - pcl2-ce-beta
 Dependencies:
   PackageDependencies:
-  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
 ReleaseDate: 2026-07-09
 Installers:
 - Architecture: x64


### PR DESCRIPTION
## 📖 Description

This pull request fixed an issue while using winget to install PCL-CE.

2.15.0/2.15.0-beta.7 is currently using .NET Windows Desktop Runtime 10.0. However, the dependencies in the config is keeping .NET Windows Desktop Runtime 8.0.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests\p\PCLCommunity\PCL2-CE\2.15.0` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest manifests\p\PCLCommunity\PCL2-CE\2.15.0`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423832)