### PR TITLE
Update version: BlackwellSystems.agent-lsp version 0.19.0

### DIFF
--- a/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.installer.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.19.0
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: agent-lsp.exe
+  PortableCommandAlias: agent-lsp
+ReleaseDate: 2026-08-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.19.0/agent-lsp_windows_amd64.zip
+  InstallerSha256: 875192AFC8610673C0FE32DEC126E791B01E32F56AF2607E90BBB3E5B7A28E42
+- Architecture: arm64
+  InstallerUrl: https://github.com/blackwell-systems/agent-lsp/releases/download/v0.19.0/agent-lsp_windows_arm64.zip
+  InstallerSha256: BA7FE44EFFAADA3A8AFDB93650E1F8D9D7BEEB9CC0637529A4A8CF5D82A39E2F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.locale.en-US.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.19.0
+PackageLocale: en-US
+Publisher: Blackwell Systems
+PublisherUrl: https://github.com/blackwell-systems
+PublisherSupportUrl: https://github.com/blackwell-systems/agent-lsp/issues
+PackageName: agent-lsp
+PackageUrl: https://github.com/blackwell-systems/agent-lsp
+License: MIT
+LicenseUrl: https://github.com/blackwell-systems/agent-lsp/blob/main/LICENSE
+ShortDescription: MCP server giving AI agents reliable access to language server protocol
+Description: agent-lsp is a stateful MCP server over real language servers. It keeps the language server's semantic index warm and adds a skill layer that turns multi-step code operations into single, correct workflows. 50 tools, 30 languages, persistent sessions.
+Tags:
+- ai
+- code-intelligence
+- developer-tools
+- language-server
+- lsp
+- mcp
+ReleaseNotes: |-
+  ### Added
+  • **Custom language routing for unrecognized file extensions** ([#21](https://github.com/blackwell-systems/agent-lsp/pull/21))：a file whose extension is not in the built-in list now routes to a matching configured server instead of silently falling back to `plaintext`, so it gets full hover, diagnostics, definition, and references. Extension-based routing takes priority over the current client in multi-server mode, and tool handlers no longer hardcode `plaintext`. This enables **Luau** (`luau-lsp`) as a first-class, CI-exercised language. Contributed by [@fluffy-den](https://github.com/fluffy-den). Closes #19, #20.
+
+  ### Fixed
+  • **macOS auto-watcher file-descriptor exhaustion** ([#18](https://github.com/blackwell-systems/agent-lsp/issues/18))：the always-on auto-watcher walked the whole workspace and, because the fsnotify kqueue backend opens one fd per file in every watched directory, a tree containing large data/cache directories (browser profiles, leveldb, caches) could grow to hundreds of thousands of fds, peg `kern.maxfilesperproc`, and exhaust the system-wide file table (machine-wide `ENFILE`). The watcher is now bounded two ways. **At startup** it skips any single directory larger than `AGENT_LSP_WATCH_MAX_DIR_ENTRIES` (default 2048) and stops once total watched entries exceed `AGENT_LSP_WATCH_MAX_ENTRIES` (default 50000), applied to the initial walk, workspace-folder extension, and runtime directory creation. **At runtime** a guard samples the process's open-fd count every 30s and tears the watcher down if it exceeds `AGENT_LSP_WATCH_MAX_FDS` (default 60000), catching descriptors fsnotify opens for files *created while the watcher runs* (which the startup budget cannot see). `AGENT_LSP_DISABLE_WATCHER=1` turns the watcher off entirely. (FSEvents would avoid per-file fds outright, but it requires cgo and would break the project's `CGO_ENABLED=0` cross-compiled release; the runtime guard is the pure-Go equivalent.) Reported by [@ratacat](https://github.com/ratacat).
+ReleaseNotesUrl: https://github.com/blackwell-systems/agent-lsp/releases/tag/v0.19.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.yaml
+++ b/manifests/b/BlackwellSystems/agent-lsp/0.19.0/BlackwellSystems.agent-lsp.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: BlackwellSystems.agent-lsp
+PackageVersion: 0.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update BlackwellSystems.agent-lsp to version 0.19.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426242)