### PR TITLE
New version: MarcoSburlino.Koinkat version 0.1.2

### DIFF
--- a/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.installer.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/MarcoSburlino/Koinkat/releases/download/v0.1.2/Koinkat_0.1.2_x64-setup.exe
+  InstallerSha256: 27B67CDF729B4132C14326461E2A1DD303D6A7A87C7675BAD9B8B96D1B03B059
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.locale.en-US.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: Marco Sburlino
+PublisherUrl: https://github.com/MarcoSburlino
+PublisherSupportUrl: https://github.com/MarcoSburlino/Koinkat/issues
+PrivacyUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/docs/privacy-policy.md
+PackageName: Koinkat
+PackageUrl: https://github.com/MarcoSburlino/Koinkat
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Marco Sburlino
+ShortDescription: Local-first multi-currency personal finance manager.
+Description: Koinkat is a local-first desktop app for tracking personal finances across multiple currencies and bank accounts. Your data lives on your device. There is no Koinkat server, no cloud sync, no telemetry and no account system. Connect European banks via PSD2 through Enable Banking, or use it manually.
+Moniker: koinkat
+Tags:
+- desktop
+- local-first
+- open-banking
+- personal-finance
+- privacy
+- psd2
+- react
+- rust
+- sqlite
+- tauri
+- typescript
+ReleaseNotesUrl: https://github.com/MarcoSburlino/Koinkat/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.2/MarcoSburlino.Koinkat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version of an existing package: **MarcoSburlino.Koinkat 0.1.2**

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Installer URL and SHA256 verified against the published release asset.

Alongside the version bump, this corrects the `Description`. The previous
text said "All data stays on your device", which overstated things: the app
is local-first and has no server, but connecting a bank does send account
data through Enable Banking's PSD2 API. The new wording states what is
accurate - no server, no cloud sync, no telemetry, no account system - and
mentions the Enable Banking connection explicitly.

Upstream release: https://github.com/MarcoSburlino/Koinkat/releases/tag/v0.1.2

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426131)