### PR TITLE
Update version: CylCastillo.AgentConsole version 0.75.0

### DIFF
--- a/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.installer.yaml
+++ b/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CylCastillo.AgentConsole
+PackageVersion: 0.75.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cyl-castillo/agent-console/releases/download/v0.75.0/Agent.Console_0.75.0_x64-setup.exe
+  InstallerSha256: 71DE83F6D356DD53541591DD0BC7CA9C3EACAF455A95BC8BFA1A4AC45C822CE7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.locale.en-US.yaml
+++ b/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CylCastillo.AgentConsole
+PackageVersion: 0.75.0
+PackageLocale: en-US
+Publisher: Carlos Castillo
+PublisherUrl: https://github.com/cyl-castillo
+PublisherSupportUrl: https://github.com/cyl-castillo/agent-console/issues
+PackageName: Agent Console
+PackageUrl: https://github.com/cyl-castillo/agent-console
+License: MIT
+LicenseUrl: https://github.com/cyl-castillo/agent-console/blob/main/LICENSE
+ShortDescription: Minimalist AI-native console for directing coding agents inside a repository.
+Description: |-
+  Agent Console is a terminal-first desktop app that pairs coding-agent CLIs
+  (Claude Code, Codex) with an integrated PTY terminal, a git diff viewer,
+  per-turn working-tree snapshots, and per-tool approvals — so you can drive
+  an agent through real work without losing control. Every session is
+  witnessed into a hash-chained evidence ledger (Testigo) exportable as
+  signed proof packets verifiable in any browser. Requires the Claude Code
+  CLI and Node.js 20+.
+Moniker: agent-console
+Tags:
+- agent
+- ai
+- claude
+- cli
+- developer-tools
+- git
+- terminal
+ReleaseNotesUrl: https://github.com/cyl-castillo/agent-console/releases/tag/v0.75.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.yaml
+++ b/manifests/c/CylCastillo/AgentConsole/0.75.0/CylCastillo.AgentConsole.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CylCastillo.AgentConsole
+PackageVersion: 0.75.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update CylCastillo.AgentConsole to 0.75.0.

- Manifests copied from the merged 0.74.0 version with PackageVersion, InstallerUrl, InstallerSha256, ReleaseDate and ReleaseNotesUrl updated.
- Installer: https://github.com/cyl-castillo/agent-console/releases/download/v0.75.0/Agent.Console_0.75.0_x64-setup.exe (SHA256 verified locally).
- Submitted manually by the maintainer this release; our automated winget-releaser job hit a token issue.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (schema-identical to the merged 0.74.0 manifests)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (same installer layout as 0.74.0, which passed the pipeline's installation test)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425356)