### PR TITLE
New package: zhitongblog.Ziplark version 0.2.2

### DIFF
--- a/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.installer.yaml
+++ b/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: zhitongblog.Ziplark
+PackageVersion: 0.2.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-27
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/zhitongblog/ziplark/releases/download/v0.2.2/Ziplark_0.2.2_x64-setup.exe
+    InstallerSha256: 05A447D04C9CC234E9D72E1E795D4ED5F626E8831DB8D20ED3AB8D5B799A4BC5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.locale.en-US.yaml
+++ b/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: zhitongblog.Ziplark
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: zhitongblog
+PublisherUrl: https://github.com/zhitongblog
+PublisherSupportUrl: https://github.com/zhitongblog/ziplark/issues
+Author: doaipm
+PackageName: Ziplark
+PackageUrl: https://ziplark.com
+License: MIT
+LicenseUrl: https://github.com/zhitongblog/ziplark/blob/main/LICENSE
+Copyright: Copyright (c) 2026 doaipm
+CopyrightUrl: https://github.com/zhitongblog/ziplark/blob/main/LICENSE
+ShortDescription: Free, fast, cross-platform archiver (ZIP/RAR/7z/tar/ISO) with a desktop app, CLI and MCP server.
+Description: |-
+  Ziplark extracts ZIP, RAR (incl. RAR5 and encrypted), 7z, tar, the compressed-tar
+  variants (tar.gz/.bz2/.xz/.zst/.lz4), single-stream gz/bz2/xz/zst/lz4, and ISO 9660 /
+  Joliet disc images. It creates ZIP (AES-256), 7z (AES-256) and tar archives.
+
+  One small Rust engine drives three front-ends over the exact same code: a desktop app,
+  the ziplark command-line tool, and an MCP server so an LLM or agent can list, extract,
+  test and create archives itself.
+
+  Every extraction path is funnelled through a single zip-slip guard, so no entry can
+  escape the destination directory. Free and open source (MIT), no ads, no telemetry.
+Moniker: ziplark
+Tags:
+  - 7z
+  - archive
+  - archiver
+  - compression
+  - iso
+  - mcp
+  - rar
+  - tar
+  - unzip
+  - zip
+  - zstd
+ReleaseNotes: |-
+  Fixed: the Windows binaries now run on a clean install. Builds through 0.2.1 imported
+  VCRUNTIME140.dll and MSVCP140.dll, which are part of the Visual C++ redistributable
+  rather than Windows, so the app failed to start with STATUS_DLL_NOT_FOUND on a machine
+  without it. The MSVC runtime is now statically linked and the installer embeds the
+  WebView2 bootstrapper instead of downloading it during setup.
+ReleaseNotesUrl: https://github.com/zhitongblog/ziplark/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.yaml
+++ b/manifests/z/zhitongblog/Ziplark/0.2.2/zhitongblog.Ziplark.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: zhitongblog.Ziplark
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **zhitongblog.Ziplark** version **0.2.2** — a free, MIT-licensed, cross-platform archiver (ZIP, RAR/RAR5, 7z, tar.*, ISO 9660/Joliet) built on one Rust engine with a desktop app, a CLI and an MCP server.

This resubmits #395332, which was closed as stale on 2026-07-29. That submission genuinely was broken, and the automated validation caught it correctly: `ziplark-gui.exe` returned `-1073741515` (`STATUS_DLL_NOT_FOUND`). Thank you — that report is what found the bug.

**Root cause and fix.** The binaries imported `VCRUNTIME140.dll` / `VCRUNTIME140_1.dll` (from the bzip2/xz2/zstd C dependencies) and `MSVCP140.dll` (the bundled UnRAR source is C++). Those are part of the Visual C++ redistributable, not of Windows, so on the clean validation image the process died before `main()` ran. Rather than declare a redistributable dependency, the MSVC runtime is now **statically linked**, so the binaries import only DLLs that ship with Windows. The installer also now embeds the WebView2 bootstrapper instead of downloading it during setup, so setup works on a machine with no outbound network.

**How this was verified.** Since a CI runner has the redistributable installed, *running* the binary on one cannot catch this class of bug — which is exactly why it shipped unnoticed. The project now parses the PE import table (and the delay-load table) of every Windows binary in CI and fails the build on any DLL that is not part of a base Windows install. For 0.2.2 the shipped `ziplark-gui.exe` imports only:

`advapi32, api-ms-win-core-synch-l1-2-0, api-ms-win-crt-* (UCRT), bcryptprimitives, comctl32, dwmapi, gdi32, kernel32, ntdll, ole32, oleaut32, shell32, shlwapi, user32`

No `VCRUNTIME140*`, no `MSVCP140*`. The exe was also launched on a Windows runner and confirmed to still be running after 10s, and the binary that was verified is byte-for-byte the one inside the submitted `Ziplark_0.2.2_x64-setup.exe`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — being signed now; the previous PR carried a `Needs-CLA` label that was never cleared.
- [ ] Linked to an issue (if applicable) — n/a

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — I do not have a Windows machine to run `winget` on. The three manifests were instead validated against the official `1.12.0` JSON schemas (`winget-manifest.{installer,defaultLocale,version}.1.12.0.schema.json`) with no errors, and `InstallerSha256` was recomputed from the public download URL.
- [ ] Tested manifest locally with `winget install --manifest <path>` — same reason as above. The installer payload itself was exercised on a Windows runner as described.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Flagging the two unchecked validation boxes explicitly rather than ticking them: I could not run `winget` itself. Happy to act on anything the pipeline reports — this time I will be watching for it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425668)