### PR TITLE
New package: AtikShahriar.AgentDeck version 0.3.1

### DIFF
--- a/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.installer.yaml
+++ b/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: AtikShahriar.AgentDeck
+PackageVersion: 0.3.1
+InstallerLocale: en-US
+InstallerType: exe
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: "--silent"
+  SilentWithProgress: "--silent"
+ElevationRequirement: elevationProhibited
+UpgradeBehavior: install
+ReleaseDate: 2026-08-30
+AppsAndFeaturesEntries:
+  - DisplayName: AgentDeck
+    DisplayVersion: 0.3.1
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/atik806/AgentDeck/releases/download/v0.3.1/AgentDeck-win-Setup.exe
+    InstallerSha256: 7EC40B553A903DAC13811FE4A2442912CAED580857C7CA817F29A37613C1F3DE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.locale.en-US.yaml
+++ b/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: AtikShahriar.AgentDeck
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Atik Shahriar
+PublisherUrl: https://github.com/atik806
+PublisherSupportUrl: https://github.com/atik806/AgentDeck/issues
+PackageName: AgentDeck
+PackageUrl: https://github.com/atik806/AgentDeck
+License: MIT
+LicenseUrl: https://github.com/atik806/AgentDeck/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Atik Shahriar
+ShortDescription: A Windows multi-terminal panel where each workspace runs the coding agent of its choice.
+Description: |-
+  AgentDeck is a Windows multi-terminal panel that puts every shell in one window
+  as a real ConPTY pane, with each workspace running the coding agent of its
+  choice (Claude Code, Codex, Gemini CLI, Copilot CLI, Aider, and more). It adds
+  a workspace sidebar, drag-and-drop of file paths into panes, an offline
+  voice-to-text overlay (whisper.cpp), and in-app self-updates.
+Moniker: agentdeck
+Tags:
+  - terminal
+  - console
+  - developer-tools
+  - ai
+  - cli
+  - productivity
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.yaml
+++ b/manifests/a/AtikShahriar/AgentDeck/0.3.1/AtikShahriar.AgentDeck.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: AtikShahriar.AgentDeck
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `AtikShahriar.AgentDeck` version `0.3.1`

- AgentDeck — a Windows multi-terminal panel; each workspace runs a coding agent of its choice.
- Homepage: https://github.com/atik806/AgentDeck
- Installer: per-user Velopack `Setup.exe` (`--silent`), installs to `%LOCALAPPDATA%\AgentDeck`, no elevation.
- License: MIT.

Manifest validated locally with `winget validate` (v1.29). The installer is not code-signed yet, so automated sandbox validation may need a manual check.

#### Checklist
- [x] Manifest follows the 1.6.0 schema and `winget validate` passes.
- [x] Installer URL is a stable release asset with a matching SHA256.
- [x] I am the package owner / publisher.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426223)