### PR TITLE
Update version: Tyrrrz.DiscordChatExporter.CLI version 2.48

### DIFF
--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.installer.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: "2.48"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: DiscordChatExporter.Cli.exe
+  PortableCommandAlias: discordchatexporter
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.Cli.win-x86.zip
+  InstallerSha256: 5BA5A23C4762B35522E54023A2094D88760F137631A415FC8AA2E1CF76C8E510
+- Architecture: x64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.Cli.win-x64.zip
+  InstallerSha256: 9F6706F6311F1387BC29D536E951D6C758716A57F59A2F2CE1718616EA6574B1
+- Architecture: arm64
+  InstallerUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.48/DiscordChatExporter.Cli.win-arm64.zip
+  InstallerSha256: 0BE2DEEC0163C8FE44889C0F6E6B7D5AC4D02A97713A685F86C10BDFFC8DEED2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.locale.en-US.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: "2.48"
+PackageLocale: en-US
+Publisher: Tyrrrz
+PublisherUrl: https://github.com/Tyrrrz
+PublisherSupportUrl: https://github.com/Tyrrrz/DiscordChatExporter/issues
+PackageName: DiscordChatExporter.CLI
+PackageUrl: https://github.com/Tyrrrz/DiscordChatExporter
+License: MIT
+LicenseUrl: https://github.com/Tyrrrz/DiscordChatExporter/blob/HEAD/License.txt
+ShortDescription: Exports Discord chat logs to a file
+Tags:
+- archival
+- archiver
+- chat
+- discord
+- export
+- expoter
+- log
+ReleaseNotes: |-
+  <!-- Release notes generated using configuration in .github/release.yml at 2.48 -->
+
+  ## What's Changed
+  ### Enhancements
+  • Render polls in HTML exports by @fzlzjerry in https://github.com/Tyrrrz/DiscordChatExporter/pull/1581
+  ### Bugs
+  • Only display http(s) URLs as links in HTML export  by @96-LB in https://github.com/Tyrrrz/DiscordChatExporter/pull/1568
+  • Fix reverse exports with an after boundary by @ShiroKSH in https://github.com/Tyrrrz/DiscordChatExporter/pull/1569
+
+  ## New Contributors
+  • @ShiroKSH made their first contribution in https://github.com/Tyrrrz/DiscordChatExporter/pull/1569
+  • @fzlzjerry made their first contribution in https://github.com/Tyrrrz/DiscordChatExporter/pull/1581
+
+  **Full Changelog**：https://github.com/Tyrrrz/DiscordChatExporter/compare/2.47.3...2.48
+ReleaseNotesUrl: https://github.com/Tyrrrz/DiscordChatExporter/releases/tag/2.48
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.yaml
+++ b/manifests/t/Tyrrrz/DiscordChatExporter/CLI/2.48/Tyrrrz.DiscordChatExporter.CLI.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Tyrrrz.DiscordChatExporter.CLI
+PackageVersion: "2.48"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Tyrrrz.DiscordChatExporter.CLI to version 2.48.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425880)