### PR TITLE
Update InstallerUrl for Nano to correct path

### DIFF
--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
@@ -11,4 +11,4 @@ Installers:
   InstallerUrl: https://www.nano-editor.org/dist/windows/nano-v2.7.5-55-g0d9a73472439.exe
   InstallerSha256: 41A90ED2072CC0B1DEBFCEECD3AB4273E06C5FFA7E5E06BDBC54965EAA27FB89
 ManifestType: installer
-ManifestVersion: 1.12.0
+ManifestVersion: 1.5.0

--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
@@ -11,4 +11,4 @@ Installers:
   InstallerUrl: https://www.nano-editor.org/dist/windows/nano-v2.7.5-55-g0d9a73472439.exe
   InstallerSha256: 41A90ED2072CC0B1DEBFCEECD3AB4273E06C5FFA7E5E06BDBC54965EAA27FB89
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
@@ -8,7 +8,7 @@ Commands:
 - nano
 Installers:
 - Architecture: neutral
-  InstallerUrl: https://www.nano-editor.org/dist/win32-support/nano-v2.7.5-55-g0d9a73472439.exe
+  InstallerUrl: https://www.nano-editor.org/dist/windows/nano-v2.7.5-55-g0d9a73472439.exe
   InstallerSha256: 41A90ED2072CC0B1DEBFCEECD3AB4273E06C5FFA7E5E06BDBC54965EAA27FB89
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.installer.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.3.2 $debug=QUSU.CRLF.7-4-1.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: GNU.Nano
 PackageVersion: 2.7.5
@@ -11,4 +11,4 @@ Installers:
   InstallerUrl: https://www.nano-editor.org/dist/windows/nano-v2.7.5-55-g0d9a73472439.exe
   InstallerSha256: 41A90ED2072CC0B1DEBFCEECD3AB4273E06C5FFA7E5E06BDBC54965EAA27FB89
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.locale.en-US.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with YamlCreate.ps1 v2.3.2 $debug=QUSU.CRLF.7-4-1.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: GNU.Nano
 PackageVersion: 2.7.5
@@ -30,4 +30,4 @@ Tags:
 # InstallationNotes:
 # Documentations:
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.12.0

--- a/manifests/g/GNU/Nano/2.7.5/GNU.Nano.yaml
+++ b/manifests/g/GNU/Nano/2.7.5/GNU.Nano.yaml
@@ -1,8 +1,8 @@
 # Created with YamlCreate.ps1 v2.3.2 $debug=QUSU.CRLF.7-4-1.Win32NT
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: GNU.Nano
 PackageVersion: 2.7.5
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This updates the url for GNU.Nano to use the new URL provided by the official nano editor page (https://www.nano-editor.org/dist/windows/nano-v2.7.5-55-g0d9a73472439.exe)

The version itself remains the same.

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424471)