### PR TITLE
New version: norc.norc-cli version 0.1.9

### DIFF
--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+InstallerType: portable
+Scope: user
+Commands:
+  - norc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/RedcoatAsher/norc-cli-releases/releases/download/cli-v0.1.9/norc-win-x64.exe
+    InstallerSha256: DF49E5DE39D94F71CE3EF290E347CF91BFD79E8EC4E920885A5D80D7EC20CC66
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.locale.en-US.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.locale.en-US.yaml
@@ -1,0 +1,9 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+PackageLocale: en-US
+Publisher: norc
+PackageName: norc-cli
+License: Proprietary
+ShortDescription: Headless cron job scheduler for norc
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.yaml
+++ b/manifests/n/norc/norc-cli/0.1.9/norc.norc-cli.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: norc.norc-cli
+PackageVersion: 0.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

New package version: norc.norc-cli 0.1.9

norc-cli is a headless cron job scheduler CLI that syncs a machine's crontab with the norc web vault.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

## Microsoft Reviewers: Open in [VSCode](https://microsoft.github.io/winget-pkgs-vscode/?pr=)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424191)