### PR TITLE
New package: TVasilev.RainCleaner version 2.7.0

### DIFF
--- a/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.installer.yaml
+++ b/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TVasilev.RainCleaner
+PackageVersion: 2.7.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{8E66717F-C7B3-45B0-BD09-8438550ABA6C}'
+ReleaseDate: '2026-08-27'
+AppsAndFeaturesEntries:
+- DisplayName: Rain Cleaner - Driver Installer, Cleaning and Game Booster
+  Publisher: T. Vasilev
+  DisplayVersion: 2.7.0
+  ProductCode: '{8E66717F-C7B3-45B0-BD09-8438550ABA6C}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Rain Cleaner'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/raincleaner/RainCleaner/releases/download/v2.7.0/RainCleaner-Setup.msi
+  InstallerSha256: A9E55786E67012A6339B92744A7ED37C6C07BACB5F704B8419B92B93E7445CE8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.locale.en-US.yaml
+++ b/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TVasilev.RainCleaner
+PackageVersion: 2.7.0
+PackageLocale: en-US
+Publisher: T. Vasilev
+PublisherUrl: https://raincleaner.eu
+PublisherSupportUrl: https://raincleaner.eu/contact
+PackageName: Rain Cleaner
+PackageUrl: https://raincleaner.eu
+License: Proprietary
+LicenseUrl: https://raincleaner.eu/terms
+Copyright: Copyright (c) 2026 T. Vasilev
+ShortDescription: Free Windows cleaner, driver installer and ransomware guard that explains every change before it makes it.
+Description: |-
+  Rain Cleaner checks what is taking up space, which drivers are out of date and what starts
+  with Windows. Then it shows you what it found and why, and you decide what changes.
+
+  Cleaning comes with a reason for every item, so you can see what you lose before anything
+  is deleted. Drivers come from Microsoft's own catalogue, and when a manufacturer has a
+  newer one, the program says so instead of hosting anything itself. A game booster frees
+  resources while you play and puts every setting back afterwards; it never suspends or kills
+  a process. Emergency drivers get the network working again on a PC that cannot get online.
+  Ransomware protection places decoy files in your folders so encryption is caught early.
+
+  What it does not do: it is not an antivirus and does not replace one, and it cannot make
+  your internet connection faster - it can only measure which DNS server answers fastest.
+
+  Windows 10, Windows 11 and Windows Server. Free, no account, no subscription. The interface
+  speaks six languages.
+Moniker: raincleaner
+Tags:
+- clean
+- cleaner
+- disk-cleanup
+- driver
+- driver-updater
+- game-booster
+- optimizer
+- ransomware
+- security
+- system
+- utility
+ReleaseNotes: |-
+  The program now tells you when a new version is out. It checks once a day at start-up and
+  shows a quiet bar at the bottom; it still never downloads or installs anything by itself.
+  "Not now" means not now, and the whole thing can be switched off in Settings.
+ReleaseNotesUrl: https://raincleaner.eu/changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.yaml
+++ b/manifests/t/TVasilev/RainCleaner/2.7.0/TVasilev.RainCleaner.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TVasilev.RainCleaner
+PackageVersion: 2.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package

**TVasilev.RainCleaner 2.7.0** — a free cleaner, driver installer and ransomware guard for Windows 10 and 11.

Homepage: https://raincleaner.eu
Installer: hosted on the project's own GitHub release — https://github.com/raincleaner/RainCleaner/releases/tag/v2.7.0

---

#### Checklist

- [ ] **Contributor License Agreement** — not signed yet. The account owner is signing it now.
- [x] Checked that there are no other open pull requests for this manifest.
- [ ] **`winget validate` / `winget install --manifest` — not run.** Stated openly rather than ticked: the only Windows machine available here is **Windows Server 2019**, which has no App Installer and therefore no `winget`. See what *was* verified below.
- [x] The manifests conform to the **1.12.0** schema.

#### What was actually verified

- All three manifests validate against Microsoft's published JSON schemas (`winget-manifest.installer.1.12.0`, `defaultLocale.1.12.0`, `version.1.12.0`), checked programmatically rather than by eye.
- `ProductCode` `{8E66717F-C7B3-45B0-BD09-8438550ABA6C}` was read from the uninstall registry key **after a real installation of 2.7.0**, not guessed.
- `InstallerSha256` was computed from the exact bytes the release URL serves, then re-downloaded and compared again.
- The installer is a WiX-built MSI, installs silently with `/qn`, and was verified end to end on a real machine (`msiexec` exit code 0, program launches, correct version reported).

#### Please note

The installer is **not code-signed yet**. This is stated openly on the product's site, in its README and in the release notes — the download page offers a portable ZIP for anyone who would rather not see the SmartScreen prompt.