### PR TITLE
New version: Materializr.Materializr version 1.6.3

### DIFF
--- a/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.3
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: Materializr
+ReleaseDate: 2026-08-29
+AppsAndFeaturesEntries:
+- ProductCode: Materializr
+  DisplayVersion: v1.6.3
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Materializr'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.6.3/Materializr-Setup.exe
+  InstallerSha256: 11C991CB5E32084D0B4C5F257AE606FBC9E0785BC43FDE6F1C6494877A53020C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.3
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/HEAD/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
+Description: |-
+  Materializr is open-source 3D CAD for makers — the middle ground between
+  dead-simple tools like Tinkercad and full professional suites like FreeCAD.
+  Sketch on a plane, pull it into a solid (extrude, revolve, loft, sweep),
+  fillet and chamfer, run booleans, cut threads, and edit any step of the
+  history later. Sketches export to SVG and DXF at 1:1 mm for laser cutters and
+  2.5D CNC; it imports STEP, IGES, BREP, STL, SVG and DXF, and exports STEP,
+  STL, IGES, BREP, glTF, OBJ, 3MF, SVG and DXF. Real B-rep solids on the
+  OpenCASCADE kernel.
+Moniker: materializr
+Tags:
+- 3d
+- 3d-printing
+- cad
+- engineering
+- laser
+- modeling
+- opencascade
+- svg
+ReleaseNotes: |-
+  Materializr 1.6.3
+  Fixed
+  - Windows startup crash: 1.6.1 and 1.6.2 could exit before showing a window; the packaging pipeline now launch-tests the packaged exe so this cannot ship again
+  - Sketch grid on round faces (a tube or flange top) aligns to the world axes instead of rotating to a keyway flat
+  Added
+  - Interface translated into Spanish, Portuguese, French, German and Italian; chosen on first run or in Settings > Appearance, applied instantly
+  - Arcs take typed dimensions: chord, then a swept angle or a radius
+  - Drawing guides (angle snap, tangent, perpendicular/parallel) now work in the arc, circle, polygon and spline tools, not just lines
+  - Tangent guides fire from a point on a circle or the end of an arc; splines can be tangent references
+  Changed
+  - Loft tip-split sampling, faces as sections and bridging into the host body; extrude and booleans are time-boxed; STL export welds and repairs the mesh; a union smaller than its largest input is rejected
+ReleaseNotesUrl: https://github.com/materializr-cad/materializr/releases/tag/v1.6.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.3/Materializr.Materializr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for Materializr.Materializr version 1.6.3

Fixes a startup crash on Windows present in 1.6.1 and 1.6.2 (the app could exit before showing a window), plus a translated interface (Spanish, Portuguese, French, German, Italian) and sketching improvements. Full notes: https://github.com/materializr-cad/materializr/releases/tag/v1.6.3

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note for validation: Materializr is an OpenGL GUI application and requires a working GL context. In the headless validation sandbox it exits without a window (the same `0xE06D7363` seen on the 1.6.0 PR, #411696, which was merged after review). It launches normally on hardware with a GPU.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426126)