### PR TITLE
New version: EazyMake.EazyMake version 1.3.6

### DIFF
--- a/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.installer.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.3.6
+InstallerLocale: en-US
+InstallerType: zip
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/3667808244/EazyMake/releases/download/v1.3.6/ezmk-windows-x64.zip
+    InstallerSha256: 0d677b9ada26b3217df2a05281dfa8c0c94ed7d0698908698a767567c9789808
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: ezmk.exe
+        PortableCommandAlias: ezmk
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.locale.en-US.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.3.6
+PackageLocale: en-US
+Publisher: EazyMake
+PackageName: EazyMake
+PackageUrl: https://github.com/3667808244/EazyMake
+ShortDescription: A simple C/C++ build tool
+Description: EazyMake is a simple C/C++ build tool (CLI named ezmk) designed for ease of use. Supports GCC, Clang, and MSVC. Features zero-config setup, automatic package management, Lua scripting, and cross-compiler compatibility.
+Moniker: ezmk
+Tags:
+  - build-tool
+  - cpp
+  - c
+  - compiler
+  - package-manager
+ReleaseNotesUrl: https://github.com/3667808244/EazyMake/releases/tag/v1.3.6
+License: MIT
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.yaml
+++ b/manifests/e/EazyMake/EazyMake/1.3.6/EazyMake.EazyMake.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: EazyMake.EazyMake
+PackageVersion: 1.3.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
#### Pull Request Description

- [x] Have you signed the [Contributor License Agreement (CLA)](https://cla.opensource.microsoft.com/)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://learn.microsoft.com/windows/package-manager/winget/validate) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://learn.microsoft.com/en-us/windows/package-manager/winget/manifest/schema/1.6.0)?

---

**Description:**
New version: EazyMake.EazyMake version 1.3.6

- EazyMake is a simple C/C++ build tool (CLI named `ezmk`), GCC/Clang/MSVC.
- v1.3.6 is a code-quality cleanup patch (zero new features): warning-free build, message fixes, dedup, run_tests split.
- Portable zip (`ezmk.exe`) from the v1.3.6 GitHub Release; `InstallerSha256` taken from the release asset digest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424481)