### PR TITLE
New version: AurelioAvila.PCTweaker version 1.5.0

### DIFF
--- a/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.installer.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.5.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/download/v1.5.0/pc-tweaker-app_1.5.0_x64-setup.exe
+  InstallerSha256: 188D5BC64F6D78DB8F6DF8C778958369455FBBF2898BA7F3B6DB32A7249CE14E
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-30

--- a/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/pc-tweaker-app/issues
+PackageName: PC Tweaker
+PackageUrl: https://github.com/AurelioAvila/pc-tweaker-app
+License: Proprietary
+ShortDescription: Desktop app for Windows that applies performance, privacy, gaming and maintenance tweaks with automatic one-click rollback.
+Description: PC Tweaker applies real Windows system tweaks (registry, power plan, network DNS, temp file cleanup) across Performance, Privacy, Gaming and Maintenance categories. Every change saves a snapshot of the previous value before it's applied, so any tweak can be reverted with one click. Also reads live hardware temperatures, load and power draw, inventories installed drivers, and includes in-app auto-update.
+Tags:
+- windows
+- performance
+- tweak
+- optimizer
+- gaming
+- privacy
+ReleaseNotesUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.5.0/AurelioAvila.PCTweaker.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with Manifest Version 1.12.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

`winget validate` passes. `winget install --manifest` was not run because this machine does not have `LocalManifestFiles` enabled; instead the published installer was run directly with the `/S` switch the manifest declares, which exited 0, registered as `pc-tweaker-app 1.5.0`, and launched correctly. The `InstallerSha256` was computed from the asset downloaded over the `InstallerUrl` in this manifest and matches the locally built installer byte for byte.

Release: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.5.0