### PR TITLE
New version: kaanreal.Henkan version 1.6.1

### DIFF
--- a/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.installer.yaml
+++ b/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.installer.yaml
@@ -11,6 +11,17 @@ InstallerSwitches:
   Silent: /S
   SilentWithProgress: /S
 UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: Henkan
+    DisplayVersion: 1.6.1
+    Publisher: henkan
+    InstallerType: nullsoft
+InstallationMetadata:
+  DefaultInstallLocation: '%LOCALAPPDATA%\Henkan'
+  Files:
+    - RelativeFilePath: Henkan.exe
+      FileType: launch
+      DisplayName: Henkan
 ReleaseDate: 2026-08-23
 Installers:
   - Architecture: x64

--- a/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.installer.yaml
+++ b/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: kaanreal.Henkan
+PackageVersion: 1.6.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-23
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kaanreal/henkan/releases/download/v1.6.1/Henkan-v1.6.1-windows-setup.exe
+    InstallerSha256: C5B5AC615190BBF2B9AEE3C331DD62667BD84A933C4EBBC710BD350F16B4265B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.locale.en-US.yaml
+++ b/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.locale.en-US.yaml
@@ -7,7 +7,7 @@ PublisherUrl: https://github.com/kaanreal
 PublisherSupportUrl: https://github.com/kaanreal/henkan/issues
 Author: kaanreal
 PackageName: Henkan
-PackageUrl: https://henkan.app/
+PackageUrl: https://henkan.kaanreal.me/
 License: MIT
 LicenseUrl: https://github.com/kaanreal/henkan/blob/main/LICENSE
 Copyright: Copyright (c) 2026 kaanreal

--- a/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.locale.en-US.yaml
+++ b/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: kaanreal.Henkan
+PackageVersion: 1.6.1
+PackageLocale: en-US
+Publisher: kaanreal
+PublisherUrl: https://github.com/kaanreal
+PublisherSupportUrl: https://github.com/kaanreal/henkan/issues
+Author: kaanreal
+PackageName: Henkan
+PackageUrl: https://henkan.app/
+License: MIT
+LicenseUrl: https://github.com/kaanreal/henkan/blob/main/LICENSE
+Copyright: Copyright (c) 2026 kaanreal
+ShortDescription: Convert osu!mania maps and skins to and from Etterna and StepMania.
+Description: Henkan is a cross-platform desktop and CLI tool for converting maps and skins between osu!mania and Etterna or StepMania while preserving timing, BPM changes, holds, metadata, and snapping.
+Moniker: henkan
+Tags:
+  - beatmap
+  - converter
+  - etterna
+  - osu-mania
+  - rhythm-game
+  - stepmania
+  - vsrg
+ReleaseNotesUrl: https://github.com/kaanreal/henkan/releases/tag/v1.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.yaml
+++ b/manifests/k/kaanreal/Henkan/1.6.1/kaanreal.Henkan.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: kaanreal.Henkan
+PackageVersion: 1.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds Henkan 1.6.1 from the upstream GitHub release. The manifest validates with Windows Package Manager 1.29.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426239)