### PR TITLE
New version: VMSOFT.TestMyLogic version 0.9.1

### DIFF
--- a/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.installer.yaml
+++ b/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.installer.yaml
@@ -14,7 +14,6 @@ ReleaseDate: 2026-08-27
 AppsAndFeaturesEntries:
 - DisplayName: TestMyLogic
   Publisher: testmylogic
-  DisplayVersion: 0.9.1
 Installers:
 - Architecture: x64
   InstallerUrl: https://dl.testmylogic.com/releases/0.9.1/TestMyLogic_0.9.1_x64-setup.exe

--- a/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.installer.yaml
+++ b/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: VMSOFT.TestMyLogic
+PackageVersion: 0.9.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-27
+AppsAndFeaturesEntries:
+- DisplayName: TestMyLogic
+  Publisher: testmylogic
+  DisplayVersion: 0.9.1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.testmylogic.com/releases/0.9.1/TestMyLogic_0.9.1_x64-setup.exe
+  InstallerSha256: 90C1815D37DAA1DF6B29E9DFE95BABB4290E95F05A79BB885745DBAAD59AB0E8
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.locale.en-US.yaml
+++ b/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: VMSOFT.TestMyLogic
+PackageVersion: 0.9.1
+PackageLocale: en-US
+Publisher: 비전측정소프트(VMSOFT)
+PublisherUrl: https://www.testmylogic.com
+PublisherSupportUrl: https://www.testmylogic.com/faq
+PrivacyUrl: https://www.testmylogic.com/privacy
+PackageName: TestMyLogic
+PackageUrl: https://www.testmylogic.com
+License: Proprietary
+Copyright: © 비전측정소프트(VMSOFT)
+ShortDescription: Overfitting validation for crypto trading strategies — PBO, walk-forward analysis and trade diagnostics, computed locally.
+Description: |-
+  TestMyLogic backtests a crypto trading strategy across its whole parameter grid and answers one question with statistics: does the strategy have real edge, or is it overfitted to the past? It downloads public market history, runs the bundled backtest engine locally, and reads the result through PBO (probability of backtest overfitting), walk-forward analysis, and trade diagnostics. Everything runs on your machine; an optional MCP connection lets an AI client drive the app.
+Moniker: testmylogic
+Tags:
+- backtesting
+- crypto
+- overfitting
+- pbo
+- quant
+- trading-strategy
+- validation
+- walk-forward
+ReleaseNotesUrl: https://www.testmylogic.com/release-notes
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.yaml
+++ b/manifests/v/VMSOFT/TestMyLogic/0.9.1/VMSOFT.TestMyLogic.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: VMSOFT.TestMyLogic
+PackageVersion: 0.9.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New version of VMSOFT.TestMyLogic (0.9.1, published 2026-08-27).

Supersedes #424375 ? 0.9.0 was replaced by 0.9.1 before that PR merged, so I am closing it in favor of this one. Only the version fields, release date, installer URL and SHA256 changed relative to the validated 0.9.0 manifests; the installer is Authenticode-signed and served from the same immutable URL scheme.

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (0.9.0 was install-tested locally in #424375; 0.9.1 differs only in version/URL/hash and the installer itself is verified against the published bytes)
- [x] Does your manifest conform to the 1.10 schema?