### PR TITLE
New version: Mun1to.winshotx version 0.2.10

### DIFF
--- a/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.installer.yaml
+++ b/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: Mun1to.winshotx
+PackageVersion: 0.2.10
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-30
+AppsAndFeaturesEntries:
+  - DisplayName: winshotx
+    Publisher: munir
+    ProductCode: winshotx
+    InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Mun1to/winshotx/releases/download/v0.2.10/winshotx_0.2.10_x64-setup.exe
+    InstallerSha256: A524E687408EDBACA8FADA913A68BC8B8D65175645CF124DD73BBA3204759948
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.locale.en-US.yaml
+++ b/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.locale.en-US.yaml
@@ -1,0 +1,50 @@
+PackageIdentifier: Mun1to.winshotx
+PackageVersion: 0.2.10
+PackageLocale: en-US
+Publisher: Munir Torres
+PublisherUrl: https://munito.dev
+PublisherSupportUrl: https://github.com/Mun1to/winshotx/issues
+Author: Munir Torres
+PackageName: winshotx
+PackageUrl: https://github.com/Mun1to/winshotx
+License: MIT
+LicenseUrl: https://github.com/Mun1to/winshotx/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Munir Torres
+ShortDescription: Screenshots and GIF/MP4 screen recording for Windows, in a 2.3 MB installer.
+Description: |-
+  winshotx is a free and open source screenshot and screen recording tool for Windows 10 and 11,
+  a lightweight alternative to the built-in Snipping Tool. It captures a region over a frozen
+  screenshot with a 6x pixel magnifier that shows the exact colour in hex and copies it with one
+  key, snaps to system windows, and records that region to GIF or MP4 at 15, 30 or 60 fps through
+  Windows Graphics Capture. The editor trims the recording frame by frame with A and B marks,
+  crops the image, annotates it with arrows, boxes, text, highlights and a mosaic that hides
+  private details, and exports to GIF, MP4, PNG or JPG, to disk or to the clipboard.
+  It can also keep what just happened: with the replay ring on, winshotx records all the time and
+  drops the old, so one key saves the last 15, 30 or 60 seconds straight into the editor without
+  stopping the recording.
+  Nothing is downloaded at runtime: MP4 is written by Media Foundation in hardware, the GIF
+  encoder is pure Rust and the text recognition is the one Windows already ships, so there is no
+  bundled FFmpeg and no OCR engine to install. It installs for the current user only, so it never
+  asks for administrator rights, and it lives in the system tray with no window of its own. There
+  is no account, no telemetry and no uploads.
+  The interface is in English and Spanish, following Windows.
+Moniker: winshotx
+Tags:
+  - screenshot
+  - screen-capture
+  - screen-recorder
+  - screen-recording
+  - gif
+  - gif-recorder
+  - mp4
+  - snipping-tool
+  - screenshot-tool
+  - rust
+  - tauri
+  - open-source
+ReleaseNotesUrl: https://github.com/Mun1to/winshotx/releases/tag/v0.2.10
+Documentations:
+  - DocumentLabel: Home page
+    DocumentUrl: https://winshotx.com/en/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.yaml
+++ b/manifests/m/Mun1to/winshotx/0.2.10/Mun1to.winshotx.yaml
@@ -1,0 +1,6 @@
+# Created using the manifest schema, by hand.
+PackageIdentifier: Mun1to.winshotx
+PackageVersion: 0.2.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Automatic update of an already published package. The installer is the signed release asset from https://github.com/Mun1to/winshotx/releases/tag/v0.2.10 and `winget validate` passes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426260)