### PR TITLE
New version: asciimoo.hister version 0.18.0

### DIFF
--- a/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.installer.yaml
+++ b/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.18.0
+InstallerType: portable
+Commands:
+- hister
+ReleaseDate: 2026-08-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/asciimoo/hister/releases/download/v0.18.0/hister_0.18.0_windows_amd64.exe
+  InstallerSha256: 1B55E01A290B9775E6E89F00326EBAB4E0CBF876008AE84F61114E12EDF51439
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.locale.en-US.yaml
+++ b/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.18.0
+PackageLocale: en-US
+Publisher: asciimoo
+PublisherUrl: https://github.com/asciimoo
+PublisherSupportUrl: https://github.com/asciimoo/hister/issues
+Author: Adam Tauber
+PackageName: Hister
+PackageUrl: https://github.com/asciimoo/hister
+License: AGPL-3.0
+LicenseUrl: https://github.com/asciimoo/hister/blob/HEAD/LICENSE
+ShortDescription: Your own search engine – Full-text search across your files, visited sites and beyond.
+Description: Hister is a versatile, privacy-focused web search engine designed to index the full content of visited web pages locally. Unlike traditional search engines, it allows you to find specific information within your own browsing history using full-text indexing.
+Tags:
+- browser-history
+- go
+- golang
+- history
+- index
+- mcp
+- mcp-server
+- personal-search
+- personal-search-engine
+- privacy
+- search
+- search-engine
+- semantic-search
+- web
+ReleaseNotes: |-
+  Changelog
+  - 13856c1 [enh] release v0.18.0
+ReleaseNotesUrl: https://github.com/asciimoo/hister/releases/tag/v0.18.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://hister.org/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.yaml
+++ b/manifests/a/asciimoo/hister/0.18.0/asciimoo.hister.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: asciimoo.hister
+PackageVersion: 0.18.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Version 0.18.0 of Hister [was released on 23 August](https://github.com/asciimoo/hister/releases/tag/v0.18.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426154)