### PR TITLE
New package: Mun1to.VoCript version 3.7.10

### DIFF
--- a/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.installer.yaml
+++ b/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Mun1to.VoCript
+PackageVersion: 3.7.10
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-23
+AppsAndFeaturesEntries:
+  - DisplayName: VoCript
+    Publisher: VoCript
+    ProductCode: VoCript
+    InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Mun1to/VoCript/releases/download/v3.7.10/VoCript_3.7.10_x64-setup.exe
+    InstallerSha256: F0F16A75FC3400B8636ED585C5F6E46F3680D7CB197EBB48B74852DDAA1D2123
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.locale.en-US.yaml
+++ b/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.locale.en-US.yaml
@@ -1,0 +1,48 @@
+PackageIdentifier: Mun1to.VoCript
+PackageVersion: 3.7.10
+PackageLocale: en-US
+Publisher: Munir Torres
+PublisherUrl: https://vocript.app
+PublisherSupportUrl: https://github.com/Mun1to/VoCript/issues
+Author: Munir Torres
+PackageName: VoCript
+PackageUrl: https://github.com/Mun1to/VoCript
+License: MIT
+LicenseUrl: https://github.com/Mun1to/VoCript/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Munir Torres
+ShortDescription: Offline voice dictation for Windows that types into any app, powered by Whisper.
+Description: |-
+  VoCript listens to your voice, or to the audio playing on your computer, and turns it into
+  text right where your cursor is, in any application. Every bit of the recognition happens on
+  your own machine with Whisper and other local models, so there is no account to create, no
+  audio leaving your computer and no waiting for a server.
+  Press a global shortcut and speak, and the text types itself into whatever window you are
+  using: a browser, a code editor, a chat, an email. It can also transcribe the sound playing
+  on your PC, or the sound of one specific application, and show the words appearing one by one
+  in a floating bubble while you talk. It transcribes audio and video files too, to plain text
+  or to subtitles.
+  A personal dictionary fixes the names it keeps getting wrong, work profiles adapt the output
+  to what you are writing, and a word tracker shows how much typing you have saved. The
+  interface is translated into 20 languages and follows your system theme.
+  Optional AI clean up can remove filler words and fix punctuation, and it runs against a local
+  model when you have one, never against the cloud unless you set that up yourself.
+Moniker: vocript
+Tags:
+  - dictation
+  - voice-typing
+  - speech-to-text
+  - transcription
+  - whisper
+  - offline
+  - privacy
+  - accessibility
+  - subtitles
+  - rust
+  - tauri
+  - open-source
+ReleaseNotesUrl: https://github.com/Mun1to/VoCript/releases/tag/v3.7.10
+Documentations:
+  - DocumentLabel: Home page
+    DocumentUrl: https://vocript.app
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.yaml
+++ b/manifests/m/Mun1to/VoCript/3.7.10/Mun1to.VoCript.yaml
@@ -1,0 +1,6 @@
+# Created using the manifest schema, by hand.
+PackageIdentifier: Mun1to.VoCript
+PackageVersion: 3.7.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request type

- [x] New package
- [ ] Package update
- [ ] Package removal
- [ ] Metadata or other change

### Package

`Mun1to.VoCript` version `3.7.10`

VoCript is a free and open source offline voice dictation tool for Windows: you press a global
shortcut, speak, and the text types itself into whatever application has the cursor. All the
speech recognition runs locally with Whisper and other on-device models, so no audio ever leaves
the machine and no account is needed. I am the author of the package.

### Checklist

- [x] Checked that there is no other open pull request for this manifest addition.
- [x] Validated locally with `winget validate --manifest <path>`, which returns `Manifest validation succeeded.`
- [x] Conforms to the 1.6 schema.
- [x] Verified the installer URL and its SHA256: the hash in the manifest was computed from the file downloaded from that exact release URL.
- [ ] **Not** tested with `winget install --manifest <path>`. This machine already has VoCript installed from the same NSIS installer and I did not want to reinstall over it. The installer is the one published on GitHub releases and in daily use.

### Installer notes

- NSIS installer, per user only (`installMode: currentUser` in Tauri), so it never prompts for
  administrator rights.
- Silent install with `/S`.
- The uninstall entry registers with `DisplayName: VoCript` and `Publisher: VoCript` under the
  current user's uninstall key, which is what the `AppsAndFeaturesEntries` block reflects.
- The package is also on the Microsoft Store as `9P247C96LC72`. This manifest points at the
  GitHub release instead, which is the build that carries the app's own auto updater.
