### PR TITLE
New package: vRED.ViewMD v0.9.1

### DIFF
--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
@@ -8,7 +8,7 @@ MinimumOSVersion: 10.0.17763.0
 InstallerType: portable
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vRED.ViewMD/releases/download/v0.9.1/viewmd.exe
+  InstallerUrl: https://github.com/FXGears/viewmd/releases/download/v0.9.1/viewmd.exe
   InstallerSha256: 5D012677E2D27D99D980763A8323CFB030700A019C6AC7A2DF4170A77E4C7CD0
   PortableCommandAlias: viewmd
   FileExtensions:

--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: vRED.ViewMD
+PackageVersion: 0.9.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vRED.ViewMD/releases/download/v0.9.1/viewmd.exe
+  InstallerSha256: 5D012677E2D27D99D980763A8323CFB030700A019C6AC7A2DF4170A77E4C7CD0
+  PortableCommandAlias: viewmd
+  FileExtensions:
+  - md
+  - markdown
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.installer.yaml
@@ -9,7 +9,7 @@ InstallerType: portable
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/FXGears/viewmd/releases/download/v0.9.1/viewmd.exe
-  InstallerSha256: 5D012677E2D27D99D980763A8323CFB030700A019C6AC7A2DF4170A77E4C7CD0
+  InstallerSha256: B539595A566EC8C2C66514D608E54337E50D7BEC419AF4E3ADE547B46FC077BA
   PortableCommandAlias: viewmd
   FileExtensions:
   - md

--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.locale.en-US.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.locale.en-US.yaml
@@ -6,10 +6,10 @@ PackageLocale: en-US
 Publisher: vRED
 PublisherUrl: https://volatility.red
 PackageName: ViewMD
-PackageUrl: https://github.com/vRED.ViewMD
+PackageUrl: https://github.com/FXGears/viewmd
 License: GPL-3.0-only
-LicenseUrl: https://github.com/vRED.ViewMD/blob/master/LICENSE
-ShortDescription: The fastest way to read a markdown file on Windows. 652KB. No bloat.
+LicenseUrl: https://github.com/FXGears/viewmd/blob/master/LICENSE
+ShortDescription: The fastest way to read a markdown file on Windows. 758KB. No bloat.
 Description: |-
   ViewMD does one thing: renders a .md file in a window. No editor, no tabs, no sidebar, no plugins, no settings, no config files, no internet connection, no telemetry. Double-click a markdown file. Read it. Close the window.
 Tags:
@@ -18,6 +18,6 @@ Tags:
 - lightweight
 - rust
 - dark-mode
-ReleaseNotesUrl: https://github.com/vRED.ViewMD/releases/tag/v0.9.1
+ReleaseNotesUrl: https://github.com/FXGears/viewmd/releases/tag/v0.9.1
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.locale.en-US.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: vRED.ViewMD
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: vRED
+PublisherUrl: https://volatility.red
+PackageName: ViewMD
+PackageUrl: https://github.com/vRED.ViewMD
+License: GPL-3.0-only
+LicenseUrl: https://github.com/vRED.ViewMD/blob/master/LICENSE
+ShortDescription: The fastest way to read a markdown file on Windows. 652KB. No bloat.
+Description: |-
+  ViewMD does one thing: renders a .md file in a window. No editor, no tabs, no sidebar, no plugins, no settings, no config files, no internet connection, no telemetry. Double-click a markdown file. Read it. Close the window.
+Tags:
+- markdown
+- viewer
+- lightweight
+- rust
+- dark-mode
+ReleaseNotesUrl: https://github.com/vRED.ViewMD/releases/tag/v0.9.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.yaml
+++ b/manifests/v/vRED/ViewMD/0.9.1/vRED.ViewMD.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: vRED.ViewMD
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package: vRED.ViewMD v0.9.1

### Description
ViewMD is a lightweight markdown viewer for Windows. 758KB binary, sub-100ms startup, dark mode, no Electron.

### URLs
- GitHub: https://github.com/FXGears/viewmd
- Release: https://github.com/FXGears/viewmd/releases/tag/v0.9.1

### Manifest type
New package submission (multi-file manifest v1.6.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424796)