### PR TITLE
New package: io.github.frathe.picfetch version 0.2.11

### DIFF
--- a/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.installer.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.11
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: picfetch.exe
+  PortableCommandAlias: picfetch
+ReleaseDate: "2026-08-28"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.11/picfetch-windows-amd64.zip
+  InstallerSha256: 99D51D5DA4DB0B8B82EF8D59F82470C6D529E2D723FBF155AEDBD7D23B41B899
+- Architecture: arm64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.11/picfetch-windows-arm64.zip
+  InstallerSha256: 4F50A56993EED5E75B60DA4C5FB001F203370C7F094D5FB921613850DCBC0186
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.locale.en-US.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.11
+PackageLocale: en-US
+Publisher: Florian Rathe
+PublisherUrl: https://github.com/frathe
+PublisherSupportUrl: https://github.com/frathe/picfetch/issues
+Author: Florian Rathe
+PackageName: PicFetch
+PackageUrl: https://frathe.github.io/picfetch/
+License: MIT
+LicenseUrl: https://github.com/frathe/picfetch/blob/v0.2.11/LICENSE
+Copyright: Copyright (c) 2026 Florian Rathe
+ShortDescription: A small multi-platform desktop app for quickly viewing and browsing images.
+Description: |-
+  A small Fyne desktop app for quickly viewing images. Drop one or more images onto the window to view them, and step through the set with the keyboard.
+
+  Supports JPEG, PNG, GIF, WebP, BMP, TIFF, ICO, XPM, HEIC, AVIF, SVG, and camera RAW previews.
+Moniker: picfetch
+Tags:
+- image-viewer
+- pictures
+- photos
+- fyne
+- go
+- portable
+ReleaseNotes: |-
+  New Features
+  - Changed a few labels to make them less confusing
+
+  Bugfix
+  - Hashing a folder no longer crashes when the file set shrinks underneath the pool
+  - A file the scanner produced no URI for no longer panics the hashing pass
+  - A crash when pressing 0 after rotating an image and returning to the drop zone
+
+  Full Changelog: https://github.com/frathe/picfetch/compare/v0.2.10...v0.2.11
+ReleaseNotesUrl: https://github.com/frathe/picfetch/releases/tag/v0.2.11
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.11/io.github.frathe.picfetch.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: PicFetch 0.2.11 (`io.github.frathe.picfetch`). Portable zip of `picfetch.exe` (x64 and arm64) from https://github.com/frathe/picfetch/releases/tag/v0.2.11

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Schema 1.12 JSON validation passed. `winget validate` / `winget install` were not run here (Linux). Installer type is zip + nested portable; not MSI/exe.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425898)