### PR TITLE
New package: ColinGPT9.ClipsKitty version 1.1.4

### DIFF
--- a/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.installer.yaml
+++ b/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: ColinGPT9.ClipsKitty
+PackageVersion: 1.1.4
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ColinGPT9/clips-studio/releases/download/v1.1.4/ClipsKitty-Web-Setup-1.1.4.exe
+    InstallerSha256: C6CB1F67B8EB8ACA05B35604F3724622E8EB52CA412F64153922AC274746D109
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.installer.yaml
+++ b/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.installer.yaml
@@ -7,6 +7,12 @@ InstallModes:
   - interactive
   - silent
   - silentWithProgress
+# Spelled out rather than left to winget's inference for `nullsoft`. Verified
+# by running the real installer with /S: no window, installs silently. Every
+# comparable package already in winget (Figma, Notion) declares these.
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
 UpgradeBehavior: install
 ReleaseDate: 2026-08-28
 Installers:

--- a/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.locale.en-US.yaml
+++ b/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.locale.en-US.yaml
@@ -1,0 +1,52 @@
+PackageIdentifier: ColinGPT9.ClipsKitty
+PackageVersion: 1.1.4
+PackageLocale: en-US
+Publisher: ColinGPT9
+PublisherUrl: https://github.com/ColinGPT9
+PublisherSupportUrl: https://github.com/ColinGPT9/clips-studio/issues
+PrivacyUrl: https://colingpt9.github.io/clips-studio/privacy.html
+Author: ColinGPT9
+PackageName: Clips Kitty
+PackageUrl: https://colingpt9.github.io/clips-studio/
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/ColinGPT9/clips-studio/blob/main/LICENSE
+Copyright: Copyright (c) 2026 ColinGPT9
+ShortDescription: Turn long videos into vertical clips using AI that runs on your own PC.
+Description: |-
+  Clips Kitty finds the best moments in a long video and cuts them into vertical
+  clips for Shorts, TikTok and Reels. It works from a YouTube, Twitch or Kick link,
+  or from a video file on your disk.
+
+  Everything runs locally. Transcription, moment scoring, speaker tracking,
+  subtitles and rendering all happen on your own machine, so your footage is never
+  uploaded to a service, there is no subscription, and there is no monthly clip
+  limit. The language model runs through Ollama and you choose which one.
+
+  It also translates, subtitles and dubs clips into 19 languages, follows the
+  active speaker so a talking head stays in frame, and learns a creator's recurring
+  jokes and catchphrases to score their moments better.
+
+  Alpha software: it works, it is rough in places, and the known issues are listed
+  in the repository.
+Moniker: clips-kitty
+Tags:
+  - ai
+  - video
+  - video-editing
+  - shorts
+  - clips
+  - twitch
+  - youtube
+  - kick
+  - subtitles
+  - local-ai
+  - open-source
+  - content-creation
+ReleaseNotesUrl: https://github.com/ColinGPT9/clips-studio/releases/tag/v1.1.4
+Documentation:
+  - DocumentLabel: Known issues
+    DocumentUrl: https://github.com/ColinGPT9/clips-studio/blob/main/KNOWN-ISSUES.md
+  - DocumentLabel: Changelog
+    DocumentUrl: https://github.com/ColinGPT9/clips-studio/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.yaml
+++ b/manifests/c/ColinGPT9/ClipsKitty/1.1.4/ColinGPT9.ClipsKitty.yaml
@@ -1,0 +1,10 @@
+# winget version manifest.
+#
+# These three files are what a pull request to microsoft/winget-pkgs contains.
+# They are kept here so the next release can copy and edit them rather than
+# rediscovering the format. See packaging/winget/README.md.
+PackageIdentifier: ColinGPT9.ClipsKitty
+PackageVersion: 1.1.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission for **Clips Kitty**, a local-first AI video clipping app for Windows.

- Homepage: https://colingpt9.github.io/clips-studio/
- Source: https://github.com/ColinGPT9/clips-studio (AGPL-3.0-or-later)
- Release: https://github.com/ColinGPT9/clips-studio/releases/tag/v1.1.4

### Checklist

- [x] Manifests validate against schema 1.6.0
- [x] `InstallerSha256` verified against the asset as GitHub serves it
- [x] Installer URL is a permanent GitHub release asset
- [x] All URLs in the locale manifest return 200
- [x] This package is not already in the repository

### One thing worth flagging for validation

**The installer is a web installer, and the payload is large.**
`ClipsKitty-Web-Setup-1.1.4.exe` is 795 KB and downloads roughly **5.8 GB** from
Hugging Face when it runs. The size is inherent to what the app is: it bundles a
CUDA build of PyTorch, an Ollama runtime and two Whisper models, because all the
AI runs on the user's own machine rather than on a server.

winget itself handles this fine — it just runs the installer — but a download
that size inside the validation VM's time limit may well time out. If the
automated check fails on the download rather than on the manifests, that is why,
and I am happy to work through whatever you need.

The installer supports silent and interactive modes and installs per-user, as
declared in the installer manifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425676)