### PR TITLE
New package: fpinero.mouse-desktop version 0.1.0

### DIFF
--- a/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.installer.yaml
+++ b/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: fpinero.mouse-desktop
+PackageVersion: 0.1.0
+
+# The release publishes a bare .exe, not an archive, so this is `portable` directly rather
+# than `zip` with a nested portable inside it.
+InstallerType: portable
+
+# Without this, winget derives the alias from the file name and you would type
+# `mouse-desktop-x64` to start it. The same reasoning as the `#/mouse-desktop.exe` fragment
+# in the Scoop manifest: the documentation, the troubleshooting table and `Get-Process` all
+# say `mouse-desktop`.
+Commands:
+  - mouse-desktop
+
+ReleaseDate: 2026-08-23
+
+# Versioned URLs, never `releases/latest/download/...`: a manifest pins one version and its
+# hash, so a URL that follows the newest release would stop matching the hash on the day a
+# new one ships.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fpinero/mouse-desktop/releases/download/v0.1.0/mouse-desktop-x64.exe
+    InstallerSha256: 5C92E1F82ACC8515134BF0384655DBF5518ABDF333C12D2A9D61C7E2D1D550DE
+  - Architecture: arm64
+    InstallerUrl: https://github.com/fpinero/mouse-desktop/releases/download/v0.1.0/mouse-desktop-arm64.exe
+    InstallerSha256: 3890093C8543D481F428E5268D4821AC0652188B90EA2EA9965B0C05B45B5F40
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.locale.en-US.yaml
+++ b/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: fpinero.mouse-desktop
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Fernando Piñero
+PublisherUrl: https://github.com/fpinero
+PublisherSupportUrl: https://github.com/fpinero/mouse-desktop/issues
+Author: Fernando Piñero
+PackageName: mouse-desktop
+PackageUrl: https://mouse-desktop.nivelepsilon.com
+License: MIT
+LicenseUrl: https://github.com/fpinero/mouse-desktop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Fernando Piñero
+CopyrightUrl: https://github.com/fpinero/mouse-desktop/blob/main/LICENSE
+ShortDescription: Switch Windows virtual desktops with a mouse gesture, without Administrator privileges
+Description: |-
+  Hold the wheel button and drag horizontally to move one virtual desktop per 60 pixels.
+  Keep dragging to walk across several. Press and release without dragging and the click is
+  passed on intact, so middle click keeps closing browser tabs. Drag vertically and nothing
+  happens.
+
+  Windows already changes virtual desktop with Ctrl+Win+Left and Ctrl+Win+Right, but that
+  means taking a hand off the mouse. Vendor software such as Logitech Options can remap a
+  mouse button to that shortcut, and every one of those tools needs an Administrator account
+  to install. This does the same job using only what a standard user is allowed to do.
+
+  One 270 KB executable. No Administrator privileges, no runtime to install, no driver, no
+  service, and no network connections. It installs a low level mouse hook with
+  SetWindowsHookEx and synthesises the documented Ctrl+Win+Arrow shortcut with SendInput;
+  both are documented Win32 calls and neither requires a privilege.
+
+  Note that winget will not register it to start with Windows. Once it is running, right
+  click the tray icon, the two blue arrows next to the clock, and tick "Start with Windows".
+Moniker: mouse-desktop
+Tags:
+  - desktop
+  - gesture
+  - mouse
+  - productivity
+  - tray
+  - virtual-desktop
+  - windows
+ReleaseNotesUrl: https://github.com/fpinero/mouse-desktop/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: Product page
+    DocumentUrl: https://mouse-desktop.nivelepsilon.com
+  - DocumentLabel: Configuration and troubleshooting
+    DocumentUrl: https://github.com/fpinero/mouse-desktop#configuration
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.yaml
+++ b/manifests/f/fpinero/mouse-desktop/0.1.0/fpinero.mouse-desktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: fpinero.mouse-desktop
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `fpinero.mouse-desktop` version 0.1.0.

A tray utility that switches Windows virtual desktops with a mouse gesture: hold the wheel
button, drag left or right, and Windows moves to the neighbouring desktop. One 270 KB
executable with no runtime, no driver and no service, and it needs no Administrator
privileges at install time or at run time, which is the reason it exists: the vendor mouse
software that does the same job cannot be installed on a managed machine.

- Source: https://github.com/fpinero/mouse-desktop (Rust, MIT)
- Product page: https://mouse-desktop.nivelepsilon.com

Two notes on the manifest, in case they save a reviewer a question:

- `InstallerType: portable` rather than `zip` with a nested portable, because the release
  publishes a bare `.exe` and there is nothing to unpack.
- `Commands: [mouse-desktop]` so the alias is not derived from the file name. Without it the
  command would be `mouse-desktop-x64`, and every piece of the project's documentation,
  including its troubleshooting table, refers to `mouse-desktop`.

The installer URLs are versioned rather than `releases/latest/download/...`, so they keep
matching the hashes pinned here when a new release ships.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
      <!-- Not signed yet. The bot's prompt on this PR is where I will do it. -->
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Tested on Windows 11 with winget 1.29.290: `winget validate` reports "Manifest validation
succeeded", `winget install --manifest` installs, the `mouse-desktop` alias starts it, it
appears in `winget list`, and it uninstalls cleanly.
