### PR TITLE
New version: AhmedArif.RosBE version 20260829

### DIFF
--- a/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.installer.yaml
+++ b/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: AhmedArif.RosBE
+PackageVersion: 20260829
+Commands:
+  - rosbe
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: rosbe.exe
+        PortableCommandAlias: rosbe
+    InstallerUrl: https://github.com/ahmedarif193/winget-rosbe/releases/download/v20260829/rosbe-bootstrapper-20260829-win-x64.zip
+    InstallerSha256: 3FC36EDFE95C0851214A7398168D7C3A326FE63FA7E9BE8F219AF2319E9313A1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.locale.en-US.yaml
+++ b/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.locale.en-US.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: AhmedArif.RosBE
+PackageVersion: 20260829
+PackageLocale: en-US
+Publisher: Ahmed Arif
+PublisherUrl: https://github.com/ahmedarif193
+PublisherSupportUrl: https://github.com/ahmedarif193/winget-rosbe/issues
+Author: Ahmed Arif
+PackageName: RosBE
+PackageUrl: https://github.com/ahmedarif193/winget-rosbe
+License: MIT
+LicenseUrl: https://github.com/ahmedarif193/winget-rosbe/blob/main/LICENSE
+ShortDescription: RosBE bootstrapper and toolchain manager (unofficial ReactOS support)
+Description: |-
+  A lightweight, winget-installable Rust bootstrapper for RosBE.
+
+  `winget install` adds the `rosbe` command. Run `rosbe install` to
+  download and verify the RosBE toolchain bundle, then `rosbe enable`
+  to add the active toolchain directories to PATH.
+
+  Managed in this version:
+    - LLVM-MinGW (Clang) 23.1.0   - llvm-mingw 20260826 (UCRT)
+    - MinGW-GCC                  16.2.0    - crosstool-NG Canadian-cross (UCRT)
+    - CMake                      3.31.6
+    - Ninja                      1.12.1
+    - WinFlexBison (Flex+Bison)  2.5.25    - Flex 2.6.4 + Bison 3.8.2
+    - QEMU (Windows bundle)      11.1.0    - qemu.weilnetz.de build 20260811
+
+  `rosbe update` refreshes the toolchain bundle. `rosbe remove` removes
+  the installed bundle and PATH entries.
+
+  Not an official ReactOS release. Intended for preview / early adoption.
+Moniker: rosbe
+Tags:
+  - reactos
+  - bootstrapper
+  - build-environment
+  - cross-compiler
+  - llvm
+  - clang
+  - mingw
+  - gcc
+  - cmake
+  - ninja
+  - development
+  - operating-system
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.yaml
+++ b/manifests/a/AhmedArif/RosBE/20260829/AhmedArif.RosBE.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: AhmedArif.RosBE
+PackageVersion: 20260829
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Update from [RosBE](https://github.com/ahmedarif193/winget-rosbe) :rocket:

- **Package**: `AhmedArif.RosBE`
- **Version**: `20260829`
- **Release**: https://github.com/ahmedarif193/winget-rosbe/releases/tag/v20260829
- **Bootstrapper SHA256 (x64)**: `3FC36EDFE95C0851214A7398168D7C3A326FE63FA7E9BE8F219AF2319E9313A1`
- **Post-install**: `rosbe install` then `rosbe enable`

Managed toolchain versions:
- LLVM-MinGW: `20260826`
- MinGW-GCC (ct-ng Canadian-cross): `16.2.0` (v16.2 from ahmedarif193/mingw-gcc16.2)
- CMake: `3.31.6`
- Ninja: `1.12.1`
- WinFlexBison: `2.5.25`
- QEMU (Windows bundle): `11.1.0` (20260811 build from qemu.weilnetz.de)

- [x] Signed the Microsoft CLA
- [x] Only modifies one manifest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426161)