### PR TITLE
Update: Remove Microsoft.OpenJDK.17 installer locale stanza

### DIFF
--- a/manifests/m/Microsoft/OpenJDK/17/17.0.20.101/Microsoft.OpenJDK.17.installer.yaml
+++ b/manifests/m/Microsoft/OpenJDK/17/17.0.20.101/Microsoft.OpenJDK.17.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: Microsoft.OpenJDK.17
 PackageVersion: 17.0.20.101
-InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine


### PR DESCRIPTION
## 📖 Description
Removes the InstallerLocale stanza introduced by the `wingetcreate` tool.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [X] Linked to an issue (if applicable)
  - Relevant [#[Issue Number]](https://github.com/microsoft/winget-pkgs/issues/67792)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

<img width="912" height="234" alt="image" src="https://github.com/user-attachments/assets/cc079ea7-c92a-4491-9dc6-620619eba253" />

<img width="1794" height="424" alt="image" src="https://github.com/user-attachments/assets/aff8103a-1962-4a4e-af5d-d17be00a5d47" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424122)