### PR TITLE
New version: Feci.ParleyDeckCli version 1.47.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.47.0
+InstallerType: portable
+Commands:
+- parley
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.47.0/parley-v1.47.0-windows-x64.exe
+  InstallerSha256: BD801939F32A207B4BE341E08E1887029A66AD48E292FC32840604D3EE903F77
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-cli/releases/download/v1.47.0/parley-v1.47.0-windows-arm64.exe
+  InstallerSha256: 12B64DF961A0F5F702D11619D095452DA0D53939F0480F9993AC97231E7ACBA6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.47.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck CLI
+PackageUrl: https://github.com/feci/parley-deck-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-cli/blob/main/LICENSE
+ShortDescription: Orchestrates Parley Deck multi-agent cooperation workflows across local CLI agents.
+Description: "Runs multi-agent design, implementation and review rounds across locally installed AI agent CLIs, keeping the cooperation trail in a repository-local directory. Release 1.47.0 makes the protocol ask, before anything is designed, what already exists. Every round-1 artifact now carries an Existing alternatives section that enumerates the mechanisms a proposal builds by hand and, for each one, names what the toolchain, standard library, dependencies or platform already ships. A scoped null result is legal and must name the sources consulted, because a recorded search can be argued with while an unexamined absence cannot. The form is deliberate rather than stylistic. An open-ended instruction to consider alternatives is measured not to work, whereas naming the specific items to check does. The rule is carried by the round-1 prompt and enforced by the runtime validator, so a bare heading or a passing mention in prose does not satisfy it. Design rounds previously had no artifact validator at all, unlike review rounds, which meant an agent process could exit successfully having written nothing. They have one now. The correlated-agreement section it replaces was conditional and excluded the mechanically decidable work it was most needed for. It is now unconditional and binds every track, and the section is smaller than the text it replaced."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-cli/releases/tag/v1.47.0
+Tags:
+- agents
+- ai
+- cli
+- codex
+- claude
+- multi-agent
+- orchestration
+- protocol
+- review
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.yaml
+++ b/manifests/f/Feci/ParleyDeckCli/1.47.0/Feci.ParleyDeckCli.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckCli
+PackageVersion: 1.47.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckCli 1.47.0.

- Portable installer, x64 and arm64, published as assets on the upstream GitHub release.
- Description is quoted, so no colon-space sequence can break the locale manifest.
- One application per pull request; the companion skill package is submitted separately.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426220)