### PR TITLE
Fix PHP installer manifest's download URL for version 8.5.8

### DIFF
--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.8/PHP.PHP.NTS.8.5.installer.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.8/PHP.PHP.NTS.8.5.installer.yaml
@@ -16,13 +16,13 @@ Commands:
 ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x64
-  InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.8-nts-Win32-vs17-x64.zip
+  InstallerUrl: https://downloads.php.net/~windows/releases/archives/php-8.5.8-nts-Win32-vs17-x64.zip
   InstallerSha256: 63A3F6493F37C9FF3E288EC16621222A6CDA5167DD1ABFFEC0019E7F18C8E7E9
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: x86
-  InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.8-nts-Win32-vs17-x86.zip
+  InstallerUrl: https://downloads.php.net/~windows/releases/archives/php-8.5.8-nts-Win32-vs17-x86.zip
   InstallerSha256: 421EE83FB2288C79C56D7488E0F658070F73B6AD072BACC6B3572BC8CCDF57F9
   Dependencies:
     PackageDependencies:


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
This pull requests changes the Installers.InstallerUrl attributes in the manifest to reflect the correct download URLs to PHP Non Thread Safe version 8.5.8

## ✅ Checklist

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [X] Linked to an issue (if applicable)
  - Resolves #424156 

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [X] This PR only modifies one (1) manifest
- [X] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [X] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424343)