### PR TITLE
New version: CaptainKillSwitch.CaptainKillSwitch version 0.4.4

### DIFF
--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.4
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{BA88907A-EF23-4021-A105-0A75FB2382D4}'
+ReleaseDate: 2026-08-28
+AppsAndFeaturesEntries:
+- Publisher: Captain Kill Switch Team
+  ProductCode: '{BA88907A-EF23-4021-A105-0A75FB2382D4}'
+  UpgradeCode: '{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/Captain Kill Switch'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/captainkillswitch/downloads/releases/download/v0.4.4/captain-kill-switch-0.4.4-windows-x64.msi
+  InstallerSha256: 52A80D7493B78BDB4100AA8B0D4CCD6376758B44DFFD31817183E6AF07C12AB5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.4
+PackageLocale: en-US
+Publisher: Captain Kill Switch Team
+PublisherUrl: https://captainkillswitch.com/
+PublisherSupportUrl: https://github.com/captainkillswitch/downloads/issues
+Author: Captain Kill Switch Team
+PackageName: Captain Kill Switch
+PackageUrl: https://captainkillswitch.com/
+License: Proprietary (free)
+LicenseUrl: https://captainkillswitch.com/about
+Copyright: Copyright (c) 2026 Captain Kill Switch Team
+ShortDescription: Close every running application in one click from the system tray.
+Description: Captain Kill Switch is a free system-tray utility that closes every running application in one click - a clean close request first, then a firm stop within two seconds. An allowlist model protects Windows system and session processes. Tiny native app, auto-updates, 10 languages. Anonymous usage statistics only; see https://captainkillswitch.com/privacy.
+Moniker: captain-kill-switch
+ReleaseNotes: |-
+  The Windows installer is now code-signed. It shows a verified publisher
+  (Dragon Hedge Pty Ltd) instead of an unknown-publisher warning.
+  - No functional changes since 0.4.3.
+ReleaseNotesUrl: https://github.com/captainkillswitch/downloads/releases/tag/v0.4.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.yaml
+++ b/manifests/c/CaptainKillSwitch/CaptainKillSwitch/0.4.4/CaptainKillSwitch.CaptainKillSwitch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CaptainKillSwitch.CaptainKillSwitch
+PackageVersion: 0.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package
CaptainKillSwitch.CaptainKillSwitch version 0.4.4

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes

Version bump from 0.4.3, submitted by the package maintainer. Built from the
merged 0.4.3 manifests, so the only differences are version, URL, hash,
ProductCode, release date and release notes.

**This release is the first with an Authenticode-signed installer.** The MSI is
signed with a Certum code signing certificate issued to Dragon Hedge Pty Ltd and
timestamped, so Windows now shows a verified publisher instead of an unknown one.
There are no functional changes since 0.4.3.

- `InstallerSha256` is the hash of the **signed** MSI, computed from the
  published release asset: `52A80D7493B78BDB4100AA8B0D4CCD6376758B44DFFD31817183E6AF07C12AB5`
- `ProductCode` regenerates per build. `UpgradeCode` is unchanged
  (`{984FC5FB-4BE0-5465-85FF-3FDCFED283B5}`), so in-place upgrades keep working.

The `winget install --manifest` box is unticked deliberately: I have no Windows
machine and have not run that step, so I won't claim it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425637)