### PR TITLE
Add JDEProjects.SimpleFirearmLogbook version 1.6.0

### DIFF
--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.installer.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: JDEProjects.SimpleFirearmLogbook
 PackageVersion: 1.6.0
@@ -21,4 +21,4 @@ Installers:
     InstallerUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/releases/download/v1.6.0/SimpleFirearmLogbook-v1.6.0-setup.exe
     InstallerSha256: CF027ACCFCAAFB0A6EF828294D83691A31FC690FE849C4C37DDCB9F1BBAC03E6
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.installer.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: JDEProjects.SimpleFirearmLogbook
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+ReleaseDate: 2026-08-28
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: Simple Firearm Logbook
+    Publisher: JDE Projects
+    DisplayVersion: 1.6.0
+    InstallerType: inno
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/releases/download/v1.6.0/SimpleFirearmLogbook-v1.6.0-setup.exe
+    InstallerSha256: CF027ACCFCAAFB0A6EF828294D83691A31FC690FE849C4C37DDCB9F1BBAC03E6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.locale.en-US.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: JDEProjects.SimpleFirearmLogbook
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: JDE Projects
+PublisherUrl: https://github.com/JDE-Projects
+PublisherSupportUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/issues
+Author: JDE Projects
+PackageName: Simple Firearm Logbook
+PackageUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/blob/main/LICENSE
+Copyright: Copyright (c) JDE Projects
+ShortDescription: "A private, offline logbook for your personal firearm collection: records, photos, documents, dispositions, imports, and exports."
+Description: |-
+  Simple Firearm Logbook is a private, offline Windows desktop app for keeping records of a personal firearm collection. It stores firearm records with permanent log numbers, multiple photos and document attachments per firearm, NFA and trust flags, and disposition history (sold, traded, lost, or stolen) that keeps the record instead of deleting it. It can import an existing collection from a CSV with a preview and per-row checks, and export a single firearm or the full collection to HTML and CSV.
+
+  All data stays on the machine. The only network call is an optional version check against GitHub Releases. There are no accounts, no tracking, and no data collection.
+Moniker: simple-firearm-logbook
+Tags:
+  - firearm
+  - logbook
+  - inventory
+  - collection
+  - records
+  - nfa
+  - offline
+ReleaseNotesUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.locale.en-US.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: JDEProjects.SimpleFirearmLogbook
 PackageVersion: 1.6.0
@@ -28,4 +28,4 @@ Tags:
   - offline
 ReleaseNotesUrl: https://github.com/JDE-Projects/Simple-Firearm-Logbook/releases/tag/v1.6.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: JDEProjects.SimpleFirearmLogbook
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.yaml
+++ b/manifests/j/JDEProjects/SimpleFirearmLogbook/1.6.0/JDEProjects.SimpleFirearmLogbook.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: JDEProjects.SimpleFirearmLogbook
 PackageVersion: 1.6.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **JDEProjects.SimpleFirearmLogbook** version 1.6.0.

Simple Firearm Logbook is a private, offline Windows desktop app for keeping records of a personal firearm collection (records, photos, document attachments, dispositions, CSV import, and HTML/CSV export). The installer is the publisher's own GitHub release asset, built on GitHub with a build-provenance attestation.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — N/A, no related issue

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
