### PR TITLE
Add Aburousan.Hilbert version 0.2.3

### DIFF
--- a/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.installer.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.3
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/aburousan/hilbert-editor/releases/download/tauri-v0.2.3/Hilbert_0.2.3_x64-setup.exe
+  InstallerSha256: 26878275E0B2F8F586F198E205C62E916DB084791CF5D7FF4C7C786DD0918DCA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.locale.en-US.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Kazi Abu Rousan
+PublisherUrl: https://github.com/aburousan
+PublisherSupportUrl: https://github.com/aburousan/hilbert-editor/issues
+PackageName: Hilbert
+PackageUrl: https://github.com/aburousan/hilbert-editor
+License: MIT
+LicenseUrl: https://github.com/aburousan/hilbert-editor/blob/main/LICENSE
+ShortDescription: An offline desktop editor for Typst, aimed at maths and physics writing.
+Description: Hilbert is a local, offline desktop editor for the Typst typesetting language, built for maths and physics writing. It compiles and previews as you type, and ships with tools for equations, figures, plots, matrices, tables, and data import, along with code intelligence from tinymist. It installs per user and needs no administrator rights.
+Moniker: hilbert
+Tags:
+- editor
+- latex
+- markdown
+- math
+- offline
+- physics
+- science
+- typesetting
+- typst
+ReleaseNotesUrl: https://github.com/aburousan/hilbert-editor/releases/tag/tauri-v0.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.yaml
+++ b/manifests/a/Aburousan/Hilbert/0.2.3/Aburousan.Hilbert.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Aburousan.Hilbert
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Hilbert 0.2.3.

- Installer: NSIS `-setup.exe`, per-user scope, no administrator rights required.
- Release: https://github.com/aburousan/hilbert-editor/releases/tag/tauri-v0.2.3

Manifests written by hand rather than generated: komac's analyzer aborts on the Tauri WebView2 bootstrapper ("Failed to install WebView2") when it runs the installer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/423894)