### PR TITLE
New package: Craftbag.Craftbag version 0.1.0

### DIFF
--- a/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.installer.yaml
+++ b/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Craftbag.Craftbag
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: craftbag.exe
+  PortableCommandAlias: craftbag
+- RelativeFilePath: craftbag-mcp.exe
+  PortableCommandAlias: craftbag-mcp
+Commands:
+- craftbag
+- craftbag-mcp
+UpgradeBehavior: install
+ReleaseDate: 2026-08-28
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/craftbag/craftbag/releases/download/v0.1.0/craftbag-x86_64-pc-windows-msvc.zip
+  InstallerSha256: BD5695E60051340491A4CD4E2ABEBD37A7812AF23566B50072BB63E7E4E2409C
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.locale.en-US.yaml
+++ b/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Craftbag.Craftbag
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Craftbag
+PublisherUrl: https://github.com/craftbag
+PublisherSupportUrl: https://github.com/craftbag/craftbag/issues
+Author: Craftbag
+PackageName: craftbag
+PackageUrl: https://github.com/craftbag/craftbag
+License: Apache-2.0 or MIT
+LicenseUrl: https://github.com/craftbag/craftbag/blob/HEAD/LICENSE
+Copyright: Copyright (c) Craftbag contributors
+ShortDescription: Discover and load Agent Skills for CLI and MCP hosts
+Description: |-
+  craftbag walks project and home skill trees and catalogs, loads, explains,
+  and validates Agent Skills (SKILL.md). The same operations are available
+  over MCP stdio as craftbag-mcp for hosts that do not embed the Rust crate.
+Moniker: craftbag
+Tags:
+- agents
+- cli
+- mcp
+- rust
+- skills
+ReleaseNotesUrl: https://github.com/craftbag/craftbag/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.yaml
+++ b/manifests/c/Craftbag/Craftbag/0.1.0/Craftbag.Craftbag.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Craftbag.Craftbag
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: Craftbag.Craftbag version 0.1.0.

Portable zip from GitHub Releases. The archive root has `craftbag.exe` and `craftbag-mcp.exe` (CLI plus MCP stdio server). x64 only.

```
unzip -l craftbag-x86_64-pc-windows-msvc.zip
  craftbag-mcp.exe
  craftbag.exe
SHA256 BD5695E60051340491A4CD4E2ABEBD37A7812AF23566B50072BB63E7E4E2409C
```

This is a console CLI, not a GUI app. Portable zip + NestedInstallerType portable, same shape as Patchloom.Patchloom.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are not other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.12 schema

Local `winget validate` / `winget install` were not run. This submitter is on macOS. Hash and zip layout were checked against the live v0.1.0 asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425912)