### PR TITLE
New version: Ironship.WordHunter version 1.1.0

### DIFF
--- a/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.installer.yaml
+++ b/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: Word Hunter
+ReleaseDate: 2026-08-29
+AppsAndFeaturesEntries:
+- DisplayName: Word Hunter
+  Publisher: wordhunter
+  DisplayVersion: 1.1.0
+  ProductCode: Word Hunter
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Word Hunter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Ironship/WordHunter/releases/download/WordHunter1.1.0/Word.Hunter.Setup.exe
+  InstallerSha256: F74549A2B4B6A0AF423C9EB4A1046E383F8B31040357BAE6A85A2C1B6FC9480E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.locale.en-US.yaml
+++ b/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Ironship
+PublisherUrl: https://github.com/Ironship
+PublisherSupportUrl: https://github.com/Ironship/WordHunter/issues
+Author: Ironship
+PackageName: Word Hunter
+PackageUrl: https://github.com/Ironship/WordHunter
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Ironship/WordHunter/blob/WordHunter1.1.0/LICENSE
+ShortDescription: Local-first reader and spaced repetition tool for language learning
+Description: |-
+  Word Hunter is a desktop reader and vocabulary-learning workspace. It can
+  import texts, ebooks, subtitles and PDFs, save words with their context, and
+  review them with flashcards and spaced repetition. Data is stored locally.
+Moniker: wordhunter
+Tags:
+- ebook
+- flashcard
+- language-learning
+- ocr
+- reader
+- spaced-repetition
+- vocabulary
+ReleaseNotes: |-
+  Imports German quest vocabulary from World of Warcraft together with its
+  encounter history, and suggests when a long-running word may be ready to
+  mark as known. Saved words can now be renamed without losing their learning
+  progress. Adds shuffled review sessions, masking of German separable verbs
+  on reverse cards, dyslexia-friendly reader fonts, bold and italic in the
+  book editor, and read-aloud that keeps the highlighted word on screen.
+  Starting up and saving are markedly faster on large libraries, and image
+  text recognition is no longer cut off while it is still running.
+ReleaseNotesUrl: https://github.com/Ironship/WordHunter/releases/tag/WordHunter1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.yaml
+++ b/manifests/i/Ironship/WordHunter/1.1.0/Ironship.WordHunter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Ironship.WordHunter
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version: Ironship.WordHunter version 1.1.0

- [x] Have you signed the [Contributor License Agreement](https://aka.ms/winget-cla)?
- [x] Have you checked that there are no other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update?
- [x] Have you validated your manifest locally with `winget validate --manifest manifests/i/Ironship/WordHunter/1.1.0/`?
- [ ] Have you run `winget install --manifest manifests/i/Ironship/WordHunter/1.1.0/` to verify the installation?

`winget validate` passes on winget v1.29.290. The last box is left unticked
rather than ticked untruthfully: a local install was not performed. The
installer URL points at the published GitHub release asset, and its SHA-256
was verified against a fresh download of that asset
(`F74549A2...9480E`, 49,869,218 bytes). The same NSIS package is built and
inspected on a clean Windows runner by the project's release pipeline before
the release is published.

Stable Word Hunter 1.1.0: vocabulary import from World of Warcraft quest text
with encounter history, editable saved words, shuffled reviews,
dyslexia-friendly reader fonts, and a considerably faster start on large
libraries.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426199)