### PR TITLE
New version: Microsoft.VFSforGit version 2.0.26229.1 (x64 + arm64)

### DIFF
--- a/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.installer.yaml
+++ b/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VFSforGit
+PackageVersion: 2.0.26229.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+ProductCode: '{489CA581-F131-4C28-BE04-4FB178933E6D}_is1'
+ReleaseDate: 2026-08-17
+AppsAndFeaturesEntries:
+- DisplayName: VFS for Git version 2.0.26229.1
+  Publisher: Microsoft
+  ProductCode: '{489CA581-F131-4C28-BE04-4FB178933E6D}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\VFS for Git'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/VFSForGit/releases/download/v2.0.26229.1/SetupGVFS.2.0.26229.1.exe
+  InstallerSha256: 2A4A19FC239A9B50B135F237211212650644B1025C53D3184A951E485736C988
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/VFSForGit/releases/download/v2.0.26229.1/SetupGVFS.2.0.26229.1-arm64.exe
+  InstallerSha256: A013B4215B7F94E0742E34DBBD26BF608293F37253E0B4854DAFF1B4A760A569
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VFSforGit
+PackageVersion: 2.0.26229.1
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://github.com/microsoft
+PublisherSupportUrl: https://github.com/microsoft/VFSForGit/issues
+PackageName: GVFS
+PackageUrl: https://aka.ms/vfs-for-git
+License: MIT
+LicenseUrl: https://github.com/microsoft/VFSForGit/blob/HEAD/License.md
+ShortDescription: Virtual File System for Git - a tool to scale Git for monorepo scenarios.
+Moniker: vfs-for-git
+Tags:
+- gvfs
+- vfs-for-git
+- vfsforgit
+ReleaseNotes: |-
+  What's Changed
+  - Update default Microsoft Git version to v2.55.0.vfs.0.8 by Johannes Schindelin (@dscho) in #2084
+  - Read git config strings via a config snapshot in LibGit2Repo by tyrielv in #2086
+  - Fail blob hydration cleanly on a malformed (NUL-byte) placeholder SHA by tyrielv in #2074
+  - Record HTTP status code on blob-hydration failure telemetry by tyrielv in #2085
+  - Fix build break: return DownloadAttemptResult from the malformed-SHA guard by tyrielv in #2091
+ReleaseNotesUrl: https://github.com/microsoft/VFSForGit/releases/tag/v2.0.26229.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/microsoft/VFSForGit/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.yaml
+++ b/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VFSforGit
+PackageVersion: 2.0.26229.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Microsoft.VFSforGit 2.0.26229.1 — full update (x64 + arm64)

VFS for Git 2.0.26229.1 is the first 2.0 release and adds a native **arm64** installer alongside the existing **x64** installer.

The automated ingestion in #424566 picked up the x64 installer only. This PR provides the complete manifest set with **both** installers so arm64 users get correct `winget` coverage.

### Installers
| Architecture | Asset | SHA256 |
| --- | --- | --- |
| x64 | `SetupGVFS.2.0.26229.1.exe` | `2A4A19FC239A9B50B135F237211212650644B1025C53D3184A951E485736C988` |
| arm64 | `SetupGVFS.2.0.26229.1-arm64.exe` | `A013B4215B7F94E0742E34DBBD26BF608293F37253E0B4854DAFF1B4A760A569` |

Both installers are Inno Setup packages that share the same `AppId` / `ProductCode` (`{489CA581-F131-4C28-BE04-4FB178933E6D}_is1`).

The arm64 installer was installed and verified on native ARM64 hardware via `winget install --manifest` (hash verified, install succeeded).

Supersedes #424566.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?