### PR TITLE
New version: Jorji49.streamtop version 1.1.2

### DIFF
--- a/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.installer.yaml
+++ b/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 1.1.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: streamtop.exe
+    PortableCommandAlias: streamtop
+UpgradeBehavior: install
+ReleaseDate: 2026-08-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Jorji49/streamtop/releases/download/v1.1.2/streamtop-windows-x86_64-1.1.2.zip
+    InstallerSha256: 47BE8CD903F9DAD53C5D03E08A45C34D1404E861C82EA83DE45B8D2E4CE976FE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.locale.en-US.yaml
+++ b/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Ahmet Kayra Kama
+PublisherUrl: https://github.com/Jorji49
+PublisherSupportUrl: https://github.com/Jorji49/streamtop/issues
+Author: Ahmet Kayra Kama
+PackageName: streamtop
+PackageUrl: https://github.com/Jorji49/streamtop
+License: MIT
+LicenseUrl: https://github.com/Jorji49/streamtop/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Ahmet Kayra Kama
+ShortDescription: HLS, DASH, and IPTV stream monitor for the terminal
+Description: Monitor live HLS, MPEG-DASH, and IPTV streams from the command line. Wire probes for GOP, audio, and TR 101 290 MPEG-TS checks. LL-HLS and SCTE-35 ad markers, glass-to-glass latency, PSSH and DRM probe, VOD crawl, synthetic player QoE simulation, SRT and RTMP ingest, Prometheus metrics, OpenTelemetry traces, and Quick Play.
+Moniker: streamtop
+Tags:
+  - hls
+  - dash
+  - iptv
+  - diagnostics
+  - monitoring
+  - streaming
+  - mpeg
+  - scte
+ReleaseNotesUrl: https://github.com/Jorji49/streamtop/releases/tag/v1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.yaml
+++ b/manifests/j/Jorji49/streamtop/1.1.2/Jorji49.streamtop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Jorji49.streamtop
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add Jorji49.streamtop version 1.1.2
- Use the verified GitHub release archive and SHA256

## Validation
- Release asset digest matches InstallerSha256
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426168)