### PR TITLE
Add arm64 installer to GitTower.GitFlowNext version 2.0.0

### DIFF
--- a/manifests/g/GitTower/GitFlowNext/2.0.0/GitTower.GitFlowNext.installer.yaml
+++ b/manifests/g/GitTower/GitFlowNext/2.0.0/GitTower.GitFlowNext.installer.yaml
@@ -18,5 +18,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/gittower/git-flow-next/releases/download/v2.0.0/git-flow-next-v2.0.0-windows-amd64.zip
   InstallerSha256: 66D8808F977C498D505841ADE0C44C3AAE6256419C0E06F3AFD82CB38F573B7F
+- Architecture: arm64
+  InstallerUrl: https://github.com/gittower/git-flow-next/releases/download/v2.0.0/git-flow-next-v2.0.0-windows-arm64.zip
+  InstallerSha256: 607A767131C3B60F7798F14801223805A34CB17232FED8CF464C9BC6933BA784
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the missing `arm64` installer entry to the existing 2.0.0 manifest. Nothing else in the manifest changes.

git-flow-next has shipped a Windows arm64 build since this release, but only the x86 and x64 installers were ever submitted, so `winget install` on Windows on ARM resolves to the x64 binary instead of the native one.

The new entry points at the same GitHub release as the two existing entries, and its SHA-256 matches the checksum published in that release's `git-flow-next-v2.0.0-checksums.txt`:

```
607a767131c3b60f7798f14801223805a34cb17232fed8cf464c9bc6933ba784  git-flow-next-v2.0.0-windows-arm64.zip
```

`InstallerType: zip`, `NestedInstallerType: portable` and `NestedInstallerFiles` are declared at manifest level, so the new installer inherits them unchanged.

Submitted by the publisher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425666)