### PR TITLE
New version: eeyzs1.DevWit version 0.6.0

### DIFF
--- a/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.installer.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.5.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-11
+# ProductCode 由 appId 派生不随版本变，沿用 0.1.1 本机真实安装实证值
+AppsAndFeaturesEntries:
+  - Publisher: eeyzs1
+    ProductCode: 8de26b52-cf1c-58c4-8f9f-a7b471bba36e
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/eeyzs1/DevWit/releases/download/v0.5.0/DevWit.Setup.0.5.0.exe
+    InstallerSha256: A518E67576C9ABF5473F5DF620D77C7B4ED2101637F00E9AE0F8F02393A120DE
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.locale.en-US.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: eeyzs1
+PublisherUrl: https://github.com/eeyzs1
+PackageName: DevWit
+PackageUrl: https://github.com/eeyzs1/DevWit
+License: MIT
+LicenseUrl: https://github.com/eeyzs1/DevWit/blob/main/LICENSE
+ShortDescription: Lean-context AI-native desktop IDE. Describe your intent; the agent plans, executes with your approval, and delivers reviewable diffs with a full execution trace.
+Tags:
+  - ai
+  - ide
+  - llm
+  - agent
+  - code-editor
+  - electron
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.locale.zh-CN.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.5.0
+PackageLocale: zh-CN
+Publisher: eeyzs1
+PublisherUrl: https://github.com/eeyzs1
+PackageName: DevWit
+PackageUrl: https://github.com/eeyzs1/DevWit
+License: MIT
+LicenseUrl: https://github.com/eeyzs1/DevWit/blob/main/LICENSE
+ShortDescription: 简洁上下文 AI 原生桌面 IDE。你描述意图，Agent 规划、经你授权后执行，交付可审查的 diff 与完整执行轨迹。
+Tags:
+  - ai
+  - ide
+  - llm
+  - agent
+  - 代码编辑器
+  - 开发者工具
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.5.0/eeyzs1.DevWit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.installer.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.6.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-22
+# ProductCode 由 appId 派生且不随版本变化，沿用 0.1.1 本机真实安装实证值
+AppsAndFeaturesEntries:
+  - Publisher: eeyzs1
+    ProductCode: 8de26b52-cf1c-58c4-8f9f-a7b471bba36e
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/eeyzs1/DevWit/releases/download/v0.6.0/DevWit.Setup.0.6.0.exe
+    InstallerSha256: 97A121581DBCA4692EF890FDA7FED0166677B0EDC6D3556BF91AEFE0F4BE4D6E
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.locale.en-US.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: eeyzs1
+PublisherUrl: https://github.com/eeyzs1
+PackageName: DevWit
+PackageUrl: https://github.com/eeyzs1/DevWit
+License: MIT
+LicenseUrl: https://github.com/eeyzs1/DevWit/blob/main/LICENSE
+ShortDescription: Lean-context AI-native desktop IDE. Describe your intent; the agent plans, executes with your approval, and delivers reviewable diffs with a full execution trace.
+Tags:
+  - ai
+  - ide
+  - llm
+  - agent
+  - code-editor
+  - electron
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.locale.zh-CN.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.6.0
+PackageLocale: zh-CN
+Publisher: eeyzs1
+PublisherUrl: https://github.com/eeyzs1
+PackageName: DevWit
+PackageUrl: https://github.com/eeyzs1/DevWit
+License: MIT
+LicenseUrl: https://github.com/eeyzs1/DevWit/blob/main/LICENSE
+ShortDescription: 简洁上下文 AI 原生桌面 IDE。你描述意图，Agent 规划、经你授权后执行，交付可审查的 diff 与完整执行轨迹。
+Tags:
+  - ai
+  - ide
+  - llm
+  - agent
+  - 代码编辑器
+  - 开发者工具
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.yaml
+++ b/manifests/e/eeyzs1/DevWit/0.6.0/eeyzs1.DevWit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: eeyzs1.DevWit
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
By creating a pull request in winget-pkgs, you agree to the [Code of Conduct](https://github.com/microsoft/winget-pkgs?tab=coc-ov-file#microsoft-open-source-code-of-conduct). All changes are subject to the [dco validation](https://github.com/microsoft/winget-pkgs#dco) and [validation requirements](https://aka.ms/winget-pr-validation).

For contributions related to a GitHub issue, please provide a link to the issue here.

-->
#### Description
v0.6.0 update: cost budget dashboard, first-run tours, and one-click sample project.

#### Motivation and Context
- Update DevWit from 0.5.0 to 0.6.0
- Winget installer: DevWit.Setup.0.6.0.exe (SHA256 verified from GitHub release)

#### How Has This Been Tested?
- [x] winget install eeyzs1.DevWit upgrade path (previous 0.5.0 -> 0.6.0)
- SHA256 computed from the published GitHub release artifact

#### Packaging
- Manifest 1.10.0, nullsoft NSIS installer, x64

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/425984)