### PR TITLE
New version: neyham.AIUsageDashboard version 0.8.2

### DIFF
--- a/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.installer.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.installer.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.2
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-28
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/neyham/ai-usage-dashboard/releases/download/v0.8.2/AI-Usage-Dashboard_0.8.2_x64-setup.exe
+    InstallerSha256: 19AD5DD08D2030B4D53420210D2D54C1B2BADF87EE7729F6ADAB5C818EE4D5A0
+    AppsAndFeaturesEntries:
+      - DisplayName: AI Usage Dashboard
+        DisplayVersion: 0.8.2
+        Publisher: neyha
+        ProductCode: AI Usage Dashboard
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.locale.en-US.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.2
+PackageLocale: en-US
+Publisher: neyham
+PublisherUrl: https://github.com/neyham
+PublisherSupportUrl: https://github.com/neyham/ai-usage-dashboard/issues
+Author: neyham
+PackageName: AI Usage Dashboard
+PackageUrl: https://github.com/neyham/ai-usage-dashboard
+License: MIT
+LicenseUrl: https://github.com/neyham/ai-usage-dashboard/blob/v0.8.2/LICENSE
+Copyright: Copyright (c) 2026 neyham
+ShortDescription: Local Windows dashboard for Claude Code, Codex, Grok Build, Cursor, Antigravity, and DeepSeek usage.
+Description: |-
+  AI Usage Dashboard is a local-first Windows desktop dashboard and screensaver
+  for viewing Claude Code, Codex, Grok Build, Cursor, and Antigravity usage
+  windows alongside a DeepSeek API balance. Display Settings provide a
+  write-only DeepSeek API key field, optional Cursor and Antigravity panels
+  that stay off by default, and an optional Low Power Mode that disables
+  animation and reduces renderer update work. Credentials and provider
+  requests stay in the native Rust backend; the renderer receives sanitized
+  usage summaries only. The project has no developer-operated server,
+  analytics, or telemetry.
+Moniker: ai-usage-dashboard
+Tags:
+  - ai
+  - antigravity
+  - claude
+  - claude-code
+  - codex
+  - cursor
+  - dashboard
+  - deepseek
+  - grok
+  - usage
+ReleaseNotesUrl: https://github.com/neyham/ai-usage-dashboard/releases/tag/v0.8.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.yaml
+++ b/manifests/n/neyham/AIUsageDashboard/0.8.2/neyham.AIUsageDashboard.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet manifest schema 1.12.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: neyham.AIUsageDashboard
+PackageVersion: 0.8.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package update

Updates neyham.AIUsageDashboard to version 0.8.2.

- Installer: official NSIS asset from the v0.8.2 GitHub Release
- SHA-256 verified against both the downloaded installer and published SHA256SUMS (`19AD5DD08D2030B4D53420210D2D54C1B2BADF87EE7729F6ADAB5C818EE4D5A0`)
- Locale URLs point at the v0.8.2 tag
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425927)