### PR TITLE
New package: TechyGeeksHome.DriverGeek version 1.0.2

### DIFF
--- a/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.installer.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.0.2
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{E1F5AC9E-3E9F-478D-BD69-40D637942B89}_is1'
+ReleaseDate: 2026-08-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/techygeekshome/DriverGeek/releases/download/v1.0.2/DriverGeekSetup.exe
+    InstallerSha256: 0FF303182ED09864EDF6837B86C2DF53599857757C03B83515365FBDF10DA37B
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.locale.en-US.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/DriverGeek/issues
+PackageName: DriverGeek
+PackageUrl: https://techygeekshome.info/drivergeek/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/techygeekshome/DriverGeek/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+CopyrightUrl: https://github.com/techygeekshome/DriverGeek/blob/main/LICENSE
+ShortDescription: Lists every driver on a Windows PC and surfaces the driver updates Windows Update files under Optional and never offers.
+Description: |-
+  Windows already knows about driver updates you have never been offered. They sit under
+  Settings, Windows Update, Advanced options, Optional updates - four clicks deep, where
+  almost nobody looks. DriverGeek lists every device on the machine with the driver it is
+  actually running, including version, date, provider and whether it is signed, and puts
+  the updates Windows is already holding for you on the same screen.
+
+  For hardware Windows Update does not cover, it links to the manufacturer own support
+  page for that device. It does not host drivers, it does not scrape vendor sites and it
+  does not ship a driver pack.
+
+  It distinguishes a driver with a newer version available from a driver that is merely old,
+  and will tell you plainly when nothing needs doing. There is no "247 issues found", no
+  scan-then-pay, no paid tier and no upsell.
+
+  Version 1.0 reads and reports: everything it does is a read of your machine and a question
+  put to Windows Update. Nothing is downloaded and nothing is installed.
+
+  No telemetry, no account, no bundled offers. Installs per-user by default, so no admin
+  rights and no UAC prompt. Requires Windows 10 or later, 64-bit.
+Moniker: drivergeek
+Tags:
+  - drivers
+  - driver-updates
+  - windows-update
+  - device-manager
+  - hardware
+  - inventory
+  - system-tools
+  - utility
+ReleaseNotesUrl: https://github.com/techygeekshome/DriverGeek/releases/tag/v1.0.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.0.2/TechyGeeksHome.DriverGeek.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: **TechyGeeksHome.DriverGeek** version **1.0.2**.

DriverGeek is a free, GPL-3.0 driver inventory tool for Windows 10 and 11. It lists every device with
the driver it is actually running and surfaces the driver updates Windows Update files under Optional
updates. It hosts no drivers and installs nothing. Publisher page: https://techygeekshome.info/drivergeek/

Same publisher as the existing TechyGeeksHome.PDFGeek and TechyGeeksHome.DiskGeek submissions.

The installer is Inno Setup, `PrivilegesRequired=lowest`, so it installs per-user with no UAC prompt -
hence `Scope: user`, matching the PDFGeek manifest. `InstallerSha256` is taken from `SHA256SUMS.txt`
published alongside the installer in the same GitHub release, which is generated by the release
workflow from the artefact it uploads.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

On the two unchecked boxes: these manifests were validated against the published 1.12.0 JSON schemas
rather than with the `winget` CLI, and the installer has not been installed from the manifest on this
machine. Flagging that rather than ticking boxes I cannot stand behind. The installer itself is the
same build published in the release, and the hash is the one shipped with it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425978)