### PR TITLE
New version: Jorji49.streamtop version 0.3.1

### DIFF
--- a/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.installer.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: streamtop.exe
+    PortableCommandAlias: streamtop
+UpgradeBehavior: install
+ReleaseDate: 2026-08-26
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v0.3.1/streamtop-windows-x86_64-0.3.1.zip
+    InstallerSha256: B1D7B1C24BF81927FB19CE85594C1DC6431B019077F7782941194114DE273539
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.locale.en-US.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Ahmet Kayra Kama
+PublisherUrl: https://github.com/Jorji49
+PublisherSupportUrl: https://github.com/Jorji49/streamtop/issues
+Author: Ahmet Kayra Kama
+PackageName: streamtop
+PackageUrl: https://github.com/Jorji49/streamtop
+License: MIT
+LicenseUrl: https://github.com/Jorji49/streamtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ahmet Kayra Kama
+ShortDescription: Terminal diagnostic engine for live HLS, DASH, and IPTV streams
+Description: Live HLS, DASH, and IPTV stream diagnostics TUI with wire probe, LL-HLS telemetry, SCTE-35, Prometheus, and Quick Play.
+Moniker: streamtop
+Tags:
+  - hls
+  - dash
+  - iptv
+  - diagnostics
+  - tui
+  - streaming
+ReleaseNotesUrl: https://github.com/Jorji49/streamtop/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.1/Jorji49.streamtop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Portable Windows x64 package for [streamtop](https://github.com/Jorji49/streamtop) — HLS/DASH/IPTV diagnostics TUI.

- **Install:** `winget install streamtop` (Moniker / PackageName)
- PackageIdentifier: `Jorji49.streamtop` (winget catalog requires Publisher.Package)
- Version: 0.3.1
- InstallerType: zip / NestedInstallerType: portable
- Command after install: `streamtop`
- InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v0.3.1/streamtop-windows-x86_64-0.3.1.zip

## Validation
- `winget validate --manifest` succeeded locally