### PR TITLE
New package: SimonThorpe.Octomon version 0.7.3

### DIFF
--- a/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.installer.yaml
+++ b/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: SimonThorpe.Octomon
+PackageVersion: 0.7.3
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: octomon.exe
+    PortableCommandAlias: octomon
+Commands:
+  - octomon
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/securitypedant/octomon/releases/download/v0.7.3/octomon-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 9661264305E268FC96E4806C18DB92FA157F692D31815FB0C107E431DC718657
+  - Architecture: arm64
+    InstallerUrl: https://github.com/securitypedant/octomon/releases/download/v0.7.3/octomon-aarch64-pc-windows-msvc.zip
+    InstallerSha256: 8FC257A6AD29A26337832AE10FAFD746E29617B8647336B3CE48670FAD278A9C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.locale.en-US.yaml
+++ b/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: SimonThorpe.Octomon
+PackageVersion: 0.7.3
+PackageLocale: en-US
+Publisher: Simon Thorpe
+PublisherUrl: https://octomon.dev
+PublisherSupportUrl: https://github.com/securitypedant/octomon/issues
+PackageName: octomon
+PackageUrl: https://octomon.dev
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/securitypedant/octomon/blob/main/LICENSE-MIT
+ShortDescription: "Btop-style terminal network monitor: latency, bandwidth, and Wi-Fi signal"
+Description: |-
+  octomon is a terminal dashboard for your network connection: per-target
+  latency, jitter and loss, live path monitoring, bandwidth per process,
+  DNS health, speed tests with bufferbloat grading, and an analysis ladder
+  that names what is actually wrong when the connection degrades.
+Moniker: octomon
+Tags:
+  - network
+  - monitor
+  - terminal
+  - tui
+  - latency
+  - bandwidth
+  - ping
+  - diagnostics
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.yaml
+++ b/manifests/s/SimonThorpe/Octomon/0.7.3/SimonThorpe.Octomon.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: SimonThorpe.Octomon
+PackageVersion: 0.7.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package submission for octomon, a btop-style terminal network monitor (https://octomon.dev, MIT OR Apache-2.0).

- Portable zip package (x64 + arm64) from the project's GitHub release assets
- SHA256s match the published `.sha256` files and were verified against a fresh download
- Manifests written against the 1.9.0 schemas

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? 
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424276)