### PR TITLE
New version: LoreoInc.Loreo version 2.0.4

### DIFF
--- a/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.installer.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.4
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/farrokh/loreo-releases/releases/download/v2.0.4/Loreo_2.0.4_x64-setup.exe
+    InstallerSha256: 88BA0E1A02906253EB6AF18C936402A18D6C9C9B6A665F5C6CBD1884287C2C14
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.locale.en-US.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.4
+PackageLocale: en-US
+Publisher: Loreo Inc.
+PublisherUrl: https://getloreo.com
+PublisherSupportUrl: https://getloreo.com
+PackageName: Loreo
+PackageUrl: https://getloreo.com
+License: Proprietary
+Copyright: Copyright (c) Loreo Inc.
+ShortDescription: Turns meetings and long-form audio into transcripts and structured notes.
+Moniker: loreo
+Tags:
+  - transcription
+  - meeting-notes
+  - audio
+  - notes
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.yaml
+++ b/manifests/l/LoreoInc/Loreo/2.0.4/LoreoInc.Loreo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: LoreoInc.Loreo
+PackageVersion: 2.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] Package version updated to `2.0.4`
- [x] Installer URL points to the published Loreo `v2.0.4` release
- [x] Installer SHA-256 matches the published Authenticode-signed installer

This updates `LoreoInc.Loreo` from `2.0.3` to `2.0.4`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424412)