### PR TITLE
New package: TechyGeeksHome.CleanGeek version 1.0.2

### DIFF
--- a/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.installer.yaml
+++ b/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.CleanGeek
+PackageVersion: 1.0.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{5ADCD81B-C0F1-4602-BE7B-B68F3625C868}_is1'
+ReleaseDate: 2026-08-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/techygeekshome/CleanGeek/releases/download/v1.0.2/CleanGeekSetup.exe
+    InstallerSha256: BDDD958930187CDE766595E8C2F2693C4BBD405C7330155E171368A85B2D6F94
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.locale.en-US.yaml
+++ b/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.CleanGeek
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/CleanGeek/issues
+PackageName: CleanGeek
+PackageUrl: https://techygeekshome.info/cleangeek/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/techygeekshome/CleanGeek/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+CopyrightUrl: https://github.com/techygeekshome/CleanGeek/blob/main/LICENSE
+ShortDescription: A free Windows disk cleaner that shows what each item is worth before it deletes anything - and has no registry cleaner.
+Description: |-
+  CleanGeek recovers disk space from the things on a Windows machine that nothing needs:
+  Windows Update and delivery optimisation leftovers, temporary files, crash dumps, the
+  system memory dump, thumbnail and icon caches, per-browser caches and previous Windows
+  installations. Every item reports how much it would recover before anything is removed,
+  and the scan and the clean are always two separate steps.
+
+  Nothing is ticked by default except caches and temporary files. Anything with a cost -
+  cookies, history, saved form data, the Recycle Bin - is opt-in and says in plain words
+  what clearing it will cost you. Nothing outside a known, named list is ever deleted.
+
+  There is no registry cleaner and there will not be one. Saved passwords are not a cleanup
+  target. The component store and the Prefetch folder are left alone.
+
+  It also lists everything installed on the machine and everything that starts with Windows,
+  handing an uninstall to the publisher's own uninstaller rather than doing it itself.
+
+  No telemetry, no account, no bundled offers and no paid tier. Installs per-user by default,
+  so no admin rights and no UAC prompt. Requires Windows 10 or later, 64-bit.
+Moniker: cleangeek
+Tags:
+  - cleaner
+  - disk-cleanup
+  - temp-files
+  - cache
+  - windows-update
+  - startup
+  - uninstaller
+  - maintenance
+  - utility
+ReleaseNotesUrl: https://github.com/techygeekshome/CleanGeek/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.yaml
+++ b/manifests/t/TechyGeeksHome/CleanGeek/1.0.2/TechyGeeksHome.CleanGeek.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.CleanGeek
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: **TechyGeeksHome.CleanGeek** version **1.0.2**.

CleanGeek is a free, GPL-3.0 disk cleaner for Windows 10 and 11. It reports what each item would
recover before anything is deleted, ticks nothing by default except caches and temporary files, and
deliberately has no registry cleaner. Publisher page: https://techygeekshome.info/cleangeek/

Same publisher as the existing TechyGeeksHome.PDFGeek and TechyGeeksHome.DiskGeek submissions.

The installer is Inno Setup, `PrivilegesRequired=lowest`, so it installs per-user with no UAC prompt -
hence `Scope: user`, matching the PDFGeek manifest. `InstallerSha256` is taken from `SHA256SUMS.txt`
published alongside the installer in the same GitHub release, which is generated by the release
workflow from the artefact it uploads.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

On the two unchecked boxes: these manifests were validated against the published 1.12.0 JSON schemas
rather than with the `winget` CLI, and the installer has not been installed from the manifest on this
machine. Flagging that rather than ticking boxes I cannot stand behind. The installer itself is the
same build published in the release, and the hash is the one shipped with it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425977)