### PR TITLE
Add version: Emran-goat.crux 0.1.0

### DIFF
--- a/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.installer.yaml
+++ b/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Emran-goat.crux
+PackageVersion: 0.1.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/Emran-goat/crux/releases/download/v0.1.0/crux-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 2b3ecb39f7136a065904ba01d0842fe2b1bf00286085a1ffb0d022bcbe9323aa
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: crux.exe
+        PortableCommandAlias: crux
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.locale.en-US.yaml
+++ b/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Emran-goat.crux
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Emran-goat
+PackageName: crux
+PackageUrl: https://github.com/Emran-goat/crux
+License: MIT
+LicenseUrl: https://github.com/Emran-goat/crux/blob/main/LICENSE
+ShortDescription: Finds the exact commit behind a behavior change.
+Description: |-
+  crux bisects more than pass/fail. Give it any command whose output changed
+  and it finds the exact commit that flipped the behavior, then explains the
+  flip: minimized causal diff, interaction faults, dependency-chain evidence,
+  ranked candidates for non-monotone history.
+Tags:
+  - git
+  - bisect
+  - debugging
+  - cli
+  - rust
+ReleaseNotesUrl: https://github.com/Emran-goat/crux/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.yaml
+++ b/manifests/e/Emran-goat/crux/0.1.0/Emran-goat.crux.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Emran-goat.crux
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Adds Emran-goat.crux 0.1.0.

crux finds the commit that changed a program's behavior and shows the lines that caused the change.

- Source: https://github.com/Emran-goat/crux
- Installer: https://github.com/Emran-goat/crux/releases/tag/v0.1.0
- Manifests created with [winget-create](https://github.com/microsoft/winget-create) style, verified sha256 against the release asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424115)