### PR TITLE
New version: DoiT.dci version 2.7.1

### DIFF
--- a/manifests/d/DoiT/dci/2.7.1/DoiT.dci.installer.yaml
+++ b/manifests/d/DoiT/dci/2.7.1/DoiT.dci.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.7.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: dci.exe
+    PortableCommandAlias: dci
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/doitintl/dci-cli/releases/download/v2.7.1/dci_2.7.1_windows_amd64.zip
+    InstallerSha256: 009960756ec426e17e536dfca0c5433c651d5d5f9dec169197e9ffb1afbe188e
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.7.1/DoiT.dci.locale.en-US.yaml
+++ b/manifests/d/DoiT/dci/2.7.1/DoiT.dci.locale.en-US.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.7.1
+PackageLocale: en-US
+Publisher: DoiT
+PublisherUrl: https://github.com/doitintl
+PublisherSupportUrl: https://github.com/doitintl/dci-cli/issues
+PackageName: dci
+ShortDescription: Cloud Intelligence™ CLI
+Moniker: dci
+Tags:
+  - cli
+  - doit
+  - finops
+License: MIT
+LicenseUrl: https://github.com/doitintl/dci-cli/blob/main/LICENSE
+ReleaseNotesUrl: https://github.com/doitintl/dci-cli/releases/tag/v2.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DoiT/dci/2.7.1/DoiT.dci.yaml
+++ b/manifests/d/DoiT/dci/2.7.1/DoiT.dci.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DoiT.dci
+PackageVersion: 2.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New version: DoiT.dci version 2.7.1

- **PackageIdentifier:** DoiT.dci
- **PackageVersion:** 2.7.1
- **InstallerUrl:** https://github.com/doitintl/dci-cli/releases/download/v2.7.1/dci_2.7.1_windows_amd64.zip

Auto-submitted by [dci-cli CI](https://github.com/doitintl/dci-cli/actions).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424693)