### PR TITLE
New package: Devlikebear.Linetta version 1.0.0

### DIFF
--- a/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.installer.yaml
+++ b/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/devlikebear/linetta/releases/download/v1.0.0/Linetta_1.0.0_x64-setup.exe
+    InstallerSha256: 84C88C01FF0D89F3ED2B6ED7F55DCB3E5E1FF2FC48484BFA06551406A12423E8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.locale.en-US.yaml
+++ b/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: devlikebear
+PublisherUrl: https://github.com/devlikebear
+Author: devlikebear
+PackageName: Linetta
+PackageUrl: https://github.com/devlikebear/linetta
+License: Proprietary
+ShortDescription: Local-first desktop writing app for long-form fiction.
+Moniker: linetta
+Tags:
+  - desktop
+  - fiction
+  - writing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.yaml
+++ b/manifests/d/Devlikebear/Linetta/1.0.0/Devlikebear.Linetta.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Devlikebear.Linetta
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Devlikebear.Linetta** version **1.0.0**.

Linetta is a local-first desktop writing app for long-form fiction. Projects live in a local SQLite database; there is no account and no mandatory cloud.

- Homepage / source: https://github.com/devlikebear/linetta
- Release: https://github.com/devlikebear/linetta/releases/tag/v1.0.0
- Installer: NSIS, `Scope: user`, silent switch `/S`

`InstallerSha256` was taken from the release's `SHA256SUMS` and re-checked against a fresh download of the file `InstallerUrl` serves.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Not applicable — new package, no upstream issue.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (winget 1.12, passed)
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Notes on the two unchecked boxes

**CLA** — not yet signed at the time of opening. Will sign when the bot asks.

**`winget install --manifest`** — not run, so it is not claimed. What was verified instead:

- The NSIS installer built from this exact release tag was installed on Windows 11 and launched, so the binary and its `Scope: user` install path are known good.
- `InstallerUrl` resolves (HTTP 200, 20,704,058 bytes) and the SHA matches from three independent places: the release `SHA256SUMS`, a fresh download, and the rendered manifest.

Happy to run the install test and report back if that is preferred before validation.

### Note for reviewers

The installer is not code-signed, so SmartScreen warns on first run. Flagging it up front rather than having it turn up in validation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426119)