### PR TITLE
New version: TechyGeeksHome.DriverGeek version 1.1.0

### DIFF
--- a/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.installer.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.1.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{E1F5AC9E-3E9F-478D-BD69-40D637942B89}_is1'
+ReleaseDate: 2026-08-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/techygeekshome/DriverGeek/releases/download/v1.1.0/DriverGeekSetup.exe
+    InstallerSha256: 92BDD8F33EBEEC8453C93FBE1726386005C550BB9502100090947D38D23D9A8F
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.locale.en-US.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/DriverGeek/issues
+PackageName: DriverGeek
+PackageUrl: https://techygeekshome.info/drivergeek/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/techygeekshome/DriverGeek/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+CopyrightUrl: https://github.com/techygeekshome/DriverGeek/blob/main/LICENSE
+ShortDescription: Lists every driver on a Windows PC, surfaces the updates Windows Update files under Optional, and installs only the ones you tick.
+Description: |-
+  Windows already knows about driver updates you have never been offered. They sit under
+  Settings, Windows Update, Advanced options, Optional updates - four clicks deep, where
+  almost nobody looks. DriverGeek lists every device on the machine with the driver it is
+  actually running, including version, date, provider and whether it is signed, and puts
+  the updates Windows is already holding for you on the same screen.
+
+  Updates come from Windows Update only. DriverGeek does not host drivers, does not scrape
+  vendor sites and does not ship a driver pack.
+
+  It distinguishes a driver with a newer version available from a driver that is merely old,
+  and will tell you plainly when nothing needs doing. There is no "247 issues found", no
+  scan-then-pay, no paid tier and no upsell.
+
+  Installing is opt-in, one device at a time, and never automatic. Before anything is
+  replaced it takes a System Restore point and writes a copy of the driver you are running
+  now to disk, and it stops rather than carries on if either fails. Boot-critical and storage
+  controller drivers are listed and labelled but have no tick box at all.
+
+  No telemetry, no account, no bundled offers. Installs per-user by default, so no admin
+  rights and no UAC prompt to install the app itself. Requires Windows 10 or later, 64-bit.
+Moniker: drivergeek
+Tags:
+  - drivers
+  - driver-updates
+  - windows-update
+  - device-manager
+  - hardware
+  - inventory
+  - system-tools
+  - utility
+ReleaseNotesUrl: https://github.com/techygeekshome/DriverGeek/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.yaml
+++ b/manifests/t/TechyGeeksHome/DriverGeek/1.1.0/TechyGeeksHome.DriverGeek.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.DriverGeek
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

TechyGeeksHome.DriverGeek 1.1.0.

This supersedes #425978, which was opened for 1.0.2 a few hours before 1.1.0 was released. I am closing that PR so there is one current manifest per package.

Changes since the 1.0.2 manifest:

- New installer URL and SHA-256 for the v1.1.0 release.
- `ShortDescription` and `Description` corrected. The 1.0.2 text said the app links to a manufacturer's support page for hardware Windows Update does not cover. That feature does not exist in the application, and the claim has now been removed from the project README as well.
- The description reflects that 1.1.0 can install an update the user ticks, where 1.0.x only reported.

`ProductCode` is unchanged: the Inno Setup `AppId` is fixed across versions by design.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`

The last two are unticked deliberately rather than overlooked — this manifest was prepared without a Windows host to run `winget validate` on. What was done instead: the installer was downloaded from the release and its SHA-256 checked against the release's own `SHA256SUMS.txt`, the three files were parsed and checked against the 1.12.0 manifest shape, and the `ProductCode` was read from the Inno Setup script in the source repository rather than guessed. Happy to correct anything the validation pipeline flags.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426205)