### PR TITLE
New package: JTeixeiraz.Postly version 0.1.0

### DIFF
--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
@@ -1,0 +1,27 @@
+# Manifesto de instalador do Postly para o Windows Package Manager.
+#
+# As três âncoras abaixo são substituídas pelo workflow a cada release:
+#   0.1.0  a versão sem o "v" do nome da tag
+#   https://github.com/JTeixeiraz/Postly/releases/download/v0.1.0/Postly_0.1.0_x64-setup.exe     a URL do instalador na release publicada
+#   390727BCCFC5F03D7A60A0605A124C8E685FB51526300BC23BEB2CC905BEE3FA  o hash do arquivo baixado, calculado no runner
+#
+# Escrever o manifesto à mão em vez de gerar com `wingetcreate new`: aquele
+# comando é interativo e não roda desacompanhado, e o que o CI precisa é
+# exatamente rodar sozinho.
+PackageIdentifier: JTeixeiraz.Postly
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-08-30"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/JTeixeiraz/Postly/releases/download/v0.1.0/Postly_0.1.0_x64-setup.exe
+    InstallerSha256: 390727BCCFC5F03D7A60A0605A124C8E685FB51526300BC23BEB2CC905BEE3FA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
@@ -1,4 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
 # Manifesto de instalador do Postly para o Windows Package Manager.
+#
+# ManifestVersion 1.9.0, e não a 1.12 que o template do pull request cita: o
+# `winget` estável de hoje é o 1.11, e ele recusa o cabeçalho de schema de uma
+# versão que não conhece — "the schema header URL does not match the expected
+# pattern". Verificado no runner do GitHub validando as duas lado a lado.
 #
 # As três âncoras abaixo são substituídas pelo workflow a cada release:
 #   0.1.0  a versão sem o "v" do nome da tag
@@ -24,4 +31,4 @@ Installers:
     InstallerUrl: https://github.com/JTeixeiraz/Postly/releases/download/v0.1.0/Postly_0.1.0_x64-setup.exe
     InstallerSha256: 390727BCCFC5F03D7A60A0605A124C8E685FB51526300BC23BEB2CC905BEE3FA
 ManifestType: installer
-ManifestVersion: 1.12.0
+ManifestVersion: 1.9.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.installer.yaml
@@ -1,20 +1,8 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
-# Manifesto de instalador do Postly para o Windows Package Manager.
-#
-# ManifestVersion 1.9.0, e não a 1.12 que o template do pull request cita: o
-# `winget` estável de hoje é o 1.11, e ele recusa o cabeçalho de schema de uma
-# versão que não conhece — "the schema header URL does not match the expected
-# pattern". Verificado no runner do GitHub validando as duas lado a lado.
-#
-# As três âncoras abaixo são substituídas pelo workflow a cada release:
-#   0.1.0  a versão sem o "v" do nome da tag
-#   https://github.com/JTeixeiraz/Postly/releases/download/v0.1.0/Postly_0.1.0_x64-setup.exe     a URL do instalador na release publicada
-#   390727BCCFC5F03D7A60A0605A124C8E685FB51526300BC23BEB2CC905BEE3FA  o hash do arquivo baixado, calculado no runner
-#
-# Escrever o manifesto à mão em vez de gerar com `wingetcreate new`: aquele
-# comando é interativo e não roda desacompanhado, e o que o CI precisa é
-# exatamente rodar sozinho.
+# Schema 1.9.0 rather than 1.12: the stable winget (1.11) rejects a schema
+# header for a version it does not know, which is what failed validation here.
+
 PackageIdentifier: JTeixeiraz.Postly
 PackageVersion: 0.1.0
 MinimumOSVersion: 10.0.17763.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# A descrição que aparece em `winget show JTeixeiraz.Postly`.
+#
+# Em inglês porque este é o locale padrão do manifesto e o público do winget é
+# internacional; o `pt-BR` vive no arquivo ao lado.
+PackageIdentifier: JTeixeiraz.Postly
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: JTeixeiraz
+PublisherUrl: https://github.com/JTeixeiraz
+PublisherSupportUrl: https://github.com/JTeixeiraz/Postly/issues
+PackageName: Postly
+PackageUrl: https://github.com/JTeixeiraz/Postly
+License: MIT
+LicenseUrl: https://github.com/JTeixeiraz/Postly/blob/main/LICENSE
+Copyright: Copyright (c) 2026 João Teixeira
+ShortDescription: A marketing department that runs on your own machine
+Description: |-
+  Four AI roles take turns on local Ollama models to research the market,
+  create the piece, audit it and publish to your social networks. One model at
+  a time, because four do not fit on an ordinary machine: before each handoff
+  the system measures free memory, loads the strongest model that fits, records
+  the whole conversation and unloads it before the next one starts.
+
+  Nothing leaves your computer except the image generation call and the browser
+  that publishes to your own accounts. No telemetry, no project server, no
+  account to create.
+
+  Requires Ollama, which the app installs on first run.
+Moniker: postly
+Tags:
+  - ai
+  - ollama
+  - llm
+  - local-ai
+  - marketing
+  - social-media
+  - automation
+  - open-source
+  - privacy
+ReleaseNotesUrl: https://github.com/JTeixeiraz/Postly/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
@@ -1,9 +1,5 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
-# A descrição que aparece em `winget show JTeixeiraz.Postly`.
-#
-# Em inglês porque este é o locale padrão do manifesto e o público do winget é
-# internacional; o `pt-BR` vive no arquivo ao lado.
 PackageIdentifier: JTeixeiraz.Postly
 PackageVersion: 0.1.0
 PackageLocale: en-US

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
 # A descrição que aparece em `winget show JTeixeiraz.Postly`.
 #
 # Em inglês porque este é o locale padrão do manifesto e o público do winget é
@@ -39,4 +41,4 @@ Tags:
   - privacy
 ReleaseNotesUrl: https://github.com/JTeixeiraz/Postly/releases
 ManifestType: defaultLocale
-ManifestVersion: 1.12.0
+ManifestVersion: 1.9.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.pt-BR.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.pt-BR.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+
 PackageIdentifier: JTeixeiraz.Postly
 PackageVersion: 0.1.0
 PackageLocale: pt-BR
@@ -21,6 +23,5 @@ Description: |-
   projeto, sem conta para criar.
 
   Precisa do Ollama, que o aplicativo instala na primeira abertura.
-Moniker: postly
 ManifestType: locale
-ManifestVersion: 1.12.0
+ManifestVersion: 1.9.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.pt-BR.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.locale.pt-BR.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: JTeixeiraz.Postly
+PackageVersion: 0.1.0
+PackageLocale: pt-BR
+Publisher: JTeixeiraz
+PublisherUrl: https://github.com/JTeixeiraz
+PublisherSupportUrl: https://github.com/JTeixeiraz/Postly/issues
+PackageName: Postly
+PackageUrl: https://github.com/JTeixeiraz/Postly
+License: MIT
+LicenseUrl: https://github.com/JTeixeiraz/Postly/blob/main/LICENSE
+ShortDescription: Um departamento de marketing que roda na sua máquina
+Description: |-
+  Quatro cargos de IA se revezam em modelos locais do Ollama para pesquisar o
+  mercado, criar a peça, auditar e publicar nas suas redes. Um modelo por vez,
+  porque numa máquina comum não cabem quatro: a cada troca de cargo o sistema
+  mede a memória livre, sobe o modelo mais forte que couber, grava a conversa
+  inteira e descarrega antes do próximo.
+
+  Nada sai do seu computador além da chamada que gera a imagem e do navegador
+  que publica nas suas próprias contas. Sem telemetria, sem servidor do
+  projeto, sem conta para criar.
+
+  Precisa do Ollama, que o aplicativo instala na primeira abertura.
+Moniker: postly
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: JTeixeiraz.Postly
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.yaml
+++ b/manifests/j/JTeixeiraz/Postly/0.1.0/JTeixeiraz.Postly.yaml
@@ -1,5 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: JTeixeiraz.Postly
 PackageVersion: 0.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.12.0
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## 📖 Description

New package: **JTeixeiraz.Postly** version **0.1.0**.

Postly is an open-source desktop application that orchestrates local Ollama
models as a marketing team — four AI roles take turns to research, create,
audit and publish to social networks, with a single model resident at a time.

- Homepage: https://jteixeiraz.github.io/Postly/
- Source: https://github.com/JTeixeiraz/Postly
- Release: https://github.com/JTeixeiraz/Postly/releases/tag/v0.1.0
- License: MIT

The installer is the NSIS package produced by Tauri. It requests
`asInvoker` (no elevation) and installs per user, which is why the manifest
declares `Scope: user`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable) — not applicable, this is a new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## 🔍 Verification

The `InstallerSha256` was computed from the file served by the public release
URL, not from a local build:

```
390727BCCFC5F03D7A60A0605A124C8E685FB51526300BC23BEB2CC905BEE3FA
```

Manifests validated against the official 1.12.0 JSON schemas before
submission, and the files are UTF-8 without BOM.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426449)