### PR TITLE
New package: Nabisori.nabiTerm version 0.1.481

### DIFF
--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
@@ -1,0 +1,16 @@
+# `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Nabisori.nabiTerm
+PackageVersion: 0.1.481
+InstallerType: inno
+Scope: user
+InstallerSwitches:
+  Silent: /VERYSILENT /NOLAUNCH
+  SilentWithProgress: /SILENT /NOLAUNCH
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/matrixism-cmyk/NabiTerm/releases/download/v0.1.481/nabiTerm-setup.exe
+  InstallerSha256: DEDB60EDC8A0130CFC15322D65546B666E219E39615FB5228D9CF68F2A2EC732
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
@@ -1,5 +1,5 @@
 # `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Nabisori.nabiTerm
 PackageVersion: 0.1.481
@@ -13,4 +13,4 @@ Installers:
   InstallerUrl: https://github.com/matrixism-cmyk/NabiTerm/releases/download/v0.1.481/nabiTerm-setup.exe
   InstallerSha256: DEDB60EDC8A0130CFC15322D65546B666E219E39615FB5228D9CF68F2A2EC732
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.installer.yaml
@@ -6,8 +6,8 @@ PackageVersion: 0.1.481
 InstallerType: inno
 Scope: user
 InstallerSwitches:
-  Silent: /VERYSILENT /NOLAUNCH
-  SilentWithProgress: /SILENT /NOLAUNCH
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /CURRENTUSER /NOLAUNCH
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP- /CURRENTUSER /NOLAUNCH
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/matrixism-cmyk/NabiTerm/releases/download/v0.1.481/nabiTerm-setup.exe

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.locale.en-US.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Nabisori.nabiTerm
 PackageVersion: 0.1.481
@@ -25,4 +25,4 @@ Tags:
 - korean
 - rust
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.locale.en-US.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Nabisori.nabiTerm
+PackageVersion: 0.1.481
+PackageLocale: en-US
+Publisher: Nabisori
+PublisherUrl: https://nabisori.kr
+PublisherSupportUrl: https://github.com/matrixism-cmyk/NabiTerm/issues
+PackageName: nabiTerm
+PackageUrl: https://nabisori.kr/nabiterm.php
+License: Apache-2.0
+LicenseUrl: https://github.com/matrixism-cmyk/NabiTerm/blob/main/LICENSE
+ShortDescription: Windows terminal multiplexer with SSH/SFTP client and editor
+Description: |-
+  A native Windows terminal, professional SFTP client and code editor in one window.
+  Korean by default, free, Apache-2.0. Includes a local control plane and MCP server
+  so AI agents running in a pane can drive the terminal and move files over SFTP.
+Moniker: nabiterm
+Tags:
+- terminal
+- ssh
+- sftp
+- editor
+- korean
+- rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.yaml
@@ -1,0 +1,8 @@
+# `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Nabisori.nabiTerm
+PackageVersion: 0.1.481
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.yaml
+++ b/manifests/n/Nabisori/nabiTerm/0.1.481/Nabisori.nabiTerm.yaml
@@ -1,8 +1,8 @@
 # `cargo run -p xtask -- pkg` 가 만든다 — 손으로 고치지 말 것.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Nabisori.nabiTerm
 PackageVersion: 0.1.481
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Nabisori.nabiTerm** version **0.1.481**.

nabiTerm is a native Windows terminal multiplexer with a built-in SSH/SFTP client and a code
editor, written in Rust and shipped as a single executable with no external runtime.
Apache-2.0, source at https://github.com/matrixism-cmyk/NabiTerm

- Installer: Inno Setup, per-user by default (no admin rights required)
- Silent switches: `/VERYSILENT /NOLAUNCH` — `/NOLAUNCH` is the app's own switch so an
  unattended install does not start the GUI
- Architecture: x64 only

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
  <!-- The package author will sign when the CLA bot comments on this PR. -->
- [ ] Linked to an issue (if applicable) — not applicable, this is a new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
  <!-- Searched open PRs for "nabiTerm": 0 results. manifests/n/Nabisori/ does not exist yet. -->
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### What was verified, and what was not

Being explicit rather than ticking boxes that weren't done:

**Verified**

- All three manifests validate against the official 1.12.0 JSON schemas
  (`winget-manifest.{version,installer,defaultLocale}.1.12.0.schema.json`).
- `InstallerSha256` was computed from the **published release asset**, downloaded fresh from
  the URL in the manifest, not from a local build:
  `dedb60edc8a0130cfc15322d65546b666e219e39615fb5228d9cf68f2a2ec732`
- The manifests are generated from the release artifact by a task in the project
  ([`xtask pkg`](https://github.com/matrixism-cmyk/NabiTerm/blob/main/xtask/src/pkg.rs)),
  so version, URL and hash are never typed by hand.

**Not done**

- `winget validate` / `winget install --manifest` were not run. The submitting machine has
  PowerShell-style Store app-execution aliases for `winget` that fail with
  `0xC0E90002 (no applicable app licenses found)`, so the CLI is not usable there.
  The schema validation above was done instead.

Happy to fix anything the validation pipeline flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424797)