### PR TITLE
New version: yanqirenshi.yaoyorozu version 0.1.0

### DIFF
--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.installer.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 PackageIdentifier: yanqirenshi.yaoyorozu
 PackageVersion: 0.1.0
 InstallerLocale: en-US

--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.installer.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: yanqirenshi.yaoyorozu
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+InstallerType: msi
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/yanqirenshi/yaoyorozu/releases/download/v0.1.0/YAOYOROZU_0.1.0_x64_en-US.msi
+    InstallerSha256: 1598D3157AD65A38E8ECF18C934FCA21083A0DB67733FCE4458EE782548D8FFA
+    ProductCode: '{F318AD0F-8CD8-4B03-BB8C-1C9681DC01CE}'
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.locale.en-US.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: yanqirenshi.yaoyorozu
 PackageVersion: 0.1.0
 PackageLocale: en-US

--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.locale.en-US.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: yanqirenshi.yaoyorozu
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: yanqirenshi
+PublisherUrl: https://github.com/yanqirenshi
+PackageName: YAOYOROZU
+PackageUrl: https://github.com/yanqirenshi/yaoyorozu
+License: Proprietary
+LicenseUrl: https://github.com/yanqirenshi/yaoyorozu/blob/main/LICENSE
+Copyright: Copyright (c) 2026 yanqirenshi
+ShortDescription: Session viewer and AI agent integration desktop app for Claude Code
+Moniker: yaoyorozu
+Tags:
+  - claude
+  - claude-code
+  - ai
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: yanqirenshi.yaoyorozu
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.yaml
+++ b/manifests/y/yanqirenshi/yaoyorozu/0.1.0/yanqirenshi.yaoyorozu.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 PackageIdentifier: yanqirenshi.yaoyorozu
 PackageVersion: 0.1.0
 DefaultLocale: en-US


### PR DESCRIPTION
## Description

Initial submission of YAOYOROZU (`yanqirenshi.yaoyorozu`), a session viewer and AI agent integration desktop app for Claude Code.

- InstallerType: msi
- Scope: machine (per MSI ALLUSERS=1)
- ProductCode and installer SHA256 were extracted directly from the published MSI (GitHub Release [v0.1.0](https://github.com/yanqirenshi/yaoyorozu/releases/tag/v0.1.0))
- Unsigned installer (SmartScreen warning is expected)

## Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (pending — will complete via the CLA bot's prompt on this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (ran locally: "マニフェストの検証は成功しました" / manifest validation succeeded, no warnings)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (the exact published MSI was installed and uninstalled directly on the maintainer's machine, confirming install/uninstall work correctly)
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)? (confirmed via `winget validate`, which passed cleanly)