### PR TITLE
New version: PLFJY.ContextMenuMgrPlus.Beta version 1.7.5-beta.20260829195439

### DIFF
--- a/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.installer.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.installer.yaml
@@ -1,0 +1,26 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus.Beta'
+PackageVersion: '1.7.5-beta.20260829195439'
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /NORESTART
+  SilentWithProgress: /SILENT /NORESTART
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5-Beta+c5e9732/ContextMenuMgrPlus-1.7.5-Beta+c5e9732-x64-self-contained-Setup.exe
+  InstallerSha256: 862ba88727ada339863e002d54a1feb218dfd643fc21a0a8b26c88f17a4a6ecd
+- Architecture: x86
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5-Beta+c5e9732/ContextMenuMgrPlus-1.7.5-Beta+c5e9732-x86-self-contained-Setup.exe
+  InstallerSha256: 1ac272dcdcc09a233ea7c03a0286c09fd4fe991a0cb6ba11442f33d9bef6286d
+- Architecture: arm64
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5-Beta+c5e9732/ContextMenuMgrPlus-1.7.5-Beta+c5e9732-arm64-self-contained-Setup.exe
+  InstallerSha256: d72f1f946a15421cb6bc3112e9edfac31235fd79e06b6345a20b43eea1100e8c
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.en-US.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus.Beta'
+PackageVersion: '1.7.5-beta.20260829195439'
+PackageLocale: en-US
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'Beta channel for Context Menu Manager Plus.'
+Description: 'Context Menu Manager Plus Beta is a prerelease channel for validating new context menu management features and fixes. It may contain regressions. Stable and Beta are mutually exclusive channels; installing one replaces the other.'
+Tags:
+- 'context-menu'
+- 'windows'
+- 'shell'
+- 'registry'
+- 'wpf'
+- 'beta'
+- 'prerelease'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5-Beta+c5e9732
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.zh-CN.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.zh-CN.yaml
@@ -1,0 +1,27 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus.Beta'
+PackageVersion: '1.7.5-beta.20260829195439'
+PackageLocale: zh-CN
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'Context Menu Manager Plus 的 Beta 渠道版本。'
+Description: 'Context Menu Manager Plus Beta 用于提前验证新的右键菜单管理功能和修复，可能包含回归问题。Stable 和 Beta 是互斥渠道，安装一个会替换另一个。'
+Tags:
+- '右键菜单'
+- '上下文菜单'
+- 'Windows'
+- 'Shell'
+- '注册表'
+- 'WPF'
+- 'Beta'
+- '预发布'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5-Beta+c5e9732
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.zh-TW.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.locale.zh-TW.yaml
@@ -1,0 +1,27 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus.Beta'
+PackageVersion: '1.7.5-beta.20260829195439'
+PackageLocale: zh-TW
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'Context Menu Manager Plus 的 Beta 渠道版本。'
+Description: 'Context Menu Manager Plus Beta 用於提前驗證新的右鍵選單管理功能和修復，可能包含回歸問題。Stable 和 Beta 是互斥渠道，安裝一個會替換另一個。'
+Tags:
+- '右鍵選單'
+- '內容選單'
+- 'Windows'
+- 'Shell'
+- '登錄檔'
+- 'WPF'
+- 'Beta'
+- '預發布'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5-Beta+c5e9732
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/Beta/1.7.5-beta.20260829195439/PLFJY.ContextMenuMgrPlus.Beta.yaml
@@ -1,0 +1,8 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus.Beta'
+PackageVersion: '1.7.5-beta.20260829195439'
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Generated from PLFJY/ContextMenuMgr release v1.7.5-Beta+c5e9732.

Stable and Beta are mutually exclusive channels and share the same installer AppId and service identity intentionally.

The Beta package-manager channel only tracks GitHub Pre-releases. Stable GitHub Releases do not generate or update this Beta manifest. For Beta prereleases the package version is derived from the GitHub Release publish time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426230)