### PR TITLE
New package: KrzysztofCichocki.PDFManipulator version 2.2.0

### DIFF
--- a/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.installer.yaml
+++ b/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: KrzysztofCichocki.PDFManipulator
+PackageVersion: 2.2.0
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+ReleaseDate: 2026-07-12
+Installers:
+- Architecture: x64
+  InstallerType: inno
+  InstallerUrl: https://github.com/kr-ci/pdf-manipulator/releases/download/v2.2.0/PDFManipulator-2.2.0-Setup.exe
+  InstallerSha256: E18850953858A02D492E24519EB3F22AC96F70DA351AC061C1C66E6F0D60AC73
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/kr-ci/pdf-manipulator/releases/download/v2.2.0/PDFManipulator-2.2.0.msi
+  InstallerSha256: AF654B166A4F33FE8CCF933CADD9FE8EB35EED59745C376FBC12096C5B4EA8EC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.locale.en-US.yaml
+++ b/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: KrzysztofCichocki.PDFManipulator
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: Krzysztof Cichocki
+PublisherUrl: https://github.com/kr-ci
+PublisherSupportUrl: https://pdf-manipulator.com/
+Author: Krzysztof Cichocki
+PackageName: PDF Manipulator
+PackageUrl: https://pdf-manipulator.com/
+License: AGPL-3.0
+LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
+Copyright: Copyright (c) Krzysztof Cichocki
+ShortDescription: Free offline PDF toolkit — merge, split, encrypt and convert without uploading a file.
+Description: |-
+  PDF Manipulator is a free, open-source desktop application that processes PDF files entirely
+  on your own computer. Nothing is uploaded, no account is required and there are no ads.
+
+  It covers 12 operations: merge, split, encrypt, remove password, PDF to DOCX conversion,
+  rotate pages, remove pages, reorder pages, pack to ZIP, recover password, search text and
+  a password generator. Single files or entire batches, with operations chained so only the
+  final result is written to disk.
+
+  The interface ships in 53 languages and 38 appearance themes. Source code is available under
+  AGPL-3.0, so the claim that files never leave the machine can be verified rather than trusted.
+Moniker: pdf-manipulator
+Tags:
+- pdf
+- pdf-editor
+- pdf-converter
+- merge-pdf
+- split-pdf
+- encrypt-pdf
+- offline
+- privacy
+- open-source
+ReleaseNotes: |-
+  Added support for 42 new interface languages, including Svenska, Norsk, Dansk, Suomi,
+  Islenska, Cestina, Slovencina, Magyar, Romana, Hrvatski, Turkce, Ukrainska, Lietuviu,
+  Latviesu, Eesti, Hindi, Bengali, Japanese, Korean, Tamil, Telugu, Marathi, Gujarati,
+  Urdu, Tieng Viet, Bahasa Indonesia, Bahasa Melayu, Thai and Filipino.
+ReleaseNotesUrl: https://pdf-manipulator.com/
+Documentations:
+- DocumentLabel: Download and verification
+  DocumentUrl: https://pdf-manipulator.com/download-en/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.locale.en-US.yaml
+++ b/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.locale.en-US.yaml
@@ -9,7 +9,7 @@ Author: Krzysztof Cichocki
 PackageName: PDF Manipulator
 PackageUrl: https://pdf-manipulator.com/
 License: AGPL-3.0
-LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
+LicenseUrl: https://github.com/kr-ci/pdf-manipulator/blob/main/LICENSE
 Copyright: Copyright (c) Krzysztof Cichocki
 ShortDescription: Free offline PDF toolkit — merge, split, encrypt and convert without uploading a file.
 Description: |-

--- a/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.yaml
+++ b/manifests/k/KrzysztofCichocki/PDFManipulator/2.2.0/KrzysztofCichocki.PDFManipulator.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: KrzysztofCichocki.PDFManipulator
+PackageVersion: 2.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `KrzysztofCichocki.PDFManipulator` version `2.2.0`

PDF Manipulator is a free, open-source (AGPL-3.0) desktop application that processes PDF files
entirely on the local machine — merge, split, encrypt, remove password, PDF to DOCX, rotate,
reorder and remove pages, pack to ZIP, recover password, search text, password generator.
No upload, no account, no ads.

- Homepage: https://pdf-manipulator.com/
- Source: https://github.com/kr-ci/pdf-manipulator
- Release: https://github.com/kr-ci/pdf-manipulator/releases/tag/v2.2.0

Installers are served from GitHub Releases (immutable, versioned URLs). Both `InstallerSha256`
values match the `SHA256SUMS.txt` published in that release.

The `.exe` is an Inno Setup installer, so it is declared as `InstallerType: inno` and relies on
winget's built-in silent switches rather than explicit ones. The `.msi` is declared as `wix`.

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Notes on the unchecked boxes, so a reviewer does not have to guess:

- **CLA** — the bot has requested it on this PR; it is being handled.
- **`winget validate` / `winget install`** — no Windows machine was available, so neither command
  was run. Instead the three manifests were validated programmatically against the official
  `1.12.0` JSON schemas (`version`, `installer`, `defaultLocale`), which report no errors, and the
  installer type was confirmed by inspecting the binary itself rather than trusting the release
  notes. Happy to fix anything the automated validation pipeline flags.
