### PR TITLE
New package: GRCSAC.NetVane version 1.3.1

### DIFF
--- a/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.installer.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.3.1
+# Matches the published requirement ("Windows 10 or 11, 64-bit"). Deliberately not stricter: this
+# field makes winget REFUSE to install below it, so it must not promise less than the website does.
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-31
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://netvane.doorvane.com/downloads/NetVane-Setup-1.3.1.exe
+    InstallerSha256: 9348C39EB5C3C4B84BA40E0613F04BEB28C888B69BEB0AE266418843D1026AE0
+    # Inno's uninstall key is "{AppId}_is1"; AppId is pinned in installer/netvane.iss and must
+    # never change between versions, since it drives upgrade and uninstall detection.
+    ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+    AppsAndFeaturesEntries:
+      # UninstallDisplayName in the .iss is "NetVane {version}", so the ARP name is NOT the
+      # package name and changes every release. Without this, winget cannot correlate an
+      # existing install and would offer an upgrade that is already applied.
+      - DisplayName: NetVane 1.3.1
+        Publisher: GRCSAC
+        ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+        # No UpgradeCode: that is an MSI concept and this is an Inno installer. Putting the Inno
+        # AppId there would look right and mean nothing.
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.locale.en-US.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.locale.en-US.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.3.1
+PackageLocale: en-US
+# Publisher matches the Authenticode certificate subject (CN=GRCSAC), which is what Windows
+# displays. GRCSAC LLC is the legal entity and appears in Copyright and the EULA. Keeping these
+# distinct is deliberate - see the note in installer/netvane.iss.
+Publisher: GRCSAC
+PublisherUrl: https://netvane.doorvane.com
+PublisherSupportUrl: https://netvane.doorvane.com/support/
+PrivacyUrl: https://netvane.doorvane.com/privacy/
+Author: GRCSAC
+PackageName: NetVane
+PackageUrl: https://netvane.doorvane.com
+License: Proprietary
+LicenseUrl: https://netvane.doorvane.com/eula/
+Copyright: Copyright (c) 2026 GRCSAC LLC
+CopyrightUrl: https://netvane.doorvane.com/eula/
+ShortDescription: Maps the devices on your network and shows what they are exposing, entirely on your own machine
+Description: |-
+  NetVane finds the devices on your network - phones, laptops, cameras, smart-home gadgets -
+  and draws them as a live map: what each device is, how it connects, and what it is exposing,
+  with plain-language fixes.
+
+  Discovered service versions are matched against an NVD and CISA-KEV vulnerability database
+  bundled with the app, so exposure checks work with no internet connection. There is no cloud
+  service, no account and no agent: the app opens a local dashboard at 127.0.0.1:8787 and keeps
+  everything in a local database on the machine it runs on.
+
+  The free edition is not a trial. Discovery, the topology map, device identification, port
+  fingerprinting, CVE and KEV matching, report export and local backups are all perpetual, with
+  no account required, and vulnerability and fingerprint data updates stay free. Optional Pro and
+  Business licences add scheduled and background scanning, multiple subnets, credentialed
+  validation, extended retention, remote alerts, and compliance reporting for teams.
+
+  Installs per-user and needs no administrator rights. A portable build is also available from
+  the website for use without installing.
+Moniker: netvane
+Tags:
+  - cve
+  - device-discovery
+  - inventory
+  - lan
+  - network
+  - network-map
+  - network-monitor
+  - network-scanner
+  - offline
+  - port-scanner
+  - privacy
+  - security
+  - sysadmin
+  - topology
+  - vulnerability-scanner
+ReleaseNotes: |-
+  NetVane has been through two independent security reviews of its privacy and security claims,
+  and this release is what came out of them. Some changes make it deliberately stricter: it now
+  scans only your own network and refuses publicly routable addresses; undoing a router fix asks
+  first and confirms with the router afterwards; a device that could not be fully checked is no
+  longer reported as secure; and sending a problem report no longer includes raw log text.
+ReleaseNotesUrl: https://netvane.doorvane.com/changelog/
+Documentations:
+  - DocumentLabel: User guide
+    DocumentUrl: https://netvane.doorvane.com/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.3.1/GRCSAC.NetVane.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
NetVane — a local-first network scanner and security monitor for Windows.

### Checklist
- [x] Manifest passes `winget validate`
- [x] Installer verified: installs and uninstalls cleanly, per-user, no admin/UAC
- [x] `InstallerSha256` matches the published installer
- [x] Installer is Authenticode-signed (`CN=GRCSAC`, Microsoft Trusted Signing, timestamped)
- [x] `InstallerUrl` is served over HTTPS from the vendor's own domain

### Notes for reviewers

**`AppsAndFeaturesEntries` carries `DisplayName` only, deliberately.** The Inno installer sets
`UninstallDisplayName` to `NetVane {version}`, so the Add/Remove Programs name is *not* the package
name and changes each release. Without the entry, winget cannot correlate an existing install and
offers an upgrade that is already applied. `DisplayVersion` is intentionally omitted — it would
equal `PackageVersion`, and @stephengillie correctly flagged that as redundant on an earlier
submission (#423491).

**Supersedes #423491 (1.2.0) and #423778 (1.2.1), both closed.** Those versions have since been
replaced by a security-remediation release, and we would rather they were not installable via
`--version`.

No `UpgradeCode` — that is MSI-only and this is an Inno Setup installer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425113)