### PR TITLE
New package: AnimeshSharma.anime-sh version 0.2.66

### DIFF
--- a/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.installer.yaml
+++ b/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.installer.yaml
@@ -4,6 +4,9 @@ InstallerType: portable
 Commands:
   - anime
 ReleaseDate: 2026-08-30
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: shinchiro.mpv
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/Anime123450/anime-sh/releases/download/v0.2.66/anime-sh-0.2.66-windows-x64.exe

--- a/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.installer.yaml
+++ b/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: AnimeshSharma.anime-sh
+PackageVersion: 0.2.66
+InstallerType: portable
+Commands:
+  - anime
+ReleaseDate: 2026-08-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Anime123450/anime-sh/releases/download/v0.2.66/anime-sh-0.2.66-windows-x64.exe
+    InstallerSha256: a92aefc0f7a1baa24dd6ae572ef9d9a6453a70d2cd0c2f03f1f0f8c775d9d86f
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.locale.en-US.yaml
+++ b/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: AnimeshSharma.anime-sh
+PackageVersion: 0.2.66
+PackageLocale: en-US
+Publisher: Animesh Sharma
+PublisherUrl: https://github.com/Anime123450
+PackageName: anime-sh
+PackageUrl: https://github.com/Anime123450/anime-sh
+License: MIT
+LicenseUrl: https://github.com/Anime123450/anime-sh/blob/master/LICENSE
+ShortDescription: The terminal-native anime client - providers, mirrors and resolvers, handled for you.
+Description: >-
+  anime-sh finds a show, picks a working source and plays it in mpv, from the
+  terminal. It tracks what you have watched, resumes where you stopped, and can
+  sync progress with AniList. Sources are plugins, so a site going down does not
+  take the app with it.
+
+  Playing anything needs mpv on PATH. Downloading needs ffmpeg. Neither is
+  bundled - run `anime doctor` and it will tell you what is missing and the
+  command to install it.
+Moniker: anime-sh
+Tags:
+  - anime
+  - cli
+  - tui
+  - terminal
+  - streaming
+  - anilist
+  - mpv
+ReleaseNotesUrl: https://github.com/Anime123450/anime-sh/blob/master/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.yaml
+++ b/manifests/a/AnimeshSharma/anime-sh/0.2.66/AnimeshSharma.anime-sh.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: AnimeshSharma.anime-sh
+PackageVersion: 0.2.66
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

`AnimeshSharma.anime-sh` version **0.2.66** — a terminal-native anime client. It finds a show, picks a working source and plays it in mpv, from the command line.

- Repository: https://github.com/Anime123450/anime-sh
- License: MIT
- Installer: a single self-contained executable (`InstallerType: portable`), published as a GitHub release asset.

### Checklist

- [x] Manifest validated locally: `winget validate --manifest` → **Manifest validation succeeded**.
- [x] Conforms to manifest schema **1.6.0**.
- [x] No other open pull request for this package (it is new).
- [ ] `winget install --manifest` — **not run.** It requires `winget settings --enable LocalManifestFiles` as administrator, which I did not enable.

### What was verified instead

The exact artifact this manifest points at was downloaded from the release URL, checked against the `InstallerSha256` in the manifest, and run on a clean `PATH` (`C:\Windows\System32` only, no Python present):

```
> anime-sh-0.2.66-windows-x64.exe --version
anime-sh 0.2.66
```

The same URL and hash are also served through a Scoop bucket, where an end-to-end `scoop install` verified the download, the checksum and the generated shim.

### Notes for the reviewer

- `Commands` lists only `anime`. The upstream Python package also installs an `anime-sh` alias, but a portable installer accepts a single command.
- The application shells out to `mpv` for playback and `ffmpeg` for downloads. Neither is bundled — mpv is GPL-licensed, so redistributing the binary would carry obligations that declaring a dependency does not. The application's own `doctor` command detects both and prints the command to install them.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426448)