### PR TITLE
New package: BrkBuilds.CanvasDownloader version 2.0.2

### DIFF
--- a/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.installer.yaml
+++ b/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: BrkBuilds.CanvasDownloader
+PackageVersion: 2.0.2
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-24
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/BrkBuilds/Canvas-Downloader/releases/download/v2.0.2/Canvas_Downloader_v2.0.2_Windows.exe
+    InstallerSha256: 4A3ACEDCB9FA636CF1438A9D10D66C8A735709437EFAA609E8005679CD43D5A5
+    ProductCode: '{A3F2D1E0-8B4C-4F7A-9C2E-5D6B3A1F8E2D}_is1'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.locale.en-US.yaml
+++ b/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.locale.en-US.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: BrkBuilds.CanvasDownloader
+PackageVersion: 2.0.2
+PackageLocale: en-US
+Publisher: BrkBuilds
+PublisherUrl: https://canvasdownloader.app/
+PublisherSupportUrl: https://github.com/BrkBuilds/Canvas-Downloader/issues
+PackageName: Canvas Downloader
+PackageUrl: https://canvasdownloader.app/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/BrkBuilds/Canvas-Downloader/blob/main/LICENSE
+Copyright: Copyright (C) 2026 BrkBuilds
+CopyrightUrl: https://github.com/BrkBuilds/Canvas-Downloader/blob/main/LICENSE
+ShortDescription: Download every file from all your Canvas courses at once, then keep the folders in sync.
+Description: |-
+  Canvas Downloader is a desktop app that downloads all your Canvas course
+  material to your own computer and keeps those folders up to date as the
+  semester goes on.
+
+  Canvas can zip one course's Files tab at a time. It cannot do several courses
+  in one run, it often misses files attached directly to modules, and it has no
+  bulk export at all for Pages, assignment briefs, announcements, discussions,
+  quizzes, or the feedback you were given. This app covers that gap.
+
+  What it does:
+  - Tick the courses you want and download all of them in one run.
+  - Sync instead of starting over. It shows every difference between the folder
+    and the course before writing anything - new files, updates, files deleted
+    on Canvas, files you deleted locally - and lets you choose.
+  - Keeps files you have edited. On a re-sync your annotated copy survives and
+    the new version lands beside it.
+  - Converts as it downloads, so the folder is ready to drag into NotebookLM,
+    ChatGPT, Claude or Gemini: PowerPoint and legacy Word to PDF, Canvas Pages
+    to plain text, Excel to structured data, archives unpacked.
+  - Fetches Panopto lecture recordings as video, audio, transcript or subtitles,
+    with transcription running locally on your own machine.
+
+  Privacy: it runs entirely on your computer. There is no account, no server and
+  nothing is uploaded. It reads only what your own Canvas account can already
+  open, using an access token you create yourself. Every line of code is public.
+
+  Known limits, stated up front:
+  - Some institutions disable Canvas access tokens. If yours has, this app
+    cannot work and no setting will change that.
+  - Office conversions need the matching Office desktop app installed.
+  - A downloaded course folder keeps the file-type scope it was created with.
+    To widen it, download the course again with All Files.
+Moniker: canvas-downloader
+Tags:
+  - backup
+  - bulk-download
+  - canvas
+  - canvas-lms
+  - coursework
+  - download
+  - education
+  - lecture
+  - notebooklm
+  - offline
+  - panopto
+  - student
+  - study
+  - sync
+  - transcription
+  - university
+ReleaseNotesUrl: https://github.com/BrkBuilds/Canvas-Downloader/releases/tag/v2.0.2
+Documentations:
+  - DocumentLabel: Setup guide
+    DocumentUrl: https://canvasdownloader.app/win-setup.html
+  - DocumentLabel: How it works
+    DocumentUrl: https://canvasdownloader.app/engine.html
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.yaml
+++ b/manifests/b/BrkBuilds/CanvasDownloader/2.0.2/BrkBuilds.CanvasDownloader.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: BrkBuilds.CanvasDownloader
+PackageVersion: 2.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: BrkBuilds.CanvasDownloader version 2.0.2

Canvas Downloader is a desktop app that downloads Canvas LMS course material in
bulk and keeps the local folders in sync. Open source, GPL-3.0-or-later.

- Homepage: https://canvasdownloader.app/
- Source: https://github.com/BrkBuilds/Canvas-Downloader
- Installer: Inno Setup, per-user (`PrivilegesRequired=lowest`), x64

I am the publisher of this package.

#### Checklist

- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?
- [x] Have you verified the `InstallerSha256` against the published release asset?

**Note on the second box:** the manifest passed `winget validate` but I have
not run a local `winget install --manifest` on this machine, so I have left
that box unchecked rather than assert it. Happy to run it and report back if
that is required before review.

The `InstallerSha256` was computed directly from the published GitHub release
asset `Canvas_Downloader_v2.0.2_Windows.exe` (91,851,637 bytes).