### PR TITLE
New package: KALMIX.Trace version 1.5.7

### DIFF
--- a/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.installer.yaml
+++ b/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KALMIX.Trace
+PackageVersion: 1.5.7
+InstallerType: portable
+Scope: user
+UpgradeBehavior: install
+Commands:
+  - kalmix-trace
+ReleaseDate: 2026-08-26
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/KalmixTech/Kalmix-Software/releases/download/trace-v1.5.7/KALMIX.Trace.1.5.7.Windows.x86.exe
+    InstallerSha256: F2005A3B2F56941A10DA652F2242022A26DD85B5A89799987AC5277AAB2861C8
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.locale.en-US.yaml
+++ b/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KALMIX.Trace
+PackageVersion: 1.5.7
+PackageLocale: en-US
+Publisher: Shanghai IOTARS Co., Ltd.
+PublisherUrl: https://www.kalmixtech.com/
+PublisherSupportUrl: https://www.kalmixtech.com/pages/contact
+PrivacyUrl: https://www.kalmixtech.com/policies/privacy-policy
+Author: Shanghai IOTARS Co., Ltd.
+PackageName: KALMIX Trace
+PackageUrl: https://www.kalmixtech.com/pages/trace
+License: Proprietary
+LicenseUrl: https://github.com/KalmixTech/Kalmix-Software/blob/main/TRACE/EULA.md
+Copyright: Copyright (c) 2026 Shanghai IOTARS Co., Ltd. All rights reserved.
+ShortDescription: Portable Windows GNSS serial monitor and NTRIP correction client.
+Description: KALMIX Trace opens a GNSS receiver serial stream, displays live NMEA and receiver-reported solution status, forwards RTCM3 corrections from an NTRIP service, and records session logs.
+Moniker: kalmix-trace
+Tags:
+  - gnss
+  - gps
+  - nmea
+  - ntrip
+  - rtcm
+  - rtk
+  - serial
+ReleaseNotesUrl: https://github.com/KalmixTech/Kalmix-Software/releases/tag/trace-v1.5.7
+Documentations:
+  - DocumentLabel: TRACE for Windows User Guide
+    DocumentUrl: https://www.kalmixtech.com/blogs/doc-trace/trace-for-windows
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+

--- a/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.yaml
+++ b/manifests/k/KALMIX/Trace/1.5.7/KALMIX.Trace.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KALMIX.Trace
+PackageVersion: 1.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
## New package

- PackageIdentifier: `KALMIX.Trace`
- PackageVersion: `1.5.7`
- InstallerType: `portable`
- Architecture: `x86`
- Official version-specific installer: KalmixTech GitHub Release
- Publisher: Shanghai IOTARS Co., Ltd.

The installer is a portable Windows GNSS serial monitor and NTRIP correction client. It does not require an interactive installer or administrator privilege to run. The release is proprietary, free to download and use, and not Authenticode-signed. The manifest uses the SHA-256 of the immutable GitHub Release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424435)