### PR TITLE
New version: Feci.ParleyDeckSkill version 2.11.0

### DIFF
--- a/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.installer.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.11.0
+InstallerType: portable
+Commands:
+- parley-deck-skill
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.11.0/parley-deck-skill-v2.11.0-windows-x64.exe
+  InstallerSha256: 09CAA3C7CB7BFDA34C8E25F04A61C03255F3DAF3AF57268E0E3943CBD8EC997F
+- Architecture: arm64
+  InstallerUrl: https://github.com/feci/parley-deck-skill/releases/download/v2.11.0/parley-deck-skill-v2.11.0-windows-arm64.exe
+  InstallerSha256: 888EFE35A5FCA79D36C65AE21AA37C25C4723180A32EFF11AB89AC513A299B46
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.locale.en-US.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.11.0
+PackageLocale: en-US
+Publisher: Feci
+PublisherUrl: https://github.com/feci
+PackageName: Parley Deck Skill
+PackageUrl: https://github.com/feci/parley-deck-skill
+License: Apache-2.0
+LicenseUrl: https://github.com/feci/parley-deck-skill/blob/main/LICENSE
+ShortDescription: Installer for the Parley Deck multi-agent cooperation skill.
+Description: "Installs the vendor-neutral Parley Deck AI cooperation skill into Codex, Claude Code, zcode, Antigravity CLI, Hermes, Kimi Code, or a custom skill directory. Release 2.11.0 adds an Existing alternatives section to the round-1 participant template, with the instruction the command-line tool now enforces. A participant enumerates the mechanisms a proposal builds by hand and, for each one, names what the toolchain, standard library, dependencies or platform already ships, marking each load-bearing element as forced by a constraint or merely inherited. A scoped null result is legal and must name the sources consulted. This closes a drift between the two halves of the project. Parley Deck CLI 1.47.0 rejects a round-1 artifact whose section is missing or empty, so a skill older than this one produces work the tool refuses. The bundled protocol snapshot carries the matching unconditional section and the corrected per-track binding row, keeping the third copy of the protocol in step with the two the drift guard covers, which is a copy that went stale twice during this change because nothing checks that the two repositories move together."
+ReleaseNotesUrl: https://github.com/feci/parley-deck-skill/releases/tag/v2.11.0
+Tags:
+- ai
+- agents
+- agy
+- antigravity
+- cli
+- codex
+- claude
+- kimi
+- multi-agent
+- skill
+- zcode
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.yaml
+++ b/manifests/f/Feci/ParleyDeckSkill/2.11.0/Feci.ParleyDeckSkill.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Feci.ParleyDeckSkill
+PackageVersion: 2.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Feci.ParleyDeckSkill 2.11.0.

- Portable installer, x64 and arm64, published as assets on the upstream GitHub release.
- Description is quoted, so no colon-space sequence can break the locale manifest.
- One application per pull request; the companion CLI package is submitted separately.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426221)