### PR TITLE
New package: XniperBuilds.Riplox version 1.4.0

### DIFF
--- a/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.installer.yaml
+++ b/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: XniperBuilds.Riplox
+PackageVersion: 1.4.0
+Platform:
+- Windows.Desktop
+# installer.iss sets MinVersion=10.0 - the bundled Python 3.11 does not run on
+# Windows 8.1 or older.
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+# installer.iss sets PrivilegesRequired=lowest, so an unattended install lands
+# in the user's profile and never prompts for admin.
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{9C2F41B7-6E4A-4C58-9B21-7D3E5A0F81C4}_is1'
+ReleaseDate: 2026-08-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/xniperbuilds/riplox-desktop/releases/download/v1.4.0/Riplox_Setup_v1.4.0.exe
+  InstallerSha256: 9C9F3328F87D241DDB6FD18CE01943653E169905EA0BB15AA564F6E0F0F8C2D6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.locale.en-US.yaml
+++ b/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: XniperBuilds.Riplox
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: XniperBuilds
+PublisherUrl: https://xniperbuilds.com
+PublisherSupportUrl: https://github.com/xniperbuilds/riplox-desktop/issues
+Author: XniperBuilds
+PackageName: Riplox
+PackageUrl: https://xniperbuilds.com/riplox-desktop/
+License: GPL-3.0
+LicenseUrl: https://github.com/xniperbuilds/riplox-desktop/blob/main/LICENSE
+Copyright: Copyright (c) XniperBuilds
+ShortDescription: A free video downloader for Windows. Paste a link, pick a quality, keep the file.
+Description: |-
+  Riplox downloads video and audio from YouTube, TikTok, Instagram, Facebook, X, Reddit and around a thousand other sites. Paste a link, choose 4K, 1440p, 1080p, 720p, 480p, 360p or MP3, and the file is yours.
+  There are no download caps, no daily quota and no paid tier, and the installer carries the app and nothing else - no bundled software and no ads. Files come out as MP4, in H.264 wherever a site offers that resolution in H.264, so they play in Windows Media Player, WhatsApp and on phones without extra codecs - and where the highest resolution exists only in a newer codec, Riplox takes the resolution rather than handing back a smaller file.
+  Whole playlists and channel sections download in one click, several at a time, and the queue survives a restart. Riplox uses yt-dlp and FFmpeg, and can update that download engine from inside the app when a site changes how it serves video, without waiting for a new release.
+Moniker: riplox
+Tags:
+- downloader
+- ffmpeg
+- free
+- instagram
+- mp3
+- open-source
+- playlist
+- tiktok
+- video
+- video-downloader
+- youtube
+- yt-dlp
+ReleaseNotesUrl: https://github.com/xniperbuilds/riplox-desktop/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.yaml
+++ b/manifests/x/XniperBuilds/Riplox/1.4.0/XniperBuilds.Riplox.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: XniperBuilds.Riplox
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: **XniperBuilds.Riplox** 1.4.0 — a free, open-source (GPL-3.0) video downloader for Windows.

- Homepage: https://xniperbuilds.com/riplox-desktop/
- Source: https://github.com/xniperbuilds/riplox-desktop
- Release: https://github.com/xniperbuilds/riplox-desktop/releases/tag/v1.4.0

### Checklist

- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? — `Manifest validation succeeded.`
- [x] Does your manifest conform to the 1.12 schema?
- [x] Have you checked that there aren't other open pull requests for the same manifest?

### Notes for the reviewer

- The installer is Inno Setup with `PrivilegesRequired=lowest`, so an unattended install lands in the user's profile and never prompts for elevation. `Scope: user` is set accordingly.
- `ProductCode` was read back from the registry of a machine with 1.4.0 actually installed, rather than derived, so upgrade detection matches what Setup writes.
- `InstallerSha256` is the checksum of the file at `InstallerUrl`; the same value is published as `SHA256SUMS.txt` on the release.
- The binary the manifest points at was installed and launched before this was opened. I have not run `winget install --manifest` on it, because this machine already carries a machine-scope install of the same version and a second, user-scope copy beside it would not have told me anything useful.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424602)