### PR TITLE
Fix: Psynect.OmniMend version 2.0.3 product scope

### DIFF
--- a/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.locale.en-US.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.3/Psynect.OmniMend.locale.en-US.yaml
@@ -13,11 +13,13 @@ PackageUrl: https://omnimend.com/
 License: Proprietary
 LicenseUrl: https://omnimend.com/terms
 Copyright: Copyright (c) 2026 Psynect Corp. All rights reserved.
-ShortDescription: AI-powered Windows diagnostics, controlled repair tools, and Security Vitals behavior monitoring.
+ShortDescription: Complete Windows host for OmniMend device diagnostics, approved PC repair, and Security Vitals Beta.
 Description: |-
-  OmniMend is an AI-powered diagnostics and repair application for Windows PCs. It helps users investigate crashes, performance problems, driver failures, hardware issues, startup trouble, and other difficult computer problems through guided diagnosis and system-aware tools. Users can review findings and recommended actions before using controlled repair tools when an appropriate fix is available.
+  OmniMend is an agentic AI diagnostic system for the devices people and technicians use. This Windows package is its complete host for local PC diagnosis and approved repair plus supported iPhone and iPad, Android, Chromebook, recovery, and professional workflows. The Apple Silicon Mac app is available separately for native local Mac diagnostics.
 
-  Security Vitals Beta adds behavior-based monitoring for suspicious Windows activity that may not have a known signature yet, including patterns associated with emerging and zero-day attacks. It works alongside Microsoft Defender or another registered antivirus, explains why an event deserves attention, and leaves the next step to the user. It does not replace antivirus or promise to detect every attack.
+  Diagnosis stays read-only. If a supported repair fits the evidence, OmniMend explains the action, waits for the user's approval, and checks the relevant result afterward.
+
+  Security Vitals Beta is a separate Windows-only workspace. It filters ordinary activity locally, uses a bounded and redacted cloud AI summary for higher-risk patterns, and works alongside Microsoft Defender or another registered antivirus. It is designed to help investigate unfamiliar behavior, including patterns that can appear in emerging or zero-day attacks. It does not replace antivirus, promise perfect detection, or quarantine anything automatically.
 Moniker: omnimend
 Tags:
 - ai


### PR DESCRIPTION
This metadata-only correction keeps the manifest specific to the Windows package while accurately describing OmniMend as a multi-device diagnostic system. It clarifies the Windows host's PC and connected-device workflows, the separate Apple Silicon Mac app, read-only diagnosis and approved repairs, and the Windows-only Security Vitals Beta boundaries. The installer URL, hash, version, license, and release metadata are unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426106)