### PR TITLE
New version: oipoistar.Tinta version 3.3.0

### DIFF
--- a/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.3.0
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-08-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v3.3.0/tinta.exe
+  InstallerSha256: 0603521FA83BB7663E41637427572E8BFC63CF9E68C866C045F52B53008E6519
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.3.0
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable of about 2.1 MB that starts in under 100 ms -
+  no Electron, no web engine, no installer. Features review annotations with a copy-for-agent loop, plain-text file references with mouse back and forward navigation, rendered link previews on hover, export to HTML, DOCX
+  and PDF plus optional Pandoc export to EPUB, ODT, PPTX, RTF and LaTeX, a Win11-style tabbed interface with drag and drop, session
+  restore and a tab context menu, native LaTeX math, native rendering for
+  twenty-two Mermaid diagram families (flowcharts with subgraphs, sequence,
+  class, state, ER, C4, requirement, architecture, block, sankey, packet,
+  kanban, treemap, radar, pie, git graphs, gantt, mindmaps, timelines,
+  journeys, quadrant and xy charts), custom themes with a built-in editor,
+  shortcut profiles, a UI in seven languages, first-class CJK text layout,
+  glyph-precise text selection, a table of contents, folder browser,
+  full-text search, zoom, a start page with recent files, and a unified editor whose rendered
+  page floats beside the source with live diagram preview.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- latex
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v3.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/3.3.0/oipoistar.Tinta.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version of oipoistar.Tinta (Tinta, a fast native markdown + Mermaid viewer for Windows).

- PackageVersion: 3.3.0
- Portable, x64, single exe from the GitHub release
- SHA256 verified against the release asset

Changes in this release: redesigned start page, a unified editor with the rendered page beside the source, optional Pandoc export, and retuned themes. Release notes: https://github.com/oipoistar/tinta/releases/tag/v3.3.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424128)