### PR TITLE
Update: TypeWhisper.TypeWhisper to 1.0.9

### DIFF
--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.installer.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.9
+InstallerType: exe
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  InstallLocation: --installto <INSTALLPATH>
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ProductCode: TypeWhisper
+AppsAndFeaturesEntries:
+- DisplayName: TypeWhisper
+  Publisher: TypeWhisper
+  ProductCode: TypeWhisper
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.9/TypeWhisper-win-x64-Setup.exe
+  InstallerSha256: 7277D491A85A6F7BEBF22712602A041A27C94AAF798DE0618292FBEF47C0C33D
+- Architecture: arm64
+  InstallerUrl: https://github.com/TypeWhisper/typewhisper-win/releases/download/v1.0.9/TypeWhisper-win-arm64-Setup.exe
+  InstallerSha256: B1A6C6F0B589AF47B5BC00DC2E347662648E966186AE820C97F8654E22E96A22
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.locale.en-US.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.9
+PackageLocale: en-US
+Publisher: TypeWhisper
+PublisherUrl: https://www.typewhisper.com
+PublisherSupportUrl: https://github.com/TypeWhisper/typewhisper-win/issues
+PrivacyUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.9/docs/PRIVACY.md
+Author: TypeWhisper
+PackageName: TypeWhisper
+PackageUrl: https://github.com/TypeWhisper/typewhisper-win
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/TypeWhisper/typewhisper-win/blob/v1.0.9/LICENSE
+ShortDescription: Speech-to-text and AI text processing for Windows.
+Description: TypeWhisper for Windows provides system-wide dictation, file transcription, reusable workflows, history, snippets, local and cloud transcription engines, and a plugin marketplace for speech-to-text and AI text processing.
+Moniker: typewhisper
+Tags:
+- ai
+- dictation
+- speech-to-text
+- transcription
+- whisper
+ReleaseNotesUrl: https://github.com/TypeWhisper/typewhisper-win/releases/tag/v1.0.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.yaml
+++ b/manifests/t/TypeWhisper/TypeWhisper/1.0.9/TypeWhisper.TypeWhisper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TypeWhisper.TypeWhisper
+PackageVersion: 1.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `TypeWhisper.TypeWhisper` to version `1.0.9` for x64 and ARM64 using the published TypeWhisper v1.0.9 installers.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there are no other open pull requests for this manifest update
- [x] This PR only modifies one package manifest
- [x] Validated the manifest locally with `winget validate --manifest manifests\t\TypeWhisper\TypeWhisper\1.0.9`
- [x] Inspected it locally with `winget show --manifest manifests\t\TypeWhisper\TypeWhisper\1.0.9`
- [x] Confirmed both installer SHA256 hashes against the published GitHub release metadata
- [x] Manifest conforms to the 1.12 schema
- [ ] Tested installation locally

Local installation was not run because this machine currently has the Microsoft Store build installed. The existing installation should not be replaced with the direct distribution during manifest preparation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425222)