### PR TITLE
New package: YSKM523.fastrans version 0.2.0

### DIFF
--- a/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.installer.yaml
+++ b/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: YSKM523.fastrans
+PackageVersion: 0.2.0
+InstallerLocale: zh-CN
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/YSKM523/fastrans/releases/download/v0.2.0/fastrans-v0.2.0-setup.exe
+  InstallerSha256: 19CB6EC3CA1DA05748B12375F78C7A65C9E1871F12AB2F44256BBC91EB35F936
+  ProductCode: '{B7E5A0F3-4C29-4E8D-9B7A-FA57C2E6D311}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: fastrans v0.2.0
+    DisplayVersion: 0.2.0
+    ProductCode: '{B7E5A0F3-4C29-4E8D-9B7A-FA57C2E6D311}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.locale.en-US.yaml
+++ b/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: YSKM523.fastrans
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: YSKM523
+PublisherUrl: https://github.com/YSKM523
+PublisherSupportUrl: https://github.com/YSKM523/fastrans/issues
+PackageName: fastrans
+PackageUrl: https://github.com/YSKM523/fastrans
+License: MIT
+LicenseUrl: https://github.com/YSKM523/fastrans/blob/main/LICENSE
+Copyright: Copyright (c) 2026 YSKM523
+ShortDescription: Type Chinese, commit English - a fully offline floating translation input bar.
+Description: |-
+  fastrans is a tiny floating input bar for Windows. Press a global hotkey in
+  any application, type Chinese (a built-in pinyin IME with abbreviations and
+  learning is included for machines without one), watch the English translation
+  appear live from a local neural model (fully offline, no API keys), then hit
+  Enter to paste it into the application you came from. Ships with a system
+  tray icon, a settings page, silent self-updates and a North-American
+  business-casual polish pass on the output.
+Moniker: fastrans
+Tags:
+- chinese
+- english
+- ime
+- offline
+- pinyin
+- translation
+- translator
+ReleaseNotesUrl: https://github.com/YSKM523/fastrans/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.locale.zh-CN.yaml
+++ b/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.locale.zh-CN.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: YSKM523.fastrans
+PackageVersion: 0.2.0
+PackageLocale: zh-CN
+Publisher: YSKM523
+PackageName: fastrans
+PackageUrl: https://github.com/YSKM523/fastrans
+License: MIT
+ShortDescription: 打中文,上屏英文——完全离线的悬浮翻译输入条。
+Description: |-
+  fastrans 是一个极简的 Windows 悬浮翻译输入条:在任何应用里按全局热键呼出,
+  打中文(内置带简拼与记忆的拼音输入,没装输入法的电脑也能用),本地神经模型
+  实时给出英文(完全离线、无 API key),回车自动粘贴回原应用。带系统托盘、
+  设置页、静默自动更新,译文自带北美办公室口吻润色。
+Tags:
+- 中文
+- 翻译
+- 离线
+- 拼音
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.yaml
+++ b/manifests/y/YSKM523/fastrans/0.2.0/YSKM523.fastrans.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: YSKM523.fastrans
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: **YSKM523.fastrans** version 0.2.0

fastrans is a fully offline floating Chinese-to-English translation input bar for Windows (Rust, MIT licensed). Homepage: https://github.com/YSKM523/fastrans

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (could not enable LocalManifestFiles without elevation; the exact installer binary was however installed/uninstalled successfully on Windows 11 x64 — per-user Inno Setup, silent mode verified)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Installer: Inno Setup, per-user scope (no admin), x64. SHA256 verified against the release's checksums.txt.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424309)