### PR TITLE
New version: DoiT.dci version 2.6.1

### DIFF
--- a/manifests/d/DoiT/dci/2.6.1/DoiT.dci.installer.yaml
+++ b/manifests/d/DoiT/dci/2.6.1/DoiT.dci.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.6.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: dci.exe
+    PortableCommandAlias: dci
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/doitintl/dci-cli/releases/download/v2.6.1/dci_2.6.1_windows_amd64.zip
+    InstallerSha256: 04fa4fad0aa7ea0d770322ea32268a410030d3ed41accb1e3664605e7a9b6eb1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.6.1/DoiT.dci.locale.en-US.yaml
+++ b/manifests/d/DoiT/dci/2.6.1/DoiT.dci.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.6.1
+PackageLocale: en-US
+Publisher: DoiT
+PublisherUrl: https://github.com/doitintl
+PublisherSupportUrl: https://github.com/doitintl/dci-cli/issues
+PackageName: dci
+ShortDescription: Cloud Intelligence™ CLI
+Moniker: dci
+Tags:
+  - cli
+  - doit
+  - finops
+License: MIT
+LicenseUrl: https://github.com/doitintl/dci-cli/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/doitintl/dci-cli/releases/tag/v2.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.6.1/DoiT.dci.yaml
+++ b/manifests/d/DoiT/dci/2.6.1/DoiT.dci.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version: DoiT.dci version 2.6.1

- **PackageIdentifier:** DoiT.dci
- **PackageVersion:** 2.6.1
- **InstallerUrl:** https://github.com/doitintl/dci-cli/releases/download/v2.6.1/dci_2.6.1_windows_amd64.zip

Auto-submitted by [dci-cli CI](https://github.com/doitintl/dci-cli/actions).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424162)