### PR TITLE
New package: tobby-fetch.tobby version 0.5.0

### DIFF
--- a/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.installer.yaml
+++ b/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: tobby-fetch.tobby
+PackageVersion: "0.5.0"
+InstallerType: portable
+Commands:
+  - tobby
+MinimumOSVersion: 10.0.14393.0
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tobby-fetch/tobby-fetch/releases/download/v0.5.0/tobby-windows-amd64.exe
+    InstallerSha256: "1b224e36655d7f184204d684b2adcd4eecf76230a48fbf89f286ad033553dbab"
+  - Architecture: arm64
+    InstallerUrl: https://github.com/tobby-fetch/tobby-fetch/releases/download/v0.5.0/tobby-windows-arm64.exe
+    InstallerSha256: "626d15261ce6151ec7502d6e113f231cca868a51276cbc7ead9fd6f2b8999c1b"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.locale.en-US.yaml
+++ b/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: tobby-fetch.tobby
+PackageVersion: "0.5.0"
+PackageLocale: en-US
+Publisher: infraBuilder SASU
+PackageName: tobby
+PackageUrl: https://tobby-fetch.github.io/tobby-fetch/
+License: GPL-3.0-only
+Copyright: Copyright © 2026 infraBuilder SASU and contributors
+ShortDescription: Secure artifact fetch-and-relocate tool with an embedded OCI registry.
+Description: |-
+  Secure artifact fetch-and-relocate tool with an embedded OCI registry.
+  Tobby fetches OCI assets — container images, Helm charts, AI models,
+  and files — and carries them across isolated network zones, from
+  connected, through restricted, down to fully air-gapped environments.
+Moniker: tobby
+Tags:
+  - oci
+  - registry
+  - air-gap
+  - mirror
+  - supply-chain
+  - containers
+  - helm
+  - sbom
+ReleaseNotesUrl: https://github.com/tobby-fetch/tobby-fetch/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.yaml
+++ b/manifests/t/tobby-fetch/tobby/0.5.0/tobby-fetch.tobby.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: tobby-fetch.tobby
+PackageVersion: "0.5.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package

`tobby-fetch.tobby` version 0.5.0 — a new package.

[Tobby](https://tobby-fetch.github.io/tobby-fetch/) fetches OCI assets — container images, Helm charts, AI models and packaged file sets — and carries them across isolated network zones, down to fully air-gapped ones, driven by digest-pinned, cosign-signed recipes. Windows is a first-class target rather than a convenience tier: the whole mirror workflow runs on a Windows CI runner on every pull request, and the mirror workstation is where the operator actually sits.

### Checklist

- [x] Manifests validate: `winget validate --manifest .` → **Manifest validation succeeded**, run against these exact files on Windows 11 with winget 1.11.510.
- [x] `InstallerSha256` values are copied from the release's own `SHA256SUMS`, which the release's SLSA build provenance covers — not recomputed from a re-download.
- [x] Installers are the official release binaries, published from a reproducible build (an independent second build compares digests and blocks the release on any mismatch), each with a CycloneDX SBOM and SLSA provenance attached to the same release.
- [x] `InstallerType: portable`, x64 and arm64, with `Commands: tobby` so the alias matches the architecture-qualified asset names.
- [x] `MinimumOSVersion: 10.0.14393.0` — the floor Go's toolchain still supports, so winget refuses the install where the binary could not run rather than installing a file that fails at first launch.

### Notes

`Publisher` is `infraBuilder SASU`, the vendor of record; the identifier uses the publishing GitHub organisation `tobby-fetch`, which is the namespace every other distribution channel for this tool already uses (`brew install tobby-fetch/tap/tobby`, the Scoop bucket at `tobby-fetch/scoop-bucket`, and `ghcr.io/tobby-fetch/tobby-fetch`).

Release: https://github.com/tobby-fetch/tobby-fetch/releases/tag/v0.5.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425358)