### PR TITLE
Update: Microsoft.PowerToys version 0.101.2362.0 with display name on ARM64

### DIFF
--- a/manifests/m/Microsoft/PowerToys/0.101.2362.0/Microsoft.PowerToys.installer.yaml
+++ b/manifests/m/Microsoft/PowerToys/0.101.2362.0/Microsoft.PowerToys.installer.yaml
@@ -26,10 +26,14 @@ Installers:
   Scope: user
   InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.101.2362.0/PowerToysUserSetup-0.101.2362.0-arm64.exe
   InstallerSha256: 4C2AE5156B7E4F1F5BA744BA6E1CF6BFE3D9614978356E6B00AA47CAB86350DB
+  AppsAndFeaturesEntries:
+    - DisplayName: PowerToys (Preview) ARM64
 - Architecture: arm64
   Scope: machine
   InstallerUrl: https://github.com/microsoft/PowerToys/releases/download/v0.101.2362.0/PowerToysSetup-0.101.2362.0-arm64.exe
   InstallerSha256: BEE299302C0CD59E282BDC92CC8AAF737713EABCCA77BB8BF09F43745D43CD93
   ElevationRequirement: elevatesSelf
+  AppsAndFeaturesEntries:
+    - DisplayName: PowerToys (Preview) ARM64
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Add display name for PowerToys installer on ARM64 to work around an issue causing it to not correlate correctly with winget index.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Related https://github.com/microsoft/winget-cli/issues/6490
  
## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424277)