### PR TITLE
Update version: Microsoft.VFSforGit version 2.0.26229.1 (add arm64 installer)

### DIFF
--- a/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.installer.yaml
+++ b/manifests/m/Microsoft/VFSforGit/2.0.26229.1/Microsoft.VFSforGit.installer.yaml
@@ -3,6 +3,7 @@
 
 PackageIdentifier: Microsoft.VFSforGit
 PackageVersion: 2.0.26229.1
+InstallerLocale: en-US
 InstallerType: inno
 Scope: machine
 ProductCode: '{489CA581-F131-4C28-BE04-4FB178933E6D}_is1'
@@ -18,5 +19,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/microsoft/VFSForGit/releases/download/v2.0.26229.1/SetupGVFS.2.0.26229.1.exe
   InstallerSha256: 2A4A19FC239A9B50B135F237211212650644B1025C53D3184A951E485736C988
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/VFSForGit/releases/download/v2.0.26229.1/SetupGVFS.2.0.26229.1-arm64.exe
+  InstallerSha256: A013B4215B7F94E0742E34DBBD26BF608293F37253E0B4854DAFF1B4A760A569
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
### Add the arm64 installer to Microsoft.VFSforGit 2.0.26229.1

VFS for Git 2.0.26229.1 (the first 2.0 release) ships a native **arm64** installer in addition to the **x64** installer. The automated ingestion (#424566) added the x64 installer only, so arm64 users currently have no `winget` coverage for this version.

This PR updates the existing `2.0.26229.1` installer manifest to add the arm64 installer next to the x64 installer. It also sets `InstallerLocale: en-US` to match the package convention (present in prior versions such as 1.0.26014.1).

### Installers
| Architecture | Asset | SHA256 |
| --- | --- | --- |
| x64 (existing) | `SetupGVFS.2.0.26229.1.exe` | `2A4A19FC239A9B50B135F237211212650644B1025C53D3184A951E485736C988` |
| arm64 (added) | `SetupGVFS.2.0.26229.1-arm64.exe` | `A013B4215B7F94E0742E34DBBD26BF608293F37253E0B4854DAFF1B4A760A569` |

Both installers are Inno Setup packages that share the same `ProductCode` (`{489CA581-F131-4C28-BE04-4FB178933E6D}_is1`).

The arm64 installer was installed and verified on native ARM64 hardware via `winget install --manifest` (hash verified, install succeeded).

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424836)