### PR TITLE
New version: teshi-org.teshi version 0.7.10

### DIFF
--- a/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.installer.yaml
+++ b/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.installer.yaml
@@ -1,0 +1,12 @@
+# Created with YamlCreate.ps1 v2.4.3 $null
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: teshi-org.teshi
+PackageVersion: 0.7.10
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  InstallerUrl: https://github.com/teshi-org/teshi/releases/download/v0.7.10/teshi-v0.7.10-x64.msi
+  InstallerSha256: 95CC5A421A6E2FACB302CB80B4E133311E08AEF1EEABB6BF49063DFA86674A0E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.locale.en-US.yaml
+++ b/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created with YamlCreate.ps1 v2.4.3 $null
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: teshi-org.teshi
+PackageVersion: 0.7.10
+PackageLocale: en-US
+Publisher: teshi-org
+PackageName: teshi
+License: MIT
+ShortDescription: Terminal-first mindmap editor for structured notes and navigation.
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.yaml
+++ b/manifests/t/teshi-org/teshi/0.7.10/teshi-org.teshi.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.4.3 $null
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: teshi-org.teshi
+PackageVersion: 0.7.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
This pull request adds teshi-org.teshi 0.7.10.

Installer: https://github.com/teshi-org/teshi/releases/download/v0.7.10/teshi-v0.7.10-x64.msi
GitHub release: https://github.com/teshi-org/teshi/releases/tag/v0.7.10

Checkboxes:
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425650)