### PR TITLE
Update: Remove Microsoft.OpenJDK.11 installer locale stanza

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/11/11.0.32.101/Microsoft.OpenJDK.11.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/11/11.0.32.101/Microsoft.OpenJDK.11.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: Microsoft.OpenJDK.11
 PackageVersion: 11.0.32.101
-InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine


### PR DESCRIPTION
## 📖 Description
Removes the InstallerLocale stanza introduced by the `wingetcreate` tool.
## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [X] Linked to an issue (if applicable)
  - Relevant [#[Issue Number]](https://github.com/microsoft/winget-pkgs/issues/67792)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

<img width="912" height="234" alt="image" src="https://github.com/user-attachments/assets/02fb5131-4f6c-438e-9d2b-0d1b78b8c352" />
<img width="800" height="227" alt="image" src="https://github.com/user-attachments/assets/ac60796c-2c40-41aa-9130-6653e2a4f65c" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424121)