### PR TITLE
New version: jvonscheidt.m3u-viewer version 0.8.0

### DIFF
--- a/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.installer.yaml
+++ b/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.m3u-viewer
+PackageVersion: 0.8.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: m3u-viewer-v0.8.0-x86_64-pc-windows-msvc\m3u-viewer.exe
+  PortableCommandAlias: m3u-viewer
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jvonscheidt/m3u-viewer/releases/download/v0.8.0/m3u-viewer-v0.8.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: D4B162DA59F55C3A1410A20A8305FB24A9F9050177D69B7EA3EA8EBB96568BF0
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-26

--- a/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.locale.en-US.yaml
+++ b/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/jvonscheidt
 PublisherSupportUrl: https://github.com/jvonscheidt/m3u-viewer/issues
 PackageName: m3u-viewer
 PackageUrl: https://github.com/jvonscheidt/m3u-viewer
-License: GPL-2.0-only
+License: Apache-2.0
 LicenseUrl: https://github.com/jvonscheidt/m3u-viewer/blob/main/LICENSE
 ShortDescription: Fast terminal viewer for large M3U playlists
 Moniker: m3u-viewer

--- a/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.locale.en-US.yaml
+++ b/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.m3u-viewer
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: jvonscheidt
+PublisherUrl: https://github.com/jvonscheidt
+PublisherSupportUrl: https://github.com/jvonscheidt/m3u-viewer/issues
+PackageName: m3u-viewer
+PackageUrl: https://github.com/jvonscheidt/m3u-viewer
+License: GPL-2.0-only
+LicenseUrl: https://github.com/jvonscheidt/m3u-viewer/blob/main/LICENSE
+ShortDescription: Fast terminal viewer for large M3U playlists
+Moniker: m3u-viewer
+Tags:
+- m3u
+- playlist
+- terminal
+- tui
+- cli
+ReleaseNotesUrl: https://github.com/jvonscheidt/m3u-viewer/releases/tag/v0.8.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/jvonscheidt/m3u-viewer/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.yaml
+++ b/manifests/j/jvonscheidt/m3u-viewer/0.8.0/jvonscheidt.m3u-viewer.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.m3u-viewer
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `jvonscheidt.m3u-viewer` to version 0.8.0.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) - not applicable

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
