### PR TITLE
New package: randlee.wyvern version 0.6.0

### DIFF
--- a/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
+++ b/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: randlee.wyvern
+PackageVersion: 0.6.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/wyvern.exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/randlee/wyvern/releases/download/v0.6.0/wyvern_0.6.0_x86_64-pc-windows-msvc.zip
+    InstallerSha256: D330F7F7903A738640613A497975B88FCDEAB3FBB03CA4B27619DBC138EC0835
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
+++ b/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
@@ -6,6 +6,7 @@ InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: bin/wyvern.exe
+    PortableCommandAlias: wyvern
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/randlee/wyvern/releases/download/v0.6.0/wyvern_0.6.0_x86_64-pc-windows-msvc.zip

--- a/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
+++ b/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.installer.yaml
@@ -5,7 +5,7 @@ PackageVersion: 0.6.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: bin/wyvern.exe
+  - RelativeFilePath: wyvern_0.6.0_x86_64-pc-windows-msvc/bin/wyvern.exe
     PortableCommandAlias: wyvern
 Installers:
   - Architecture: x64

--- a/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.locale.en-US.yaml
+++ b/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: randlee.wyvern
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Rand Lee
+PublisherUrl: https://github.com/randlee
+PublisherSupportUrl: https://github.com/randlee/wyvern/issues
+PackageName: Wyvern
+PackageUrl: https://github.com/randlee/wyvern
+License: MIT
+LicenseUrl: https://github.com/randlee/wyvern/blob/main/LICENSE
+ShortDescription: OS-native webview CLI for structured JSON dialog results
+Description: >-
+  Wyvern (*What You View, Engine Renders Natively*) opens OS-native webview
+  windows for user interaction and returns structured JSON results. JSON in,
+  JSON out — MCP-compatible from the ground up.
+Tags:
+  - cli
+  - dialog
+  - mcp
+  - rust
+  - webview
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.yaml
+++ b/manifests/r/randlee/wyvern/0.6.0/randlee.wyvern.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: randlee.wyvern
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## Package submission

- **Package:** randlee.wyvern 0.6.0
- **Source release:** https://github.com/randlee/wyvern/releases/tag/v0.6.0
- **Installer:** `wyvern_0.6.0_x86_64-pc-windows-msvc.zip` (portable `bin/wyvern.exe`)

First kit-managed wyvern release via sc-publish. Supersedes pending bootstrap PR #425477 (0.5.0 legacy asset).

## Validation

- SHA256 matches `checksums.txt` on GitHub Release v0.6.0
- Nested portable path: `bin/wyvern.exe`


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425526)