### PR TITLE
New version: Crowdin.CrowdinCLI version 5.0.0

### DIFF
--- a/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.installer.yaml
+++ b/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Crowdin.CrowdinCLI
+PackageVersion: 5.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+- crowdin
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/crowdin/crowdin-cli/releases/download/5.0.0/crowdin.exe
+  InstallerSha256: 2EB743D89243E0762EC4230730A4825690365B295B3D2718F5BD2E8B8687A4CB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.locale.en-US.yaml
+++ b/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Crowdin.CrowdinCLI
+PackageVersion: 5.0.0
+PackageLocale: en-US
+Publisher: Crowdin
+PublisherUrl: https://crowdin.com
+PublisherSupportUrl: https://github.com/crowdin/crowdin-cli/issues
+PrivacyUrl: https://crowdin.com/page/privacy-policy
+Author: Crowdin
+PackageName: Crowdin CLI
+PackageUrl: https://crowdin.github.io/crowdin-cli
+License: MIT
+LicenseUrl: https://github.com/crowdin/crowdin-cli/blob/main/LICENSE
+Copyright: © Crowdin
+ShortDescription: A command line tool that allows you to manage and synchronize localization resources with your Crowdin project.
+Description: |-
+  Crowdin CLI is a command line tool that allows you to manage and synchronize your localization resources with your Crowdin project. Using CLI, you can:
+  - Automate the process of updating your source files in your Crowdin project
+  - Download translations from Crowdin and automatically save them in the correct locations
+  - Upload all your existing translations to Crowdin in minutes
+  - Manage your localization resources without leaving the terminal
+  - Integrate Crowdin CLI with GitHub, GitLab, Jenkins, CircleCI, and other software
+Moniker: crowdin
+Tags:
+- cli
+- crowdin
+- i18n
+- l10n
+- localization
+- translation
+ReleaseNotesUrl: https://github.com/crowdin/crowdin-cli/releases/tag/5.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.yaml
+++ b/manifests/c/Crowdin/CrowdinCLI/5.0.0/Crowdin.CrowdinCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Crowdin.CrowdinCLI
+PackageVersion: 5.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Crowdin CLI 5 is a complete rewrite that ships as a self-contained x64 binary:

- `InstallerType` changes from `inno` to `portable` (winget links the binary onto `PATH` as `crowdin`)
- The `EclipseAdoptium.Temurin.17.JRE` package dependency is no longer needed

Release: https://github.com/crowdin/crowdin-cli/releases/tag/5.0.0

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424596)