### PR TITLE
chore: update OpenTubeX.OpenTubeX to 0.32.1

### DIFF
--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.installer.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.installer.yaml
@@ -1,0 +1,45 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Protocols:
+- opentubex
+ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+ReleaseDate: 2026-08-25
+AppsAndFeaturesEntries:
+- DisplayName: OpenTubeX 0.32.1
+  ProductCode: a38f022d-fec2-5f80-a7fe-620ccf1a2767
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.1-beta/opentubex-0.32.1-beta-setup-x64.exe
+  InstallerSha256: B44826CD6D23C1131F8AC76D2D4444D164E76146968F85556F9FD846FFF4E46D
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.1-beta/opentubex-0.32.1-beta-setup-x64.exe
+  InstallerSha256: B44826CD6D23C1131F8AC76D2D4444D164E76146968F85556F9FD846FFF4E46D
+  InstallerSwitches:
+    Custom: /ALLUSERS
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.1-beta/opentubex-0.32.1-beta-setup-arm64.exe
+  InstallerSha256: 1A5EBA2D2D3B14CEA2D9230B2F041A6578538210B806D2A10FFE635E77239171
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.32.1-beta/opentubex-0.32.1-beta-setup-arm64.exe
+  InstallerSha256: 1A5EBA2D2D3B14CEA2D9230B2F041A6578538210B806D2A10FFE635E77239171
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.locale.en-US.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.locale.en-US.yaml
@@ -1,0 +1,87 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.1
+PackageLocale: en-US
+Publisher: OpenTubeX contributors
+PublisherUrl: https://github.com/OpenTubeX
+PublisherSupportUrl: https://github.com/OpenTubeX/OpenTubeX/issues
+Author: OpenTubeX contributors
+PackageName: OpenTubeX
+PackageUrl: https://opentubex.org/
+License: AGPL-3.0
+LicenseUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+Copyright: Copyleft © 2020-2026
+CopyrightUrl: https://github.com/OpenTubeX/OpenTubeX/blob/HEAD/LICENSE
+ShortDescription: A private YouTube client
+Description: OpenTubeX is a private YouTube client for desktop.
+Moniker: opentubex
+Tags:
+- cross-platform
+- electron
+- privacy
+- private-youtube
+- sponsorblock
+- subscriptions
+- tabbed-browsing
+- tabs
+- video
+- videos
+- youtube
+- youtube-client
+- youtube-player
+ReleaseNotes: |-
+  Highlights
+  - Added a command palette, opened with Ctrl or Cmd + K by default (#854, #911)
+
+  More improvements
+  - Settings are easier to navigate, search, and use at different window sizes (#560, #841)
+  - Retry age-restricted and members-only videos with cookies through yt-dlp (#843, #844)
+  - External software settings group yt-dlp and FFmpeg controls, while playback follows yt-dlp's maintained client order before using the embedded fallback (#849)
+  - Video thumbnails can show YouTube's animated hover previews (#851)
+  - Set custom SponsorBlock segment colors (#850)
+  - Ambient mode fills fullscreen letterbox and pillarbox bars and stays centered beside open information docks (#900)
+  - Playlist pages have an independent Grid or List view setting (#906, #909)
+  - New tabs can start with Skip Silence enabled while each tab keeps its own choice (#893, #910)
+  - Review disk usage and clean individual caches or saved data from Data & Storage settings (#857, #913)
+  - Downloads use a persistent queue with concurrency and bandwidth limits, and Ctrl or Cmd + J opens the Downloads page (#856, #912)
+  - Player errors offer a one-click retry with the other stream extraction method (#927)
+  - Control persistent yt-dlp stream URL caching with a configurable per-entry limit (#919, #928)
+
+  Fixed bugs
+  - Fixed spacing around empty subscription feed messages (#834)
+  - Prevent long-running and alternate-audio playback sessions from stalling or losing stream state (#833)
+  - Subscription feed tabs show their content without waiting for the indicator animation (#835)
+  - Completed automatic-download notifications play the local file instead of opening an empty watch tab (#838)
+  - The Skip Silence shortcut indicator shows both skip and mute symbols (#842)
+  - Keep the custom color picker's hue when dragging outside its color area (#840)
+  - Center icons and avatars inside square sidebar tiles when labels are hidden (#837)
+  - Subscription feeds stay responsive while refreshing large lists with many tabs open (#848)
+  - Settings search highlights complete settings and sections and excludes unavailable controls (#852)
+  - Community post galleries recover from failed image requests and remain navigable after switching feed tabs (#862)
+  - Fixed restored video tabs briefly showing as loading after switching away (#880)
+  - Fixed notification spacing, wrapping, and scrollbars in fullscreen (#876)
+  - Fixed playlist duration sorting, imported search history order, and pagination localization (#875)
+  - Videos opened from timestamped links resume from saved progress after restart (#890)
+  - Clearing the search bar remains effective after switching tabs (#888)
+  - Changing the Shorts setting no longer resizes a playing Short (#853)
+  - Normal square videos no longer open in the Shorts player (#894)
+  - Fixed Shorts information panels, fullscreen menu positioning, dock animations, and title interactions (#892)
+  - Fixed Settings shortcuts, nested view flashes, and lost category scroll positions (#899)
+  - Show full player menu labels in a tooltip when text is cut off (#902)
+  - Syncing open tabs no longer reloads tabs that remain open on another device (#903)
+  - Play videos with the configured yt-dlp extractor when the built-in metadata request is IP blocked (#819, #908)
+  - Line-delimited imports keep the final record and report malformed row numbers (#866, #879)
+  - Fixed History search pagination stopping after the first 100 matches (#869, #884)
+  - Stop filtered searches from loading repeatedly after reaching the end (#915)
+  - Downloads with very long titles are shortened instead of failing (#916)
+  - Fixed Invidious popularity sorting, thumbnails, and Basic authentication scoping (#917)
+  - Tabs no longer jump back while being reordered on slower systems (#925)
+  - Moving a tab resets the "After current tab in opened order" sequence (#921)
+  - The player shows the replay icon when a video ends (#926)
+  - Compact settings breadcrumbs keep the current category readable (#922)
+  - Comments load with the video when automatic pagination is enabled (#924)
+ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.32.1-beta
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.yaml
+++ b/manifests/o/OpenTubeX/OpenTubeX/0.32.1/OpenTubeX.OpenTubeX.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: 0.32.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

The winget package is still on OpenTubeX 0.32.0, so Windows users do not receive the command palette, download queue, storage controls, and fixes released in 0.32.1.

This updates `OpenTubeX.OpenTubeX` to 0.32.1 for x64 and ARM64. It keeps user and machine installation scopes, the current repository-topic tags, and text-only release notes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validated with Komac:

```text
komac submit --dry-run --yes manifests/o/OpenTubeX/OpenTubeX/0.32.1
```

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425031)