### PR TITLE
New version: Aleckstygit.WayCoder version 0.96.7

### DIFF
--- a/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.7
+InstallerLocale: zh-CN
+InstallerType: portable
+Commands:
+  - waycoder
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://gitee.com/aleckstygit/way-coder/releases/download/v0.96.7/waycoder-v0.96.7-win-x64.zip
+    InstallerSha256: 54e101a9b52cad973100849c2ba1d848b5123d1cd970239701990b26fadd0b73
+  - Architecture: arm64
+    InstallerUrl: https://gitee.com/aleckstygit/way-coder/releases/download/v0.96.7/waycoder-v0.96.7-win-arm64.zip
+    InstallerSha256: bf71025b43ee740329771d4d027d564b2385fa76efa5d380ad2ca4a1c63d6def
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.locale.zh-CN.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.7
+PackageLocale: zh-CN
+Publisher: Aleckstygit
+PublisherUrl: https://gitee.com/aleckstygit/way-coder
+PublisherSupportUrl: https://gitee.com/aleckstygit/way-coder/issues
+PackageName: WayCoder
+PackageUrl: https://gitee.com/aleckstygit/way-coder
+License: MIT
+ShortDescription: 中文编程智能体 CLI Coding Agent
+Tags:
+  - coding
+  - agent
+  - ai
+  - cli
+  - programmer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.7/Aleckstygit.WayCoder.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.7
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version: Aleckstygit.WayCoder version 0.96.7

- Package: Aleckstygit.WayCoder（WayCoder 道码，中文版编程智能体）
- Installer type: portable (zip)
- Architectures: x64 / arm64
- Installer URLs:
  - x64: https://gitee.com/aleckstygit/way-coder/releases/download/v0.96.7/waycoder-v0.96.7-win-x64.zip
  - arm64: https://gitee.com/aleckstygit/way-coder/releases/download/v0.96.7/waycoder-v0.96.7-win-arm64.zip
- Locale: zh-CN

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424344)