### PR TITLE
New package: Demonbane18.Relmio version 0.9.0

### DIFF
--- a/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.installer.yaml
+++ b/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Demonbane18.Relmio
+PackageVersion: 0.9.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Commands:
+  - relmio
+Installers:
+- Architecture: arm64
+  NestedInstallerFiles:
+    - RelativeFilePath: relmio.exe
+      PortableCommandAlias: relmio
+  InstallerUrl: https://github.com/Demonbane18/relmio/releases/download/v0.9.0/relmio-0.9.0-windows-arm64.zip
+  InstallerSha256: AB3119CF0F8970A1090E2856BADDDE06CC5DFA8D228375A6E08557E0C55C42EB
+- Architecture: x64
+  NestedInstallerFiles:
+    - RelativeFilePath: relmio.exe
+      PortableCommandAlias: relmio
+  InstallerUrl: https://github.com/Demonbane18/relmio/releases/download/v0.9.0/relmio-0.9.0-windows-x64.zip
+  InstallerSha256: 545149597D244B510AFE5F142A7FDC9ED55CFB89E2941F81869E12270D0E2C56
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.locale.en-US.yaml
+++ b/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Demonbane18.Relmio
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Demonbane18
+PublisherUrl: https://github.com/Demonbane18/relmio
+PublisherSupportUrl: https://github.com/Demonbane18/relmio/issues
+PackageName: Relmio
+PackageUrl: https://github.com/Demonbane18/relmio
+License: Apache-2.0
+LicenseUrl: https://github.com/Demonbane18/relmio/blob/main/LICENSE
+ShortDescription: Create a private OpenAI-compatible endpoint beside self-hosted n8n.
+Tags:
+  - n8n
+  - oauth
+  - openai
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.yaml
+++ b/manifests/d/Demonbane18/Relmio/0.9.0/Demonbane18.Relmio.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Demonbane18.Relmio
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds Relmio 0.9.0 as a portable WinGet package for Windows x64 and ARM64.

This supersedes #411993, which targeted the older 0.2.15 release and remained awaiting review.

## ✅ Checklist

- [x] Signed the Contributor License Agreement
- [x] No separate issue is required for this routine manifest submission

## 📦 Manifest Checklist

- [x] Checked that there is no other open pull request for Relmio 0.9.0
- [x] This PR modifies one multi-file manifest set for one package version only
- [x] Manifest files conform to the repository's current 1.12 schema

## Validation evidence

- The three manifests are byte-for-byte output from Relmio's reviewed v0.9.0 package-manager generator.
- All manifests validate against Microsoft's official WinGet 1.12 JSON schemas.
- Both installer URLs are immutable, version-specific GitHub Release assets and resolve successfully.
- Downloaded release asset SHA-256 digests match the installer manifests:
  - x64: `545149597D244B510AFE5F142A7FDC9ED55CFB89E2941F81869E12270D0E2C56`
  - ARM64: `AB3119CF0F8970A1090E2856BADDDE06CC5DFA8D228375A6E08557E0C55C42EB`
- Both ZIP archives contain the expected root `relmio.exe`; PE inspection identifies x64 and ARM64 respectively.
- The v0.9.0 release workflow built deterministic x64 and ARM64 archives, smoke-tested the x64 portable command, validated the generated WinGet candidates, and attached the exact reviewed archives to the release.

Release: https://github.com/Demonbane18/relmio/releases/tag/v0.9.0

Release workflow: https://github.com/Demonbane18/relmio/actions/runs/33222308559

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425917)