### PR TITLE
New package: ZhoelSherk.VALVET version 0.2.0

### DIFF
--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.installer.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.installer.yaml
@@ -1,20 +1,18 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: ZhoelSherk.VALVET
 PackageVersion: 0.2.0
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.17763.0
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-- RelativeFilePath: VALVET\VALVET.exe
-  PortableCommandAlias: valvet
-UpgradeBehavior: install
 ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+  - RelativeFilePath: VALVET\VALVET.exe
+    PortableCommandAlias: valvet
+UpgradeBehavior: install
 Installers:
-- Architecture: x64
-  InstallerUrl: https://github.com/zhoel-sherk/VALVET/releases/download/v0.2.0/VALVET-0.2.0-windows-x64.zip
-  InstallerSha256: B238973302DE41398E665E0DD5F1639932A6B26A3973F8919E2CC420C3373407
+  - Architecture: x64
+    InstallerUrl: https://github.com/zhoel-sherk/VALVET/releases/download/v0.2.0/VALVET-0.2.0-windows-x64.zip
+    InstallerSha256: 5270E4B6A1E189CAB4E0716537A18AFF6DF898368D32883B6BFFF957A8CDD663
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.installer.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: ZhoelSherk.VALVET
+PackageVersion: 0.2.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: VALVET\VALVET.exe
+  PortableCommandAlias: valvet
+UpgradeBehavior: install
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zhoel-sherk/VALVET/releases/download/v0.2.0/VALVET-0.2.0-windows-x64.zip
+  InstallerSha256: B238973302DE41398E665E0DD5F1639932A6B26A3973F8919E2CC420C3373407
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.locale.en-US.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.locale.en-US.yaml
@@ -1,6 +1,4 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: ZhoelSherk.VALVET
 PackageVersion: 0.2.0
 PackageLocale: en-US
@@ -14,14 +12,17 @@ License: MIT
 LicenseUrl: https://github.com/zhoel-sherk/VALVET/blob/main/LICENSE
 Copyright: Copyright (c) 2023 Mariusz Midor and contributors
 ShortDescription: SMT BOM and pick-and-place prep (clean, merge, export). ALPHA.
-Description: |
-  Validator And Line-Verified Export Tool. Load BOM and PnP files, clean component names, cross-check, merge, and export. The Windows package is a PyInstaller onedir zip (Qt DLLs next to VALVET.exe). ACE ODBC and pythonocc are not bundled.
+Description: >
+  Validator And Line-Verified Export Tool. Load BOM and PnP files, clean
+  component names, cross-check, merge, and export. The Windows package is a
+  PyInstaller onedir zip (Qt DLLs next to VALVET.exe). ACE ODBC, pythonocc,
+  and repo example fixtures are not bundled.
 Moniker: valvet
 Tags:
-- smt
-- bom
-- electronics
-- pnp
+  - smt
+  - bom
+  - electronics
+  - pnp
 ReleaseNotesUrl: https://github.com/zhoel-sherk/VALVET/releases/tag/v0.2.0
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.locale.en-US.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: ZhoelSherk.VALVET
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Zhoel Sherk
+PublisherUrl: https://github.com/zhoel-sherk
+PublisherSupportUrl: https://github.com/zhoel-sherk/VALVET/issues
+Author: Zhoel Sherk
+PackageName: VALVET
+PackageUrl: https://github.com/zhoel-sherk/VALVET
+License: MIT
+LicenseUrl: https://github.com/zhoel-sherk/VALVET/blob/main/LICENSE
+Copyright: Copyright (c) 2023 Mariusz Midor and contributors
+ShortDescription: SMT BOM and pick-and-place prep (clean, merge, export). ALPHA.
+Description: |
+  Validator And Line-Verified Export Tool. Load BOM and PnP files, clean component names, cross-check, merge, and export. The Windows package is a PyInstaller onedir zip (Qt DLLs next to VALVET.exe). ACE ODBC and pythonocc are not bundled.
+Moniker: valvet
+Tags:
+- smt
+- bom
+- electronics
+- pnp
+ReleaseNotesUrl: https://github.com/zhoel-sherk/VALVET/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.yaml
@@ -1,8 +1,6 @@
-# Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
-
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: ZhoelSherk.VALVET
 PackageVersion: 0.2.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.yaml
+++ b/manifests/z/ZhoelSherk/VALVET/0.2.0/ZhoelSherk.VALVET.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: ZhoelSherk.VALVET
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## 📖 Description

New package: **ZhoelSherk.VALVET** version **0.2.0** (portable zip + `ArchiveBinariesDependOnPath`). Manifest schema **1.12.0**. Installer SHA256 matches the public GitHub Release asset after a slimmer PyInstaller rebuild (no README screenshots, no repo `examples/`, unused Qt modules dropped).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>` (needs admin `winget settings --enable LocalManifestFiles`; not enabled on this machine). Frozen `VALVET.exe --smoke` from the zip succeeded (exit 0).
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424105)
