### PR TITLE
Add wcaleniewafas-win1o.ez-oneko version 1.0.2

### DIFF
--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.installer.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.2
+ManifestType: installer
+ManifestVersion: 1.9.0
+
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/download/v1.0.2/oneko.exe
+    InstallerSha256: 159D07D8EF0AE88DD17FEEF9795E44A7B9EB4C75002373869A42912EC40CAA90
+    Scope: user
+    ElevationRequirement: elevationNotRequired
+    InstallerSwitches:
+      Silent: --install
+      SilentWithProgress: --install
+      Upgrade: --install
+      Uninstall: --uninstall

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
@@ -1,0 +1,35 @@
+PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: wcaleniewafas-win1o
+PublisherUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+PublisherSupportUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/issues
+Author: wcaleniewafas-win1o
+PackageName: ez-oneko
+PackageUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+License: MIT
+LicenseUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/blob/main/LICENSE
+Copyright: Copyright (c) 2026 oneko contributors
+ShortDescription: A cute Neko cat that chases your mouse cursor on Windows.
+Description: |-
+  A faithful desktop pet: a small Neko kitten (from the classic X11 'oneko' /
+  oneko.js, as in the Discord Vencord plugin) that follows your mouse, sleeps,
+  scratches itself and the screen edges, and shows the classic alert-whiskers.
+  Click-through window, global hotkeys (Alt+Shift+O show/hide, Alt+Shift+Q quit),
+  and near-zero RAM/CPU/GPU usage. Runs fully offline.
+Moniker: oneko
+Tags:
+  - neko
+  - oneko
+  - desktop-pet
+  - cat
+  - cursor
+  - fun
+ReleaseNotes: |-
+  - oneko.exe is now a console app: "winget install ez-oneko" greets you with a
+    welcome screen (usage + repo link), then the cat starts right away
+  - proper --install / --uninstall (PATH + Add/Remove Programs entry)
+  - all tweakable options documented in the header of oneko.py
+ReleaseNotesUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.2/wcaleniewafas-win1o.ez-oneko.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.installer.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.installer.yaml
@@ -1,0 +1,18 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.3
+ManifestType: installer
+ManifestVersion: 1.9.0
+
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/download/v1.0.3/oneko.exe
+    InstallerSha256: 1F6CD9731A5BA89F6DA593F16A751EEBCB26C0B8EE627D775450F3753A067DDB
+    Scope: user
+    ElevationRequirement: elevationNotRequired
+    InstallerSwitches:
+      Silent: --install
+      SilentWithProgress: --install
+      Upgrade: --install
+      Uninstall: --uninstall
+

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
@@ -1,0 +1,36 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.3
+PackageLocale: en-US
+Publisher: wcaleniewafas-win1o
+PublisherUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+PublisherSupportUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/issues
+Author: wcaleniewafas-win1o
+PackageName: ez-oneko
+PackageUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+License: MIT
+LicenseUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/blob/main/LICENSE
+Copyright: Copyright (c) 2026 oneko contributors
+ShortDescription: A cute Neko cat that chases your mouse cursor on Windows.
+Description: |-
+  A faithful desktop pet: a small Neko kitten (from the classic X11 'oneko' /
+  oneko.js, as in the Discord Vencord plugin) that follows your mouse, sleeps,
+  scratches itself and the screen edges, and shows the classic alert-whiskers.
+  Click-through window, global hotkeys (Alt+Shift+O show/hide, Alt+Shift+Q quit),
+  and near-zero RAM/CPU/GPU usage. Runs fully offline.
+Moniker: oneko
+Tags:
+  - neko
+  - oneko
+  - desktop-pet
+  - cat
+  - cursor
+  - fun
+ReleaseNotes: |-
+  - oneko.exe is now a console app: "winget install ez-oneko" greets you with a
+    welcome screen (usage + repo link), then the cat starts right away
+  - proper --install / --uninstall (PATH + Add/Remove Programs entry)
+  - all tweakable options documented in the header of oneko.py
+ReleaseNotesUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/tag/v1.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0
+

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.3/wcaleniewafas-win1o.ez-oneko.yaml
@@ -1,0 +1,6 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0
+

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.installer.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.installer.yaml
@@ -1,0 +1,16 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.5
+ManifestType: installer
+ManifestVersion: 1.9.0
+
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    InstallerUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/download/v1.0.5/ez-oneko-1.0.5-windows-x64.zip
+    InstallerSha256: 620E47A7D2DBD2D0C3CBF905080DA925AACF063574AADD74DE02BED6EF964189
+    NestedInstallerFiles:
+      - RelativeFilePath: oneko\oneko.exe
+        PortableCommandAlias: oneko
+    Scope: user
+    ElevationRequirement: elevationNotRequired

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.locale.en-US.yaml
@@ -1,0 +1,33 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.5
+PackageLocale: en-US
+Publisher: wcaleniewafas-win1o
+PublisherUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+PublisherSupportUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/issues
+Author: wcaleniewafas-win1o
+PackageName: ez-oneko
+PackageUrl: https://github.com/wcaleniewafas-win1o/ez-oneko
+License: MIT
+LicenseUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/blob/main/LICENSE
+Copyright: Copyright (c) 2026 oneko contributors
+ShortDescription: A cute Neko cat that chases your mouse cursor on Windows.
+Description: |-
+  A faithful desktop pet: a small Neko kitten (from the classic X11 'oneko' /
+  oneko.js, as in the Discord Vencord plugin) that follows your mouse, sleeps,
+  scratches itself and the screen edges, and shows the classic alert-whiskers.
+  Click-through window, global hotkeys (Alt+Shift+O show/hide, Alt+Shift+Q quit),
+  and near-zero RAM/CPU/GPU usage. Runs fully offline.
+Moniker: oneko
+Tags:
+  - neko
+  - oneko
+  - desktop-pet
+  - cat
+  - cursor
+  - fun
+ReleaseNotes: |-
+  - Fixed init.tcl crash on some Windows 10 builds (onedir build)
+  - GUI welcome window (no console), autostart at login
+ReleaseNotesUrl: https://github.com/wcaleniewafas-win1o/ez-oneko/releases/tag/v1.0.5
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.yaml
+++ b/manifests/w/wcaleniewafas-win1o/ez-oneko/1.0.5/wcaleniewafas-win1o.ez-oneko.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: wcaleniewafas-win1o.ez-oneko
+PackageVersion: 1.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Description of what has changed or why

Adding **wcaleniewafas-win1o.ez-oneko version 1.0.2** (new package).

ez-oneko is a lightweight Neko desktop pet for Windows - a port of the classic oneko / oneko.js (the cat known from the Discord Vencord plugin).

Installer notes:
- oneko.exe --install (silent switches in the manifest) copies itself to %LOCALAPPDATA%\Programs\ez-oneko, adds that folder to the **user PATH** and registers an **ARP entry** with UninstallString pointing to oneko.exe --uninstall.
- --uninstall removes everything (ARP entry, PATH value, install folder), so winget uninstall ez-oneko works cleanly.
- No elevation required (Scope: user).
- Installer is my own build (PyInstaller of my MIT-licensed source: https://github.com/wcaleniewafas-win1o/ez-oneko);
  cat sprites are from adryd325/oneko.js (MIT) / classic Neko (public domain) - credited in LICENSE.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424774)