### PR TITLE
New version: AndreaBozzo.GitNodes version 0.2.0

### DIFF
--- a/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.installer.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gitnodes.exe
+  PortableCommandAlias: gitnodes
+UpgradeBehavior: uninstallPrevious
+Commands:
+- gitnodes
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AndreaBozzo/gitnodes/releases/download/v0.2.0/gitnodes-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 0add202ad72672c684620b819c183fca6155954ecddec3a598c025181199192e
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.locale.en-US.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: Andrea Bozzo
+PublisherUrl: https://github.com/AndreaBozzo/gitnodes
+PublisherSupportUrl: https://github.com/AndreaBozzo/gitnodes/issues
+PackageName: GitNodes
+PackageUrl: https://github.com/AndreaBozzo/gitnodes
+License: GNU Affero General Public License v3.0 or later
+LicenseUrl: https://github.com/AndreaBozzo/gitnodes/blob/v0.2.0/LICENSE-AGPL
+ShortDescription: A knowledge graph over a Git repository of Markdown files.
+Description: >-
+  GitNodes turns Markdown with YAML frontmatter into a navigable, editable
+  knowledge graph while keeping Git as the source of truth.
+Moniker: gitnodes
+Tags:
+- ai
+- git
+- knowledge-base
+- knowledge-graph
+- markdown
+ReleaseNotesUrl: https://github.com/AndreaBozzo/gitnodes/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.yaml
+++ b/manifests/a/AndreaBozzo/GitNodes/0.2.0/AndreaBozzo.GitNodes.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AndreaBozzo.GitNodes
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

**AndreaBozzo.GitNodes 0.2.0** — [release notes](https://github.com/AndreaBozzo/gitnodes/releases/tag/v0.2.0)

Manifests are unchanged from the accepted 0.1.1 set apart from the version, installer URL and SHA256. The `Microsoft.VCRedist.2015+.x64` dependency and `ReleaseNotesUrl` added during the 0.1.1 review are retained, and are now part of the manifest templates in the upstream project so they carry forward automatically.

**Verification performed:**

- `winget validate --manifest` passes:
  ```
  Manifest has the following dependencies that were not validated; ensure that they are valid:
    - Packages
        Microsoft.VCRedist.2015+.x64
  Manifest validation succeeded.
  ```
- `InstallerSha256` checked byte-for-byte against the `SHA256SUMS` asset published with the GitHub release.
- The archive contents were verified directly: `gitnodes.exe` extracted from `gitnodes-x86_64-pc-windows-msvc.zip` runs and reports `gitnodes 0.2.0`.

I have not run `winget install --manifest` on this machine, so that box is left unchecked rather than claimed.