### PR TITLE
New package: JayYanez.JavaServiceSteward version 0.3.2

### DIFF
--- a/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.installer.yaml
+++ b/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: JayYanez.JavaServiceSteward
+PackageVersion: 0.3.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: java-service-steward-0.3.2-windows-x64\wrapper.exe
+    PortableCommandAlias: java-service-steward
+ReleaseDate: 2026-08-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jayyanez/java-service-steward/releases/download/v0.3.2/java-service-steward-0.3.2-windows-x64.zip
+    InstallerSha256: 070AE370B2DF57AB3C9B1B9CE99F4F913464E4A189379FFF1B0F8FE2F8B253EB
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.locale.en-US.yaml
+++ b/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: JayYanez.JavaServiceSteward
+PackageVersion: 0.3.2
+PackageLocale: en-US
+Publisher: Jay Yanez
+PublisherUrl: https://github.com/jayyanez
+PublisherSupportUrl: https://github.com/jayyanez/java-service-steward/issues
+PackageName: Java Service Steward
+PackageUrl: https://jayyanez.github.io/java-service-steward/
+License: Apache-2.0 OR MIT
+LicenseUrl: https://github.com/jayyanez/java-service-steward/blob/main/LICENSE-APACHE
+Copyright: Copyright 2026 Java Service Steward Authors
+ShortDescription: Runs, controls, and monitors Java applications as Windows services; reads wrapper.conf-style configuration files.
+Description: |-
+  Java Service Steward is a Windows service host for Java applications, written in Rust and released under Apache-2.0 OR MIT. It installs a Java application as a Windows service, launches and supervises the JVM over an authenticated loopback channel, restarts it when it fails or stops responding, rotates its log, and provides thread and heap dumps on demand. It reads the widely deployed wrapper.conf configuration format and follows its command-line conventions, so existing installations can switch to it in place. The package contains wrapper.exe and the bridge wrapper.jar; copy both next to your wrapper.conf.
+Moniker: java-service-steward
+Tags:
+  - java
+  - jvm
+  - service
+  - windows-service
+  - wrapper
+  - supervisor
+ReleaseNotesUrl: https://github.com/jayyanez/java-service-steward/releases/tag/v0.3.2
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://jayyanez.github.io/java-service-steward/
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.yaml
+++ b/manifests/j/JayYanez/JavaServiceSteward/0.3.2/JayYanez.JavaServiceSteward.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: JayYanez.JavaServiceSteward
+PackageVersion: 0.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package: **JayYanez.JavaServiceSteward** version **0.3.2** (portable zip, x64).

Java Service Steward runs, controls, and monitors Java applications as Windows services and reads wrapper.conf-style configuration files. Open source (Apache-2.0 OR MIT): https://github.com/jayyanez/java-service-steward

The zip is the official release asset built by the project's GitHub Actions release workflow (SHA256 matches the published `SHA256SUMS`, and the archive carries a Sigstore build-provenance attestation). It contains `wrapper.exe` (portable, aliased as `java-service-steward`) together with its `wrapper.jar`, which the executable locates next to itself.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validated only; portable zip, installation exercised by the pipeline)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.9.md)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/424967)