### PR TITLE
New version: zer0ken.xmux version 0.6.5

### DIFF
--- a/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.installer.yaml
+++ b/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: zer0ken.xmux
+PackageVersion: 0.6.5
+InstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/zer0ken/xmux/releases/download/v0.6.5/xmux-v0.6.5-x86_64-pc-windows-msvc.exe
+    InstallerSha256: c18c7190fd058eef2168fe790f639966bdc9d51764e0d0c75bd75198d55469f8
+    Commands:
+      - xmux
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
+++ b/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: zer0ken.xmux
+PackageVersion: 0.6.5
+PackageLocale: en-US
+Publisher: zer0ken
+PackageName: xmux
+PackageUrl: https://github.com/zer0ken/xmux
+License: MIT
+ShortDescription: Cross-environment tmux/psmux session switcher
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
+++ b/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
@@ -1,10 +1,3 @@
 PackageIdentifier: zer0ken.xmux
-PackageVersion: 0.6.5
-PackageLocale: en-US
-Publisher: zer0ken
-PackageName: xmux
-PackageUrl: https://github.com/zer0ken/xmux
-License: MIT
-ShortDescription: Cross-environment tmux/psmux session switcher
-ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+PackageVersio
+# spelling test

--- a/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
+++ b/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.locale.en-US.yaml
@@ -1,3 +1,10 @@
 PackageIdentifier: zer0ken.xmux
-PackageVersio
-# spelling test
+PackageVersion: 0.6.5
+PackageLocale: en-US
+Publisher: zer0ken
+PackageName: xmux
+PackageUrl: https://github.com/zer0ken/xmux
+License: MIT
+ShortDescription: Cross-environment tmux/psmux session switcher
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.yaml
+++ b/manifests/z/zer0ken/xmux/0.6.5/zer0ken.xmux.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: zer0ken.xmux
+PackageVersion: 0.6.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Updates the winget manifest to zer0ken.xmux 0.6.5. Generated automatically by the xmux release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424269)