### PR TITLE
New package: CompuTec.AppEngine version 3.2608.9

### DIFF
--- a/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.installer.yaml
+++ b/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CompuTec.AppEngine
+PackageVersion: 3.2608.9
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.8
+    MinimumVersion: 8.0.30
+  - PackageIdentifier: Microsoft.DotNet.AspNetCore.8
+    MinimumVersion: 8.0.30
+ElevationRequirement: elevationRequired
+UpgradeBehavior: install
+ReleaseDate: 2026-08-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.computec.one/software/appengine/releases/CompuTec.AppEngine.3.2608.9.msi
+  InstallerSha256: F7A6A7B99B5D389EE5BD1EFF32DA30D6CEC64D7833F8EDA077A6E6139DA46927
+  ProductCode: '{415A4672-4F2D-42B0-9952-E997FDAEE089}'
+  AppsAndFeaturesEntries:
+  - DisplayName: CompuTec AppEngine
+    ProductCode: '{415A4672-4F2D-42B0-9952-E997FDAEE089}'
+    UpgradeCode: '{63BC9CAA-01FD-4C89-AFD6-A26EAC42AAD6}'
+    InstallerType: msi
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.locale.en-US.yaml
+++ b/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: CompuTec.AppEngine
+PackageVersion: 3.2608.9
+PackageLocale: en-US
+Publisher: CompuTec S.A.
+PublisherUrl: https://www.computec.one
+PublisherSupportUrl: https://support.computec.pl
+PrivacyUrl: https://www.computec.one/privacy-policy
+Author: CompuTec S.A.
+PackageName: CompuTec AppEngine
+PackageUrl: https://www.computec.one/solutions/computec-appengine
+License: Proprietary
+Copyright: Copyright (c) CompuTec S.A.
+Moniker: appengine
+ShortDescription: Central platform for running CompuTec and custom business apps for SAP Business One.
+Description: CompuTec AppEngine is a web platform for managing and running business applications for SAP Business One. It serves as the runtime for CompuTec solutions such as WebUp, ProcessForce, and PDC, all available through the built-in app store. Developers can build custom apps using SAPUI5 with C#/.NET, create OData v4/REST APIs, and automate workflows triggered by SAP Business One events. AppEngine provides centralized logging, job scheduling, and Single Sign-On (SSO) support.
+Tags:
+- appengine
+- webup
+- processforce
+- pdc
+- business-one
+- computec
+- erp
+- sap
+- sapui5
+ReleaseNotesUrl: https://learn.computec.one/docs/appengine/releases/appengine/release-notes#computec-appengine-326089
+InstallationNotes: CompuTec AppEngine is now installed. Configure and access it at https://localhost:54001. For documentation, visit https://learn.computec.one/docs/appengine
+Documentations:
+- DocumentLabel: Product Documentation
+  DocumentUrl: https://learn.computec.one/docs/appengine
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.yaml
+++ b/manifests/c/CompuTec/AppEngine/3.2608.9/CompuTec.AppEngine.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CompuTec.AppEngine
+PackageVersion: 3.2608.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
Adds **CompuTec AppEngine 3.2608.9**, a self-hosted web platform for running business
applications for SAP Business One. It is the runtime for CompuTec products such as WebUp,
ProcessForce and PDC, and hosts custom SAPUI5 + .NET applications with OData v4/REST APIs.
This is the first submission for the `CompuTec` publisher.

This replaces #355507, which was closed as stale in April with a request to resubmit once the
installer issue was resolved. Both problems from that PR are gone:

- The MSI no longer carries the `LaunchCondition` that required 4096 MB of physical memory and
  aborted the install in the validation environment.
- Validation then failed three times with `APPINSTALLER_CLI_ERROR_INSTALL_MISSING_DEPENDENCY`
  and `No suitable installer found for manifest Microsoft.DotNet.Runtime.8 with version 8.0.25`.
  That was the scope-requirement behaviour described in #152555 - the pipeline passes
  `--scope machine`, which propagates to dependencies, and the .NET 8 manifests at 8.0.25 did not
  declare a scope. Versions 8.0.30 of both `Microsoft.DotNet.Runtime.8` and
  `Microsoft.DotNet.AspNetCore.8` do declare `Scope: machine`, and the manifest now requires
  8.0.30 as the minimum, so that mismatch can no longer occur.

### Dependencies

AppEngine is framework-dependent and runs as a Windows service, which is started during
installation. Without the ASP.NET Core 8 runtime the service cannot start and the MSI rolls back,
so both runtimes are declared as `PackageDependencies`. WinGet installs them ahead of the package.

### Testing

- `winget validate --manifest <path>` - passes
- `Tools\SandboxTest.ps1 <path>` in Windows Sandbox - dependencies resolved and installed
  (8.0.30), package installed, AppEngine service reaches `Running`
- The same test with `-WinGetOptions '--scope machine'`, to mirror the validation pipeline - passes
- Installed version correlates with the ARP entry through `AppsAndFeaturesEntries`

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - N/A — New package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424432)