### PR TITLE
New package: IndySoft.VidSeen version 1.0.16

### DIFF
--- a/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.installer.yaml
+++ b/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: IndySoft.VidSeen
+PackageVersion: 1.0.16
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+MinimumOSVersion: 10.0.17763.0
+AppsAndFeaturesEntries:
+- DisplayName: VidSeen
+  Publisher: IndySoft, Inc.
+  DisplayVersion: 1.0.16
+ReleaseDate: "2026-08-30"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://indyvidsrecordings.blob.core.windows.net/releases/win/1.0.16/VidSeen-win-x64-Setup.exe
+  InstallerSha256: BE9BCE04914683CB1E46E7629F85506C0E50ED8E3DE607728517CED527A74951
+- Architecture: arm64
+  InstallerUrl: https://indyvidsrecordings.blob.core.windows.net/releases/win/1.0.16/VidSeen-win-arm64-Setup.exe
+  InstallerSha256: 34A6DBB36EB7AD817824B3A006FA15575BD3BD5B8D0029A0765E6FB7ABC8F0F0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.locale.en-US.yaml
+++ b/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: IndySoft.VidSeen
+PackageVersion: 1.0.16
+PackageLocale: en-US
+Publisher: IndySoft, Inc.
+PublisherUrl: https://www.indysoft.com
+PublisherSupportUrl: https://vidseen.com/contact
+PrivacyUrl: https://vidseen.com/privacy
+Author: IndySoft, Inc.
+PackageName: VidSeen
+PackageUrl: https://vidseen.com
+License: Proprietary
+LicenseUrl: https://vidseen.com/terms
+Copyright: Copyright (c) IndySoft, Inc.
+CopyrightUrl: https://vidseen.com/terms
+ShortDescription: Screen recording that knows who watched
+Description: |-
+  Record your screen or a region of it, share a link, and know who actually watched.
+  VidSeen is screen recording with built-in viewer tracking for teams: recordings and
+  screenshots upload instantly to a shareable link, and viewers you assign are notified
+  and tracked until they have watched.
+Moniker: vidseen
+Tags:
+- screen-recording
+- screen-capture
+- screenshot
+- video
+- share
+ReleaseNotesUrl: https://vidseen.com/download
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.yaml
+++ b/manifests/i/IndySoft/VidSeen/1.0.16/IndySoft.VidSeen.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: IndySoft.VidSeen
+PackageVersion: 1.0.16
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS — relying on pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (authored on macOS — installers themselves are tested on Windows)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Initial submission of VidSeen, a screen-recording and viewer-tracking app by IndySoft, Inc. Velopack-based signed installers (x64 + arm64), silent via `--silent`.