### PR TITLE
New version: RobertasTa.SmartDuplicateFinder version 1.4.1

### DIFF
--- a/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.installer.yaml
+++ b/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.SmartDuplicateFinder
+PackageVersion: "1.4.1"
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+- SmartDuplicateFinder
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/RobertasTa/smart-duplicate-finder/releases/download/v1.4.1/SmartDuplicateFinder.exe
+  InstallerSha256: 6F2D34B7A7CA562EF817516E21BC03F7BC73805F44785F629C8A542CFB193E95
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-26

--- a/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.locale.en-US.yaml
+++ b/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.SmartDuplicateFinder
+PackageVersion: "1.4.1"
+PackageLocale: en-US
+Publisher: Robertas & Claude
+PublisherUrl: https://github.com/RobertasTa
+PublisherSupportUrl: https://github.com/RobertasTa/smart-duplicate-finder/issues
+PackageName: Smart Duplicate Finder
+PackageUrl: https://robertasta.github.io/smart-duplicate-finder/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/RobertasTa/smart-duplicate-finder/blob/master/LICENSE
+Copyright: (c) Robertas & Claude
+ShortDescription: Safe, portable duplicate file finder that never deletes your files.
+Description: |-
+  Finds duplicate files by content (MD5) and visually similar photos (perceptual
+  hash), including the iPhone HEIC and AVIF formats that Windows itself often
+  cannot open. Two-phase scan with a guided candidate dialog and per-family time
+  estimates. Results are colour-grouped by file family with a colour-coded Excel
+  report, so you can clean up at your own pace. Right-click a result to open the
+  file, open its folder or copy its path - opening is deliberately disabled for
+  executable files. By design the program never deletes
+  your files - the only optional deletion is invisible system junk
+  (Thumbs.db, .DS_Store) verified by content signature before removal.
+  The report also says which copy is most likely the original and, just as
+  importantly, WHY - reading what the files say about themselves through their
+  names, folders and dates ("the others are named as copies", "the others sit
+  deeper in folders"). Where nothing tells them apart it says so plainly
+  instead of guessing. A side effect worth mentioning: on a Python virtual
+  environment the rule reliably picks the real package over pip's vendored
+  copy of it.
+  One exe for all UI languages (English, Lithuanian, Russian and German,
+  switchable in-app, first run follows the Windows language). Optional portable
+  mode keeps all working files next to the exe and leaves no traces on the
+  computer.
+  Portable single exe: no installation, no ads, no telemetry, no network access.
+Moniker: smart-duplicate-finder
+Tags:
+- duplicate
+- duplicate-finder
+- duplicates
+- disk-cleanup
+- portable
+- open-source
+- heic
+- photos
+ReleaseNotesUrl: https://github.com/RobertasTa/smart-duplicate-finder/releases/tag/v1.4.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/RobertasTa/smart-duplicate-finder/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.yaml
+++ b/manifests/r/RobertasTa/SmartDuplicateFinder/1.4.1/RobertasTa.SmartDuplicateFinder.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.SmartDuplicateFinder
+PackageVersion: "1.4.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with Manifest Version 1.12.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

Bug-fix release. On large photo collections the visual-similarity search
could silently drop results — a bigger library could return fewer similar
pictures than a smaller one. The workload ceiling that caused it has been
raised, and if it is ever reached the scan now says so instead of staying
quiet.

Release notes: https://github.com/RobertasTa/smart-duplicate-finder/releases/tag/v1.4.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424410)