### PR TITLE
New package: MarcelGlaeser.Kubebar version 1.7.1

### DIFF
--- a/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.installer.yaml
+++ b/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarcelGlaeser.Kubebar
+PackageVersion: 1.7.1
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: '2026-08-26'
+ProductCode: '{7C3A8E2D-1B4F-4E9A-9D2C-0A1B2C3D4E5F}_is1'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://kubebar.app/download/Kubebar-Setup-1.7.1.exe
+    InstallerSha256: 0EAFD1CE198035D054795C0ABAE15E148E03CA6825772F7BAB7FEEE088861ED6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.locale.en-US.yaml
+++ b/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarcelGlaeser.Kubebar
+PackageVersion: 1.7.1
+PackageLocale: en-US
+Publisher: Marcel Glaeser
+PublisherUrl: https://kubebar.app
+PublisherSupportUrl: https://kubebar.app/support.html
+PrivacyUrl: https://kubebar.app/privacy.html
+Author: Marcel Glaeser
+PackageName: Kubebar
+PackageUrl: https://kubebar.app
+License: Proprietary
+LicenseUrl: https://kubebar.app/terms.html
+Copyright: Copyright (c) 2026 Marcel Glaeser
+ShortDescription: Kubernetes cluster monitoring from the Windows tray - pods, logs, events and metrics without a terminal.
+Description: |-
+  Kubebar keeps an eye on your Kubernetes clusters from the system tray. It reads your existing
+  kubeconfig, shows the health of nodes, pods, deployments and Helm releases, and notifies you when
+  a pod crashes, restarts or eats more CPU or memory than it should.
+
+  Select a range in a metrics chart and Kubebar shows you the log lines and events from exactly that
+  window, so you can go from "CPU spiked at 14:32" to the matching log entry in one step.
+
+  Other features include live log tailing, an integrated terminal, port forwarding, scaling and
+  restarting workloads, YAML inspection, multi-cluster context switching, an optional AI assistant
+  for diagnosing failures (bring your own Anthropic, OpenAI or local Ollama key), and a user
+  interface translated into 40 languages.
+
+  The app talks to your clusters directly - never through our servers - and contains no analytics
+  or tracking tools. A 14-day trial is included; a license is required afterwards.
+Moniker: kubebar
+Tags:
+  - kubernetes
+  - k8s
+  - kubectl
+  - cluster
+  - devops
+  - monitoring
+  - containers
+  - sre
+  - tray
+  - helm
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.yaml
+++ b/manifests/m/MarcelGlaeser/Kubebar/1.7.1/MarcelGlaeser.Kubebar.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarcelGlaeser.Kubebar
+PackageVersion: 1.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: MarcelGlaeser.Kubebar 1.7.1

Kubebar is a native Kubernetes client that lives in the Windows system tray. It reads
the existing kubeconfig and shows nodes, pods, deployments and Helm releases, with
logs, events, port forwarding and an integrated terminal.

#### Checklist

- [x] Checked that there are no other open pull requests for this package (searched, none found)
- [x] The package is new — `manifests/m/MarcelGlaeser/` does not exist yet
- [x] Manifests conform to the 1.6.0 schema — validated against the official
      `installer`, `defaultLocale` and `version` schemas
- [x] `InstallerSha256` verified against the file actually served at `InstallerUrl`
      (downloaded and hashed, 56 096 864 bytes)
- [ ] `winget validate --manifest` / `winget install --manifest` — **not run**

#### On the last point

The manifests were authored on macOS, so I could not run the two Windows-only checks.
Everything that can be verified without Windows was verified: schema conformance, the
installer hash against the live download, and that the URL resolves. If the automated
validation finds anything, I will push a fix to this branch right away.

#### Notes for reviewers

- `InstallerType: inno` — the installer is built with Inno Setup 6.7, not NSIS.
- `Scope: user` follows from `PrivilegesRequired=lowest` in the Inno script; the app
  installs per-user and needs no elevation.
- `ProductCode` is the Inno `AppId` plus the `_is1` suffix, so the uninstall entry is
  found in the registry.
- The download is served from the vendor's own domain over HTTPS.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425299)