### PR TITLE
New package: ruddro-roy.sindook version 0.8.1

### DIFF
--- a/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.installer.yaml
+++ b/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.installer.yaml
@@ -7,7 +7,6 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: sindook.exe
-  PortableCommandAlias: sindook
 ReleaseDate: 2026-08-19
 Installers:
 - Architecture: x64

--- a/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.installer.yaml
+++ b/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.installer.yaml
@@ -1,0 +1,20 @@
+# InstallerSha256 values are the SHA-256 digests from the release checksums.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: ruddro-roy.sindook
+PackageVersion: 0.8.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: sindook.exe
+  PortableCommandAlias: sindook
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ruddro-roy/sindook/releases/download/v0.8.1/sindook_0.8.1_windows_amd64.zip
+  InstallerSha256: 77aaf9d016f2db5f96a16434d7af79e1df396920ec3e5be736aa84ecb4b16895
+- Architecture: arm64
+  InstallerUrl: https://github.com/ruddro-roy/sindook/releases/download/v0.8.1/sindook_0.8.1_windows_arm64.zip
+  InstallerSha256: f056771e6e80ca572cf2536d9f791389e23ecbb5aba3e2a8e919b8f9e8dc90df
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.locale.en-US.yaml
+++ b/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: ruddro-roy.sindook
+PackageVersion: 0.8.1
+PackageLocale: en-US
+Publisher: Ruddro Roy
+PublisherUrl: https://github.com/ruddro-roy
+PublisherSupportUrl: https://github.com/ruddro-roy/sindook/issues
+Author: Ruddro Roy
+PackageName: sindook
+PackageUrl: https://github.com/ruddro-roy/sindook
+License: Apache-2.0
+LicenseUrl: https://github.com/ruddro-roy/sindook/blob/v0.8.1/LICENSE
+Copyright: Copyright 2026 Ruddro Roy
+ShortDescription: "Hybrid post-quantum file encryption (X-Wing: X25519 + ML-KEM-768)"
+Description: |-
+  Sindook is a command-line tool that seals files with hybrid post-quantum
+  encryption using the X-Wing KEM (X25519 + ML-KEM-768) and can rotate
+  recipients, passphrases, and format versions without decrypting or
+  re-encrypting the payload in fast mode. Pre-1.0 software: the format and
+  design have not received an independent security audit.
+Moniker: sindook
+Tags:
+- cli
+- encryption
+- post-quantum
+- pqc
+- x-wing
+- ml-kem
+ReleaseNotesUrl: https://github.com/ruddro-roy/sindook/releases/tag/v0.8.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.yaml
+++ b/manifests/r/ruddro-roy/sindook/0.8.1/ruddro-roy.sindook.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: ruddro-roy.sindook
+PackageVersion: 0.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Description

Initial submission of **ruddro-roy.sindook**, a hybrid post-quantum file encryption CLI (X-Wing: X25519 + ML-KEM-768), for version 0.8.1.

- Installer archives are the official Windows release assets from https://github.com/ruddro-roy/sindook/releases/tag/v0.8.1 (portable zips, amd64 and arm64).
- SHA-256 hashes are taken verbatim from the release's published `checksums.txt`.
- Release binaries are additionally signed with Sigstore keyless signatures and ship with an SBOM and GitHub build provenance; anyone can rebuild the release byte-for-byte via `scripts/verify-reproducibility.sh` in the repo.
- License: Apache-2.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425225)