### PR TITLE
Update version: GolangCI.golangci-lint version 2.13.2

### DIFF
--- a/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.installer.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.2-windows-386/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-windows-386.zip
+  InstallerSha256: 15CAD8E2347D91B259095C29C589B53BAAF051893A7B4B44861CAD09A3069E2E
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.2-windows-amd64/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-windows-amd64.zip
+  InstallerSha256: 4735FDC8E84A0CFB7A15A1C364A650942F88215E0D36C674EBC4024F7B554524
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: golangci-lint-2.13.2-windows-arm64/golangci-lint.exe
+  InstallerUrl: https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-windows-arm64.zip
+  InstallerSha256: 2DBFFBD1225D41AC5740F0B478A43B6517F3E3F702FE0AB3AEC470BD6EC8E263
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.locale.en-US.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.2
+PackageLocale: en-US
+Publisher: GolangCI
+PublisherUrl: https://golangci-lint.run/
+PublisherSupportUrl: https://github.com/golangci/golangci-lint/issues
+PackageName: golangci-lint
+PackageUrl: https://github.com/golangci/golangci-lint
+License: GPL-3.0
+LicenseUrl: https://github.com/golangci/golangci-lint/blob/HEAD/LICENSE
+ShortDescription: Fast linters Runner for Go
+Description: golangci-lint is a fast Go linters runner. It runs linters in parallel, uses caching, supports YAML configuration, integrates with all major IDEs, and includes over a hundred linters.
+Tags:
+- ci
+- go
+- golang
+- golangci-lint
+- linter
+ReleaseNotes: |-
+  `golangci-lint` is a free and open-source project built by volunteers.
+
+  If you value it, consider supporting us, the [maintainers](https://donate.golangci.org) and [linter authors](https://golangci-lint.run/docs/product/thanks/).
+
+  We appreciate it! :heart:
+
+  For key updates, see the [changelog](https://golangci-lint.run/docs/product/changelog/#2132).
+
+  ## Changelog
+  • f34e0bb6c3f4a48513018de81894f5bca1e186c1 build(deps)：bump docker/setup-buildx-action from 4.2.0 to 4.3.0 in the github-actions group (#6758)
+  • 9af7a1866c0b3b4f43d6d7cb0fba860c4cf615e8 build(deps)：bump github.com/stretchr/testify from 1.12.0 to 1.12.1 in /scripts/gen_github_action_config in the scripts group (#6757)
+  • 1b907273167eec8b3d84cae636b7798ced4433d5 build(deps)：bump github.com/uudashr/iface from 1.5.0 to 1.5.1 (#6749)
+  • 6fb5dee3889d231640dce56e5e71c522f13aef7e build(deps)：bump honnef.co/go/tools from 0.8.0 to 0.8.1 (#6748)
+  • 03da382d2ffa23d706253c9a6061a3ad84482b7a build(deps)：bump mvdan.cc/unparam to 2fa3d841b0c8 (#6756)
+  • c2bc9bf4762d8c7b267ba852d5fca450445fe5a5 build(deps)：github.com/lasiar/canonicalheader from v1.1.2 to a fork (#6761)
+  • 61b35d627783c92193f55a477fb4cb3c2d00a83b fix：decrease cache entropy (#6762)
+ReleaseNotesUrl: https://github.com/golangci/golangci-lint/releases/tag/v2.13.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.yaml
+++ b/manifests/g/GolangCI/golangci-lint/2.13.2/GolangCI.golangci-lint.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: GolangCI.golangci-lint
+PackageVersion: 2.13.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update GolangCI.golangci-lint to version 2.13.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426245)