### PR TITLE
fix: Flowscripter.template-bun-executable remove ElevationRequirement: elevationProhibited

### DIFF
--- a/manifests/f/Flowscripter/template-bun-executable/1.3.22/Flowscripter.template-bun-executable.installer.yaml
+++ b/manifests/f/Flowscripter/template-bun-executable/1.3.22/Flowscripter.template-bun-executable.installer.yaml
@@ -14,7 +14,6 @@ Dependencies:
   PackageDependencies:
   - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 ReleaseDate: 2026-07-03
-ElevationRequirement: elevationProhibited
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/flowscripter/template-bun-executable/releases/download/v1.3.22/template-bun-executable_Windows_x64.zip


### PR DESCRIPTION
The ElevationRequirement: elevationProhibited was added in #250726 as a workaround for oven-sh/bun#18193, where a Bun-compiled Windows executable launched via a symlink (as WinGet portable installs create) would run the Bun runtime itself instead of the bundled application.

That Bun issue has since been fixed upstream by oven-sh/bun#21091 (merged 2025-07-16, closed 2026-07-25): compiled executables now locate their embedded module data via the in-memory PE image rather than reopening the file through the reparse point, so launching via a symlink now works correctly. This package's release pipeline already builds with the latest Bun, which includes the fix.

Removing the elevation restriction restores standard portable-install behavior (symlinked into PATH) for this package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426153)