### PR TITLE
New package: haZii.VoZii version 1.8.0

### DIFF
--- a/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.installer.yaml
+++ b/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: haZii.VoZii
+PackageVersion: 1.8.0
+InstallerType: portable
+Commands:
+- vozii
+ReleaseDate: 2026-08-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/haZiinstinct/VoZii/releases/download/v1.8.0/VoZii.exe
+  InstallerSha256: 46AC3077BE2811B4A170E3D8306E69BAD2E3A09852EB1CF67BA61B61E8E3FA8A
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.locale.en-US.yaml
+++ b/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: haZii.VoZii
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: haZii.org
+PublisherUrl: https://hazii.org
+PublisherSupportUrl: https://github.com/haZiinstinct/VoZii/issues
+PackageName: VoZii
+PackageUrl: https://github.com/haZiinstinct/VoZii
+License: Proprietary
+LicenseUrl: https://github.com/haZiinstinct/VoZii/blob/master/LICENSE
+Copyright: (c) 2026 haZii.org
+ShortDescription: Local voice-to-text for Windows — hold a hotkey, speak, done.
+Description: |-
+  VoZii turns speech into text anywhere on Windows. Hold a hotkey (or toggle
+  with auto-stop on silence), speak, and the transcribed text is inserted into
+  the active application. Transcription runs entirely on your machine via
+  whisper.cpp (CUDA, Vulkan or CPU) — no audio ever leaves your PC. Features
+  include 9 UI languages, custom vocabulary, dictation history, an optional
+  local AI post-processing step via Ollama, and automatic model download on
+  first run.
+Moniker: vozii
+Tags:
+- dictation
+- offline
+- speech-recognition
+- speech-to-text
+- transcription
+- voice
+- whisper
+ReleaseNotesUrl: https://github.com/haZiinstinct/VoZii/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.yaml
+++ b/manifests/h/haZii/VoZii/1.8.0/haZii.VoZii.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: haZii.VoZii
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? *(LocalManifestFiles is disabled on this machine; instead the installer URL was downloaded and its SHA256 verified against the manifest and the release's SHA256SUMS.txt, and the exe itself was smoke-tested locally and in Windows Sandbox.)*
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package submission: **VoZii** — local voice-to-text for Windows (whisper.cpp based, fully offline transcription). Portable single-exe, SHA256 verified against the release's SHA256SUMS.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)