### PR TITLE
New version: AurelioAvila.SocialDashboard version 1.6.0

### DIFF
--- a/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.installer.yaml
+++ b/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.installer.yaml
@@ -1,0 +1,20 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.SocialDashboard
+PackageVersion: 1.6.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: Social Dashboard.exe
+    PortableCommandAlias: socialdashboard
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AurelioAvila/social-dashboard/releases/download/v1.6.0/Social-Dashboard-v1.6.0-win64.zip
+    InstallerSha256: 1AF9463575359363D8A785987ED2E203A6F1FD66909106820F8785BDA3EA3346
+ReleaseDate: 2026-08-26
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.SocialDashboard
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/social-dashboard/issues
+PackageName: Social Dashboard
+PackageUrl: https://github.com/AurelioAvila/social-dashboard
+License: Proprietary
+ShortDescription: Brings your YouTube, Instagram, TikTok and X stats into one calm, private window - free, local-first, no account required.
+Description: Social Dashboard is a free Windows desktop application that brings together your YouTube, Instagram and TikTok statistics in a single window. Connect your accounts, press Refresh, and see follower counts, views and trends without opening each platform separately. All the data it shows comes directly from the official API of each platform, using an access token you grant yourself - your statistics and login credentials are never sent to any server the developer operates.
+Tags:
+- social-media
+- analytics
+- youtube
+- instagram
+- tiktok
+- dashboard
+ReleaseNotesUrl: https://github.com/AurelioAvila/social-dashboard/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.yaml
+++ b/manifests/a/AurelioAvila/SocialDashboard/1.6.0/AurelioAvila.SocialDashboard.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.SocialDashboard
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates AurelioAvila.SocialDashboard to 1.6.0.

Release notes: https://github.com/AurelioAvila/social-dashboard/releases/tag/v1.6.0

This is a portable zip (NestedInstallerType: portable) with the executable at the archive root (`Social Dashboard.exe`) — verified against the actual downloaded release asset before submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424845)