### PR TITLE
New package: CCGnomes.VaultManager version 0.7.7

### DIFF
--- a/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.installer.yaml
+++ b/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultManager
+PackageVersion: 0.7.7
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# The vaultflasher:// deeplink protocol is UNCHANGED by the product rename
+# (spec: vaultflasher://flash?tag=...&arch=...), so the registered scheme stays
+# 'vaultflasher' even though the package is now CCGnomes.VaultManager.
+Protocols:
+  - vaultflasher
+# The installed app registers in Add/Remove Programs as "Vault Manager"; this
+# block lets winget correlate the installed entry with the CCGnomes.VaultManager
+# package so `winget upgrade` offers updates and `winget list` shows it as
+# managed. Confirmed against the real registry entry 2026-08-09: DisplayName
+# "Vault Manager", Publisher "ccgnomes", NSIS uninstall key "Vault Manager".
+AppsAndFeaturesEntries:
+  - DisplayName: Vault Manager
+    Publisher: ccgnomes
+    DisplayVersion: 0.7.7
+    ProductCode: Vault Manager
+    InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/markCCGnomes/vault-flasher-releases/releases/download/v0.7.7/VaultManager-x64-setup.exe
+    InstallerSha256: FD6B8E2D311E208C223C6B61236DB9386A84EF1031A269203E6040C6BD61F1E3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.locale.en-US.yaml
+++ b/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultManager
+PackageVersion: 0.7.7
+PackageLocale: en-US
+Publisher: CCGnomes
+PublisherUrl: https://ccgnomes.com
+PublisherSupportUrl: https://ccgnomes.com/vaultnode/setup/
+PackageName: Vault Manager
+PackageUrl: https://github.com/markCCGnomes/vault-flasher-releases
+License: Vault Ecosystem License v1.1
+LicenseUrl: https://github.com/markCCGnomes/vault-flasher-releases/blob/main/LICENSE
+Copyright: Copyright (c) 2026 CCGnomes
+ShortDescription: Flash a Vault Node USB stick, then set the node up and manage it
+Description: >-
+  Vault Manager flashes the official Vault Node image to a USB drive, then sets
+  the node up and looks after it. It downloads the image, verifies its SHA-256
+  against the release's published digest, and writes it to a removable USB drive
+  with a single click — with a read-back verification pass and optional WiFi
+  presetting. It only ever offers removable USB drives (never an internal or
+  system disk) and re-validates the target inside its elevated writer.
+
+  The same app then claims the node, hosts apps on it, pairs a website, manages
+  storage and devices, and reads its health.
+Moniker: vault-manager
+Tags:
+  - vault-node
+  - self-hosting
+  - flasher
+  - usb
+  - imaging
+  - node-management
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.yaml
+++ b/manifests/c/CCGnomes/VaultManager/0.7.7/CCGnomes.VaultManager.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: CCGnomes.VaultManager
+PackageVersion: 0.7.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Vault Manager by CCGnomes (we are the publisher; our own build, hosted on our
public releases mirror). This is the renamed successor to CCGnomes.VaultFlasher
— a companion removal PR retires CCGnomes.VaultFlasher 0.1.0. `winget validate`
passes; the InstallerUrl downloads anonymously and its SHA-256 matches the
manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426012)