### PR TITLE
New package: MasaKjm.Shelfbox version 0.9.3

### DIFF
--- a/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.installer.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: shelfbox-v0.9.3-x86_64-pc-windows-msvc\shelfbox.exe
+  PortableCommandAlias: shelfbox
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/masa-kjm/shelfbox/releases/download/v0.9.3/shelfbox-v0.9.3-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 1E79DA3D981F916F5F7DECC4927D38C9846B9DAF9C8FC464EAE700171FEB43FB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.locale.en-US.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.3
+PackageLocale: en-US
+Publisher: masa-kjm
+PublisherUrl: https://github.com/masa-kjm
+PublisherSupportUrl: https://github.com/masa-kjm/shelfbox/issues
+PackageName: Shelfbox
+PackageUrl: https://github.com/masa-kjm/shelfbox
+License: MIT
+LicenseUrl: https://github.com/masa-kjm/shelfbox/blob/v0.9.3/LICENSE
+ShortDescription: Keep local-only files visible in your repository while keeping them out of Git.
+Moniker: shelfbox
+Tags:
+- git
+- cli
+- config
+- local
+ReleaseNotesUrl: https://github.com/masa-kjm/shelfbox/releases/tag/v0.9.3
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/masa-kjm/shelfbox/tree/v0.9.3/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.yaml
+++ b/manifests/m/MasaKjm/Shelfbox/0.9.3/MasaKjm.Shelfbox.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: MasaKjm.Shelfbox
+PackageVersion: 0.9.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: MasaKjm.Shelfbox version 0.9.3

## 📖 Description
Add MasaKjm.Shelfbox version 0.9.3 to the Windows Package Manager community repository.

Shelfbox is a command-line tool that keeps local-only files visible in a
repository while keeping them out of Git.

The package is distributed as an x64 portable ZIP installer from the official
GitHub release.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/m/MasaKjm/Shelfbox/0.9.3`
- [x] Tested manifest locally with `winget install --manifest manifests/m/MasaKjm/Shelfbox/0.9.3`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425265)