### PR TITLE
New package: GuiOttoni.OttoRice version 1.0.7

### DIFF
--- a/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.installer.yaml
+++ b/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GuiOttoni.OttoRice
+PackageVersion: 1.0.7
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: '9F3D2C71-5B84-4E0A-8D6C-2A7E4F1B93C4_is1'
+ReleaseDate: 2026-08-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GuiOttoni/ottorice/releases/download/v1.0.7/OttoRice-Setup-1.0.7.exe
+  InstallerSha256: 0664E6CD9C47D51B6BBD8BAB67578DF9DC378C21DE6206C7CA0EF580F05F4784
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.locale.en-US.yaml
+++ b/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GuiOttoni.OttoRice
+PackageVersion: 1.0.7
+PackageLocale: en-US
+Publisher: Otto
+PublisherUrl: https://github.com/GuiOttoni
+PublisherSupportUrl: https://github.com/GuiOttoni/ottorice/issues
+PackageName: OttoRice
+PackageUrl: https://github.com/GuiOttoni/ottorice
+License: MIT
+LicenseUrl: https://github.com/GuiOttoni/ottorice/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Guilherme Ottoni Escarelli De Alencar
+ShortDescription: A Windows desktop rice/theme manager - install complete GlazeWM + YASB + Windows Terminal setups from a JSON manifest, with transactional backup and automatic rollback.
+Description: >-
+  OttoRice installs complete desktop rice/theme setups on Windows from a JSON
+  manifest, with transactional backup and automatic rollback. Paste a theme
+  repository's URL, review exactly what will change, and OttoRice installs the
+  tiling window manager, status bar, terminal color scheme, wallpaper - even
+  editor themes and Windhawk mods - as one transactional operation you can
+  always undo. Supported apps include GlazeWM, YASB Reborn, Zebar, Windows
+  Terminal, VS Code, Zed, Fastfetch, Flow Launcher, Oh My Posh, and Windhawk
+  mods (Taskbar/Start Menu/Notification Center Styler). If anything fails
+  partway through an install, everything already applied is rolled back
+  automatically.
+Moniker: ottorice
+Tags:
+- theme
+- rice
+- ricing
+- glazewm
+- yasb
+- windows-terminal
+- dotfiles
+- customization
+- desktop
+- window-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.yaml
+++ b/manifests/g/GuiOttoni/OttoRice/1.0.7/GuiOttoni.OttoRice.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GuiOttoni.OttoRice
+PackageVersion: 1.0.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12.0 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests)?

## Notes

OttoRice is an open-source (MIT) Windows desktop app that installs desktop rice/theme
setups (GlazeWM, YASB, Windows Terminal, etc.) from a JSON manifest. Repo:
https://github.com/GuiOttoni/ottorice

The installer is an Inno Setup executable (`PrivilegesRequired=lowest`, no admin
required) and is **not code-signed** at this time; `InstallerSha256` is provided
instead, so end users will see a SmartScreen "unknown publisher" prompt on first run.
Code signing is a possible future addition once a certificate is purchased, but is out
of scope for this submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424084)