### PR TITLE
Update version: Tyrrrz.DiscordChatExporter.GUI version 2.48

### DIFF
--- a/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.installer.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.GUI
+PackageVersion: "2.48"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: DiscordChatExporter.exe
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.win-x86.zip
+  InstallerSha256: 7EC491CA0E8772AA9D0536C4D6A2F9C59D4B9AB99C8D328062A1974D25DA803C
+- Architecture: x64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.win-x64.zip
+  InstallerSha256: 8952EC09078964220B24B23485FDCB1D2B1975D0BBCFCCF8775AFFAD12C42C89
+- Architecture: arm64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.win-arm64.zip
+  InstallerSha256: 88843C079159189AABBCBAB8EF198E11FF61CD41499E841FE05D102B6240C245
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.locale.en-US.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.GUI
+PackageVersion: "2.48"
+PackageLocale: en-US
+Publisher: Tyrrrz
+PublisherUrl: https://github.com/Tyrrrz
+PublisherSupportUrl: https://github.com/Tyrrrz/DiscordChatExporter/issues
+PackageName: DiscordChatExporter.GUI
+PackageUrl: https://github.com/Tyrrrz/DiscordChatExporter
+License: MIT
+LicenseUrl: https://github.com/Tyrrrz/DiscordChatExporter/blob/HEAD/License.txt
+ShortDescription: Exports Discord chat logs to a file
+Tags:
+- archival
+- archiver
+- chat
+- discord
+- export
+- expoter
+- log
+ReleaseNotes: |-
+  <!-- Release notes generated using configuration in .github/release.yml at 2.48 -->
+
+  ## What's Changed
+  ### Enhancements
+  • Render polls in HTML exports by @fzlzjerry in https://github.com/Tyrrrz/DiscordChatExporter/pull/1581
+  ### Bugs
+  • Only display http(s) URLs as links in HTML export  by @96-LB in https://github.com/Tyrrrz/DiscordChatExporter/pull/1568
+  • Fix reverse exports with an after boundary by @ShiroKSH in https://github.com/Tyrrrz/DiscordChatExporter/pull/1569
+
+  ## New Contributors
+  • @ShiroKSH made their first contribution in https://github.com/Tyrrrz/DiscordChatExporter/pull/1569
+  • @fzlzjerry made their first contribution in https://github.com/Tyrrrz/DiscordChatExporter/pull/1581
+
+  **Full Changelog**：https://github.com/Tyrrrz/DiscordChatExporter/compare/2.47.3...2.48
+ReleaseNotesUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/tag/2.48
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/GUI/2.48/Tyrrrz.DiscordChatExporter.GUI.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.GUI
+PackageVersion: "2.48"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Tyrrrz.DiscordChatExporter.GUI to version 2.48.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425420)