### PR TITLE
New package: KalyteraSystems.IPCamLapse version 0.4.4

### DIFF
--- a/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.installer.yaml
+++ b/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KalyteraSystems.IPCamLapse
+PackageVersion: 0.4.4
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- IPCamLapse
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Gyan.FFmpeg.Essentials
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: IPCamLapse.exe
+    PortableCommandAlias: IPCamLapse
+  InstallerUrl: https://github.com/KalyteraSystems/IPCamLapse/releases/download/v0.4.4/IPCamLapse-v0.4.4-win-x64.zip
+  InstallerSha256: 55B0D5E5DEB31D0FE193A322AA8D3FA7EF45D481FAD108E036ADCA17E329B4E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.locale.en-US.yaml
+++ b/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KalyteraSystems.IPCamLapse
+PackageVersion: 0.4.4
+PackageLocale: en-US
+Publisher: Kalytera Systems
+PublisherUrl: https://kalyterasystems.com
+PublisherSupportUrl: https://github.com/KalyteraSystems/IPCamLapse/issues
+Author: Kalytera Systems contributors
+PackageName: IPCamLapse
+PackageUrl: https://github.com/KalyteraSystems/IPCamLapse
+License: Apache-2.0
+LicenseUrl: https://github.com/KalyteraSystems/IPCamLapse/blob/v0.4.4/LICENSE
+ShortDescription: Turn IP camera snapshots into local timelapse videos.
+Description: IPCamLapse is a local-first application for scheduled IP camera capture, timeline review, and H.264 timelapse rendering. It includes a hardware-free demo camera and keeps camera data on the user's machine.
+Moniker: ipcamlapse
+Tags:
+- camera
+- ffmpeg
+- ip-camera
+- security
+- timelapse
+- video
+ReleaseNotes: Adds an activity-log download, Linux ARM64 release archive, hardened maintenance workflows, and persistent container credential-protection keys.
+ReleaseNotesUrl: https://github.com/KalyteraSystems/IPCamLapse/releases/tag/v0.4.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.yaml
+++ b/manifests/k/KalyteraSystems/IPCamLapse/0.4.4/KalyteraSystems.IPCamLapse.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KalyteraSystems.IPCamLapse
+PackageVersion: 0.4.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds IPCamLapse 0.4.4 as a new x64 portable package. The manifest uses the immutable GitHub release archive and installs FFmpeg Essentials as a package dependency for H.264 rendering.

The portable layout was smoke-tested locally before submission: clean manifest install, dependency installation, command-alias launch from an unrelated working directory, UI and CSS delivery, the system health endpoint, persistent user-data placement, and unattended uninstall. Version 0.4.4 keeps that layout; its manifest was validated again against the current release asset, and the repository's automated installation checks are running on the updated head.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for a routine new manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Tested the portable install and launch flow locally
- [x] Manifest conforms to the 1.12 schema

### Additional validation

- Installer SHA-256: `55B0D5E5DEB31D0FE193A322AA8D3FA7EF45D481FAD108E036ADCA17E329B4E7`
- The digest matches GitHub's immutable v0.4.4 release-asset digest
- The WinGet alias served `/`, `/css/site.css`, and `/api/system/health` during the package smoke test
- `Gyan.FFmpeg.Essentials` installed and registered its command aliases

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426412)