### PR TITLE
New package: SrdjanKotarlic.ProTimer version 2.1.0

### DIFF
--- a/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.installer.yaml
+++ b/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SrdjanKotarlic.ProTimer
+PackageVersion: 2.1.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: "2026-08-27"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/srdjankotarlic/protimer/releases/download/v2.1.0/ProTimer-Setup-2.1.0.exe
+  InstallerSha256: 0265A9871F78C33499992E63876D2110F0912FDAAE977233441EA58177C9B899
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.locale.en-US.yaml
+++ b/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SrdjanKotarlic.ProTimer
+PackageVersion: 2.1.0
+PackageLocale: en-US
+Publisher: Srdjan Kotarlic
+PublisherUrl: https://github.com/srdjankotarlic
+PublisherSupportUrl: https://github.com/srdjankotarlic/protimer/issues
+Author: Srdjan Kotarlic
+PackageName: ProTimer
+PackageUrl: https://srdjankotarlic.github.io/protimer/
+License: MIT
+LicenseUrl: https://github.com/srdjankotarlic/protimer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Srdjan Kotarlic
+ShortDescription: Free stage timer and speaker countdown for live events, conferences, and OBS.
+Description: ProTimer is a free, open-source stage timer with a separate operator view and audience output, rundown cues, phone remote control, speaker messages, OBS Browser Source output, OSC, and Bitfocus Companion control.
+Moniker: protimer
+Tags:
+- companion
+- conference
+- countdown
+- event-production
+- foss
+- obs
+- presentation
+- speaker-timer
+- stage-timer
+- stream-deck
+- timer
+ReleaseNotes: |-
+  - Keeps the operator timer preview large while grid placement controls the stage output.
+  - Adds one clear HH:MM:SS duration picker for main and rundown timers.
+  - Adds a prominent Start Rundown workflow and readable scrolling for long rundowns.
+  - Makes the audience output frameless, movable, resizable, and remotely controllable.
+  - Adds safe view-only Timer and Backstage QR display on the audience output.
+ReleaseNotesUrl: https://github.com/srdjankotarlic/protimer/blob/main/docs/RELEASE-NOTES-2.1.0.md
+Documentations:
+- DocumentLabel: User guide
+  DocumentUrl: https://github.com/srdjankotarlic/protimer#readme
+- DocumentLabel: Workflow guides
+  DocumentUrl: https://srdjankotarlic.github.io/protimer/guides/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.yaml
+++ b/manifests/s/SrdjanKotarlic/ProTimer/2.1.0/SrdjanKotarlic.ProTimer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SrdjanKotarlic.ProTimer
+PackageVersion: 2.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request

Adds the first WinGet manifest for ProTimer 2.1.0.

- Installer type: Nullsoft (per-user)
- Architecture: x64 application
- Installer URL and SHA-256 verified against the published GitHub release
- All three manifests validate against the WinGet 1.12 schemas
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425705)