### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.1.1

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.1
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{011DB6E2-3490-4FAB-8ECF-AE0D22D461AE}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{011DB6E2-3490-4FAB-8ECF-AE0D22D461AE}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.1.1/GestureSign-V2-18.1.1-x64.msi
+  InstallerSha256: 7A93A30975D9DBA68F709619306487C570AFB331AF13E66A172058CA1690E18C
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-26

--- a/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created for GestureSign V2 18.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.1
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Added French, Russian, Arabic, Spanish, and Portuguese localization across the main UI, settings, editors, dialogs, update notifications, and tray menu.
+  - Added automatic Windows display-language matching and manual language selection.
+  - Added right-to-left layout support for Arabic and safe English fallback for missing translations.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.1.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.1/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,8 @@
+# Created for GestureSign V2 18.1.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds GestureSign V2 18.1.1 using the x64 MSI published in the verified GitHub release. The manifest was validated locally with `winget validate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424397)