### PR TITLE
New version: Jorji49.streamtop version 0.3.4

### DIFF
--- a/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.installer.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.4
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: streamtop.exe
+    PortableCommandAlias: streamtop
+UpgradeBehavior: install
+ReleaseDate: 2026-08-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v0.3.4/streamtop-windows-x86_64-0.3.4.zip
+    InstallerSha256: 5BB8C5149C76DB8DFB81B086DA4AFF09E34BFB31C0F64E95E52F7F982D1E7D54
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.locale.en-US.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.4
+PackageLocale: en-US
+Publisher: Ahmet Kayra Kama
+PublisherUrl: https://github.com/Jorji49
+PublisherSupportUrl: https://github.com/Jorji49/streamtop/issues
+Author: Ahmet Kayra Kama
+PackageName: streamtop
+PackageUrl: https://github.com/Jorji49/streamtop
+License: MIT
+LicenseUrl: https://github.com/Jorji49/streamtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ahmet Kayra Kama
+ShortDescription: Terminal diagnostic engine for live HLS, DASH, and IPTV streams
+Description: Live HLS, DASH, and IPTV stream diagnostics TUI with wire probe (GOP cadence, audio), LL-HLS telemetry, SCTE-35, Prometheus (Bearer metrics), and Quick Play.
+Moniker: streamtop
+Tags:
+  - hls
+  - dash
+  - iptv
+  - diagnostics
+  - tui
+  - streaming
+ReleaseNotesUrl: https://github.com/Jorji49/streamtop/releases/tag/v0.3.4
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.yaml
+++ b/manifests/j/Jorji49/streamtop/0.3.4/Jorji49.streamtop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 0.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Portable Windows x64 package for [streamtop](https://github.com/Jorji49/streamtop) 0.3.4.

- **Install:** `winget install streamtop`
- PackageIdentifier: `Jorji49.streamtop`
- InstallerType: zip / NestedInstallerType: portable
- InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v0.3.4/streamtop-windows-x86_64-0.3.4.zip
- SHA256: 5BB8C5149C76DB8DFB81B086DA4AFF09E34BFB31C0F64E95E52F7F982D1E7D54

## Test plan
- [ ] `winget install --manifest manifests/j/Jorji49/streamtop/0.3.4`
- [ ] `streamtop --version` shows 0.3.4

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425258)