### PR TITLE
Update: AptiStock.AptiStockX to 3.1.0

### DIFF
--- a/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.installer.yaml
+++ b/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AptiStock.AptiStockX
+PackageVersion: 3.1.0
+InstallerType: inno
+Scope: user
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.aptistock.com/3.1/AptiStockX-3.1.0-Windows-x64-Setup.exe
+  InstallerSha256: F496D7E587579FA3C7E863E35E97FD5ED87401471020CC8BD52B817ADF3E356A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.locale.en-US.yaml
+++ b/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AptiStock.AptiStockX
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: AptiStock LLC
+PublisherUrl: https://aptistock.com
+PublisherSupportUrl: https://aptistock.com/help/license
+PrivacyUrl: https://aptistock.com/legal/privacy
+Author: AptiStock LLC
+PackageName: AptiStockX
+PackageUrl: https://aptistock.com
+License: Proprietary
+LicenseUrl: https://aptistock.com/legal/terms
+Copyright: Copyright (c) 2026 AptiStock LLC
+CopyrightUrl: https://aptistock.com/legal/terms
+ShortDescription: AptiStockX is a cross-platform desktop stock charting and portfolio research app.
+Description: AptiStockX is a cross-platform desktop stock charting and portfolio research app with a global symbol catalog, local watchlists, chart workspaces, technical indicators, drawing studies, portfolio tracking, and downloadable market data.
+Moniker: aptistockx
+Tags:
+- stocks
+- charts
+- portfolio
+- technical-analysis
+- trading
+- investing
+ReleaseNotes: AptiStockX 3.1 adds global market support with a searchable symbol catalog and dockable Global Market Stock Viewer, verified catalog updates, new line-study tools, and chart-rendering fixes.
+ReleaseNotesUrl: https://github.com/AptiStock/AptiStockX/releases/tag/v3.1.0
+PurchaseUrl: https://aptistock.com/buy
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.yaml
+++ b/manifests/a/AptiStock/AptiStockX/3.1.0/AptiStock.AptiStockX.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AptiStock.AptiStockX
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `AptiStock.AptiStockX` from version 3.0 to 3.1.0.

- Uses the version-specific AptiStock R2 installer URL.
- Updates the installer SHA-256 to `F496D7E587579FA3C7E863E35E97FD5ED87401471020CC8BD52B817ADF3E356A`.
- Updates release notes and the GitHub release URL for V3.1.0.
- Retains the approved Inno Setup, x64, per-user installer configuration from V3.0.

## Checklist

- [x] Signed the Contributor License Agreement in the original AptiStockX submission.
- [x] Checked that there are no other open pull requests for this package version.
- [x] This pull request modifies one package manifest set only.
- [x] Verified the installer URL is live and version-specific.
- [x] Verified the local installer SHA-256 matches the manifest.
- [ ] Microsoft WinGet validation pipeline completed.
- [ ] Installation tested by the WinGet review pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424870)