### PR TITLE
New package: ubranch.Jot version 0.2.2

### DIFF
--- a/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.installer.yaml
+++ b/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ubranch.Jot
+PackageVersion: 0.2.2
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: jot.exe
+  PortableCommandAlias: jot
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ubranch/jot-gemini-transcribe-Windows/releases/download/v0.2.2/Jot-0.2.2-windows-x64.zip
+  InstallerSha256: F2CB373800F141DA3DBA3F0007F5D35E68C782892E029E2E95DA6FBE68E0A94C
+ReleaseDate: 2026-08-27
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.locale.en-US.yaml
+++ b/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ubranch.Jot
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: ubranch
+PublisherUrl: https://github.com/ubranch
+PublisherSupportUrl: https://github.com/ubranch/jot-gemini-transcribe-Windows/issues
+PackageName: Jot
+PackageUrl: https://github.com/ubranch/jot-gemini-transcribe-Windows
+License: Apache-2.0
+LicenseUrl: https://github.com/ubranch/jot-gemini-transcribe-Windows/blob/main/LICENSE
+Copyright: Copyright 2026 Google LLC
+ShortDescription: Hold a key, speak, and the text lands at your cursor.
+Description: |-
+  Jot is a push-to-talk dictation app for Windows. Hold the dictation key, say
+  the thing, let go, and a moment later your words are in the app you were
+  already using — punctuated, filler words removed, cleaned up.
+
+  Audio goes from your PC straight to the Gemini API with your own key: no
+  middleman server, no account, no analytics. Recordings hit the disk from the
+  first millisecond, so a crash costs you nothing, and dictations made offline
+  queue and land when you reconnect.
+
+  A Windows port of Jot by Ammaar Reshi, rewritten in Rust on GPUI. Not an
+  officially supported Google product. Requires your own Gemini API key.
+Moniker: jot
+Tags:
+- dictation
+- speech-to-text
+- transcription
+- voice
+- gemini
+- ai
+- productivity
+- accessibility
+ReleaseNotesUrl: https://github.com/ubranch/jot-gemini-transcribe-Windows/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.yaml
+++ b/manifests/u/ubranch/Jot/0.2.2/ubranch.Jot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ubranch.Jot
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: ubranch.Jot 0.2.2

Jot is a push-to-talk dictation app for Windows. Hold a key, speak, let go, and the text lands at the cursor in whatever app you were already using. Audio goes from the user's PC straight to the Gemini API with their own key — no middleman server and no account.

- Repository: https://github.com/ubranch/jot-gemini-transcribe-Windows
- Release: https://github.com/ubranch/jot-gemini-transcribe-Windows/releases/tag/v0.2.2
- License: Apache-2.0

#### Checklist

- [x] Manifest passes `winget validate`
- [x] `InstallerSha256` verified against the published asset by downloading it
- [x] Installer URL is a permanent GitHub release asset
- [x] I am the publisher of this package

#### Note for the reviewer

The binary is **not code-signed**. It is an open-source project whose author is
in a country outside the eligibility list for Azure Trusted Signing, and a
traditional OV certificate with the required hardware token is not currently
practical. The project states this plainly in its own README and release notes
rather than hiding it, and `InstallerType: zip` with a nested portable
executable means nothing is written outside winget's own package directory.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425045)