### PR TITLE
New version: TechyGeeksHome.UltimateSettingsPanel version 8.0.4

### DIFF
--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.4
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: Ultimate Settings Panel.exe
+    PortableCommandAlias: usp
+UpgradeBehavior: install
+ReleaseDate: 2026-08-29
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/download/v8.0.4/Ultimate-Settings-Panel.zip
+    InstallerSha256: 20F59D823894710D8E59F6927BD0B2B5EA955B8ECF52F9C532D7523709FA2F65
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.locale.en-US.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.4
+PackageLocale: en-US
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/issues
+PackageName: Ultimate Settings Panel
+PackageUrl: https://techygeekshome.info/ultimate-settings-panel-online/
+License: Freeware
+LicenseUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+ShortDescription: 250+ Windows settings, tools and commands in one searchable panel - launch or copy any of them in a click.
+Description: |-
+  Ultimate Settings Panel puts more than 250 Windows settings, administrative tools,
+  diagnostics and commands into a single searchable window, so you stop hunting through
+  Settings, Control Panel and half-remembered run commands.
+
+  Search across everything from the top of the window, browse by category, star the entries
+  you use often, and switch between light and dark. Every card has a Run button that launches
+  the tool, setting or command directly, and a Copy button for the underlying command if you
+  would rather paste it somewhere.
+
+  Categories cover Windows 11 settings, Windows tools, Control Panel applets, networking,
+  diagnostics, power and session, server administration, terminal and shell, Outlook and
+  Office, and browsers.
+
+  Portable - a single executable that runs straight from wherever you put it, with nothing
+  to install and no administrator rights required. First released in 2014 and free ever
+  since, with no tiers, no licence fees and no commercial restriction.
+Moniker: usp
+Tags:
+  - windows-settings
+  - system-tools
+  - control-panel
+  - sysadmin
+  - diagnostics
+  - portable
+  - utility
+ReleaseNotesUrl: https://github.com/techygeekshome/Ultimate-Settings-Panel/releases/tag/v8.0.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.yaml
+++ b/manifests/t/TechyGeeksHome/UltimateSettingsPanel/8.0.4/TechyGeeksHome.UltimateSettingsPanel.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: TechyGeeksHome.UltimateSettingsPanel
+PackageVersion: 8.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

TechyGeeksHome.UltimateSettingsPanel 8.0.4.

This supersedes #418623, which was opened for 8.0.0. I am closing that one so there is a single current manifest for this package.

Same packaging as 8.0.0 - a zip carrying a portable executable, installed via `NestedInstallerType: portable` with the `usp` command alias. Only the version, the installer URL, the SHA-256, the release date and the release notes link have moved. `LicenseUrl` has been added.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`

The last two are unticked deliberately rather than overlooked - this manifest was prepared without a Windows host to run `winget validate` on. What was done instead: the zip was downloaded from the release and its SHA-256 checked against the release's own `SHA256SUMS.txt`, its contents listed to confirm `Ultimate Settings Panel.exe` sits at the archive root exactly as `RelativeFilePath` states, and the three files were parsed and checked against the 1.12.0 manifest shape. Happy to correct anything the validation pipeline flags.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426207)