### PR TITLE
New version: PasteBridge.PasteBridge version 1.2.2

### DIFF
--- a/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.installer.yaml
+++ b/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: PasteBridge.PasteBridge
+PackageVersion: 1.2.2
+
+# Squirrel.Windows bootstrapper (@electron-forge/maker-squirrel). It installs
+# per-user into %LocalAppData%\PasteBridge and needs no elevation, hence
+# Scope: user. --silent is Squirrel's own unattended flag.
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+
+# Squirrel manages its own in-place updates, so winget should install over the
+# top rather than trying to uninstall first.
+UpgradeBehavior: install
+
+Installers:
+  # NOTE: this URL is the IMMUTABLE, version-stamped copy written by
+  # scripts/deploy-updates.js — never the rolling PasteBridgeSetup.exe, whose
+  # bytes change on every release and would break this hash.
+  - Architecture: x64
+    InstallerUrl: https://updates.pastebridge.com/PasteBridge-1.2.2-Setup.exe
+    InstallerSha256: 9AB2F5610C89DF98551E338A3217998F59AF62C53B0DC810D4AEB4ADE9E1BF52
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.locale.en-US.yaml
+++ b/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: PasteBridge.PasteBridge
+PackageVersion: 1.2.2
+PackageLocale: en-US
+
+Publisher: PasteBridge
+PublisherUrl: https://pastebridge.com
+PublisherSupportUrl: https://pastebridge.com/guides
+PackageName: PasteBridge
+PackageUrl: https://pastebridge.com
+Moniker: pastebridge
+
+# Proprietary — the shipped EULA (build/LICENSE.txt) grants a personal,
+# non-transferable licence. This is NOT open source.
+License: Proprietary
+LicenseUrl: https://pastebridge.com/terms
+Copyright: Copyright (c) 2025-2026 PasteBridge
+PrivacyUrl: https://pastebridge.com/privacy
+
+ShortDescription: One clipboard across your Windows machines — copy text, images, files and folders on one PC and paste them on another.
+
+Description: |-
+  PasteBridge keeps a single clipboard across the Windows machines you use. Copy
+  text, an image, a file or a whole folder on one PC and paste it on another.
+
+  On the same network it connects directly over your LAN. Across different
+  networks it routes through a relay that only ever handles ciphertext —
+  everything is encrypted end to end with AES-256-GCM using a key derived from a
+  pairing code you choose, so the relay cannot read what passes through it.
+
+  It also works inside Remote Desktop: copy on your workstation and paste inside
+  the RDP session on your server, even with Windows' own clipboard redirection
+  turned off — PasteBridge runs in the remote session like any other app and
+  carries the clipboard itself.
+
+  Clipboard history, a sensitive-content filter that keeps credit-card numbers,
+  API keys and passwords out of both sync and history, and text transforms are
+  included. Free for 2 devices.
+
+Tags:
+  - clipboard
+  - clipboard-manager
+  - clipboard-sync
+  - file-transfer
+  - remote-desktop
+  - rdp
+  - productivity
+  - lan
+  - sync
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.yaml
+++ b/manifests/p/PasteBridge/PasteBridge/1.2.2/PasteBridge.PasteBridge.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: PasteBridge.PasteBridge
+PackageVersion: 1.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds PasteBridge 1.2.2. Manifests validated locally with `winget validate`. Installer is hosted on our own CDN at an immutable version-stamped URL; InstallerSha256 computed from that exact artifact.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425115)