### PR TITLE
New package: AegiosOT.YTile version 0.1.3

### DIFF
--- a/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.installer.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.3
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ytile.exe
+  PortableCommandAlias: ytile
+- RelativeFilePath: ytiled.exe
+  PortableCommandAlias: ytiled
+- RelativeFilePath: ykeys.exe
+  PortableCommandAlias: ykeys
+Commands:
+- ytile
+- ytiled
+- ykeys
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AegiosOT/YTile/releases/download/v0.1.3/ytile-0.1.3-win-x64.zip
+  InstallerSha256: a6b0331d88665992919cfff6a823d8ab7a2ca72fb4d246ee4b3416e193458f71
+ReleaseDate: 2026-08-29
+ManifestType: installer
+ManifestVersion: 1.10.0
+

--- a/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.locale.en-US.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: AegiosOT
+PublisherUrl: https://github.com/AegiosOT
+PublisherSupportUrl: https://github.com/AegiosOT/YTile/issues
+Author: AegiosOT
+PackageName: YTile
+PackageUrl: https://github.com/AegiosOT/YTile
+License: GPL-3.0
+LicenseUrl: https://github.com/AegiosOT/YTile/blob/main/LICENSE
+ShortDescription: Tiling window manager for Windows
+Description: |-
+  YTile tiles application windows automatically: nine workspaces per monitor
+  hidden by cloaking so alt-tab stays clean, BSP and Columns layouts plus
+  monocle, directional focus and movement that continue onto the adjacent
+  monitor, drag-to-swap, edge resizes that persist into the layout, per-app
+  float/ignore rules, optional taskbar hiding, and a named-pipe NDJSON API
+  for status bars. Ships a daemon (ytiled) and a CLI (ytile); pair with whkd
+  for hotkeys.
+Moniker: ytile
+Tags:
+- tiling
+- tiling-window-manager
+- window-manager
+- productivity
+ReleaseNotesUrl: https://github.com/AegiosOT/YTile/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+

--- a/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.yaml
+++ b/manifests/a/AegiosOT/YTile/0.1.3/AegiosOT.YTile.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: AegiosOT.YTile
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+


### PR DESCRIPTION
## Description

First submission of **AegiosOT.YTile** (YTile, a tiling window manager for Windows), version **0.1.3**.

The manifests are generated by the project's release CI from the exact released archive and are attached as assets on the release itself: https://github.com/AegiosOT/YTile/releases/tag/v0.1.3. The package is a zip with three nested portable binaries: `ytiled.exe` (daemon), `ytile.exe` (CLI), and `ykeys.exe` (the bundled hotkey daemon from https://github.com/AegiosOT/YKeys).

All three binaries are **Authenticode-signed** via Azure Artifact Signing (identity-validated individual publisher) with RFC-3161 timestamping. A previous submission of an earlier, unsigned version (#416687) repeatedly failed the Installers Scan on what appeared to be a low-prevalence/unsigned-binary heuristic and was closed by the author; this signed release supersedes it.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (on #416687)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> The manifests declare `ManifestVersion: 1.10.0` and validate cleanly with winget locally.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426010)