### PR TITLE
New package: DBaseInRs.Downloader version 1.0.10

### DIFF
--- a/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.installer.yaml
+++ b/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: DBaseInRs.Downloader
+PackageVersion: 1.0.10
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-08
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DBase-In-Rs/Downloader/releases/download/v1.0.10/dbase-downloader-v1.0.10-windows-x64-setup.exe
+  InstallerSha256: FE73A4CFC877801588560CDE2CF4ECF8BA6DDDAF9261B8BE44658E771B5D553D
+  ProductCode: '{F82F3B2C-5BC6-437D-9021-7BAA2B1F106F}_is1'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.locale.en-US.yaml
+++ b/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: DBaseInRs.Downloader
+PackageVersion: 1.0.10
+PackageLocale: en-US
+Publisher: DBase
+PublisherUrl: https://github.com/DBase-In-Rs
+PublisherSupportUrl: https://github.com/DBase-In-Rs/Downloader/issues
+Author: Velimir Majstorov
+PackageName: DBase Video & Music Downloader
+PackageUrl: https://github.com/DBase-In-Rs/Downloader
+License: GPL-3.0-only
+LicenseUrl: https://github.com/DBase-In-Rs/Downloader/blob/main/LICENSE
+Copyright: Copyright (c) Velimir Majstorov
+ShortDescription: Download video and music from any yt-dlp-supported site.
+Description: |-
+  DBase Video & Music Downloader accepts media URLs from any of the ~1,750
+  sites yt-dlp supports, reads the available formats, and downloads video or
+  audio as MP3, M4A, MP4, or the original format. It handles playlists,
+  albums, and channels, runs a sequential download queue with pause and
+  retry, keeps a persistent history, supports cookies.txt for login-required
+  sites, and keeps its yt-dlp engine up to date automatically.
+  Requires yt-dlp and FFmpeg on the PATH (or set their locations in
+  Settings).
+Moniker: dbase-downloader
+Tags:
+- audio
+- converter
+- download
+- downloader
+- ffmpeg
+- media
+- mp3
+- music
+- video
+- yt-dlp
+ReleaseNotesUrl: https://github.com/DBase-In-Rs/Downloader/releases/tag/v1.0.10
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.yaml
+++ b/manifests/d/DBaseInRs/Downloader/1.0.10/DBaseInRs.Downloader.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: DBaseInRs.Downloader
+PackageVersion: 1.0.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package: DBase Video & Music Downloader 1.0.10 — an open-source (GPL-3.0-only) Flutter desktop app that downloads video and music from yt-dlp-supported sites. First stable release; installer is Inno Setup, per-user scope.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (installer verified locally: silent install and uninstall both clean)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

---

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pulls)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425232)