### PR TITLE
New package: co2lab.Anchors version 0.1.2

### DIFF
--- a/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.installer.yaml
+++ b/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: co2lab.Anchors
+PackageVersion: 0.1.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: anchors.exe
+    PortableCommandAlias: anchors
+Commands:
+  - anchors
+ReleaseDate: "2026-08-28"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/co2-lab/anchors/releases/download/v0.1.2/anchors_0.1.2_windows_amd64.zip
+    InstallerSha256: C4A399290D50E2750DA7810D1471334BA336CB4BF6C223E38F0DF8D43F8435B9
+  - Architecture: arm64
+    InstallerUrl: https://github.com/co2-lab/anchors/releases/download/v0.1.2/anchors_0.1.2_windows_arm64.zip
+    InstallerSha256: E84C0906444D87B2E44DAFDE00B97EA902DCAE4D28409C5795416A98FF1A88D5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.locale.en-US.yaml
+++ b/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: co2lab.Anchors
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: co2lab
+PublisherUrl: https://github.com/co2-lab
+PublisherSupportUrl: https://github.com/co2-lab/anchors/issues
+PackageName: Anchors
+PackageUrl: https://github.com/co2-lab/anchors
+License: Elastic License 2.0
+LicenseUrl: https://github.com/co2-lab/anchors/blob/main/LICENSE
+ShortDescription: Spec-first continuity framework for AI-assisted development
+Description: Anchors ties spec, feature and test together through a shared identity code, then confronts each artifact against the rules declared in anchors.yaml. It maps the project as a graph, propagates change from the anchor outward, and gates every step — so work guided by AI stays anchored to what was decided.
+Moniker: anchors
+Tags:
+  - ai
+  - ai-agents
+  - cli
+  - developer-tools
+  - golang
+  - spec-first
+ReleaseNotesUrl: https://github.com/co2-lab/anchors/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.yaml
+++ b/manifests/c/co2lab/Anchors/0.1.2/co2lab.Anchors.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: co2lab.Anchors
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## New package submission

**Package:** co2lab.Anchors
**Version:** 0.1.2

[Anchors](https://github.com/co2-lab/anchors) is a spec-first continuity framework for AI-assisted development: it ties spec, feature and test together through a shared identity code, then confronts each artifact against the rules declared in `anchors.yaml`.

Distributed as a portable binary (zip), x64 and arm64.

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] This PR only modifies one (1) manifest
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

> Note: the manifests were validated against the official JSON schemas, but **not** with `winget validate`/`winget install` locally — I do not have a Windows machine available. The installer URLs and SHA256 come straight from the signed `checksums.txt` of the [v0.1.2 release](https://github.com/co2-lab/anchors/releases/tag/v0.1.2). Happy to fix anything the automated validation flags.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425738)