### PR TITLE
New package: Breizhzion.BeamMeUp version 1.0.0

### DIFF
--- a/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.installer.yaml
+++ b/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Breizhzion.BeamMeUp
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/bzhzion/beammeup/releases/download/v1.0.0/BeamMeUp_1.0.0_x64-setup.exe
+    InstallerSha256: C8FB2BD693CA9383C4749CDBF17BE2CA4D7AEEB5DA460F1A9579AF3521FAABC7
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.locale.en-US.yaml
+++ b/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Breizhzion.BeamMeUp
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: BREIZHZION
+PublisherUrl: https://breizhzion.com
+PublisherSupportUrl: https://github.com/bzhzion/beammeup/issues
+PackageName: BeamMeUp
+PackageUrl: https://beammeup.breizhzion.com
+License: BZ-1.1 (BREIZHZION Personal Use License)
+LicenseUrl: https://github.com/bzhzion/beammeup/blob/main/LICENSE
+ShortDescription: One terminal window, shared in real time between a human and an AI agent.
+Description: >-
+  BeamMeUp gives a human and an AI coding agent a single shared terminal window. The agent drives
+  PowerShell, cmd, Git Bash, WSL, or SSH sessions through a command-line connector, while the
+  human sees and can type into the exact same session, live. No MCP server to start ahead of
+  time: the agent simply calls the beammeup executable, the same way it would call git or npm.
+Moniker: beammeup
+Tags:
+  - terminal
+  - ai
+  - agent
+  - claude
+  - powershell
+  - ssh
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.yaml
+++ b/manifests/b/Breizhzion/BeamMeUp/1.0.0/Breizhzion.BeamMeUp.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Breizhzion.BeamMeUp
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## New package

- **Package**: Breizhzion.BeamMeUp
- **Version**: 1.0.0
- **Publisher**: BREIZHZION
- **Installer**: NSIS (x64), signed release build from https://github.com/bzhzion/beammeup

BeamMeUp gives a human and an AI coding agent a single shared terminal window (PowerShell/cmd/Git Bash/WSL/SSH), driven by a CLI connector with no MCP server or headless mode.

This is a fresh initial submission; a previous PR for an earlier version (0.1.0) was closed without merging.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424365)