### PR TITLE
New version: Jorji49.streamtop version 0.3.2

### DIFF
--- a/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.installer.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: streamtop.exe
+    PortableCommandAlias: streamtop
+UpgradeBehavior: install
+ReleaseDate: 2026-08-26
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v0.3.2/streamtop-windows-x86_64-0.3.2.zip
+    InstallerSha256: 2CA5C508BA57AAA9B4499AD0E16666853E27D03179ED5A90B7D668BFDDF0BBB9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.locale.en-US.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Ahmet Kayra Kama
+PublisherUrl: https://github.com/Jorji49
+PublisherSupportUrl: https://github.com/Jorji49/streamtop/issues
+Author: Ahmet Kayra Kama
+PackageName: streamtop
+PackageUrl: https://github.com/Jorji49/streamtop
+License: MIT
+LicenseUrl: https://github.com/Jorji49/streamtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ahmet Kayra Kama
+ShortDescription: Terminal diagnostic engine for live HLS, DASH, and IPTV streams
+Description: Live HLS, DASH, and IPTV stream diagnostics TUI with wire probe, LL-HLS telemetry, SCTE-35, Prometheus, and Quick Play.
+Moniker: streamtop
+Tags:
+  - hls
+  - dash
+  - iptv
+  - diagnostics
+  - tui
+  - streaming
+ReleaseNotesUrl: https://github.com/Jorji49/streamtop/releases/tag/v0.3.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.2/Jorji49.streamtop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Portable Windows x64 package for [streamtop](https://github.com/Jorji49/streamtop).

- **Install:** `winget install streamtop` (Moniker / PackageName)
- PackageIdentifier: `Jorji49.streamtop`
- Version: 0.3.2
- InstallerType: zip / NestedInstallerType: portable
- Command: `streamtop`

## Validation
- `winget validate --manifest` succeeded locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424450)