### PR TITLE
Update version: MarceloLvCabral.BrightScriptEmulator version 2.5.2

### DIFF
--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.installer.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+ReleaseDate: 2026-08-30
+AppsAndFeaturesEntries:
+- DisplayName: BrightScript Simulator 2.5.2
+  ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lvcabral/brs-desktop/releases/download/v2.5.2/brs-desktop-2.5.2-windows.exe
+  InstallerSha256: B483488522D7F1F54F9BA21D8BF752F192BBBC8B2BCA8E85957B23F62477BA64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.2
+PackageLocale: en-US
+Publisher: Marcelo Lv Cabral
+PublisherUrl: https://github.com/lvcabral
+PublisherSupportUrl: https://github.com/lvcabral/brs-desktop/issues
+PackageName: BrightScript Emulator
+PackageUrl: https://github.com/lvcabral/brs-desktop
+License: MIT
+LicenseUrl: https://github.com/lvcabral/brs-desktop/blob/master/LICENSE
+Copyright: Copyright © 2021 Marcelo Lv Cabral
+ShortDescription: Desktop Emulator for Roku 2D API
+Tags:
+- desktop
+- electron-app
+- emulator
+- roku
+- roku-development
+- simulator
+ReleaseNotes: "This release fixes file dialogs forgetting their last-used folder, the Copy Screenshot menu option sometimes becoming disabled while an app is running, and cross-origin credentialed requests failing after the Electron 43 CORS changes.\r\n\r\n## Bug Fixes\r\n\r\n• Preserved dynamically-enabled menu item states (Copy Screenshot, Save Screenshot, Close App) across macOS menu rebuilds by [@lvcabral](https://github.com/lvcabral) in [#342](https://github.com/lvcabral/brs-desktop/pull/342)\r\n• Persisted last-used folder for file dialogs so Open/Save dialogs remember the previous directory by @lvcabral  in #341\r\n• Reflected request Origin and credentials in CORS headers instead of hardcoding wildcards, fixing credentialed cross-origin fetches by @lvcabral in #340\r\n\r\n## Dependency Bumps\r\n\r\n• Bump `brs-engine` from 2.5.1 to 2.5.2 by @lvcabral\r\n• Bump `brs-scenegraph` from 0.5.1 to 0.5.2 by @lvcabral\r\n\r\n**Full Changelog**：https://github.com/lvcabral/brs-desktop/compare/v2.5.1...v2.5.2"
+ReleaseNotesUrl: https://github.com/lvcabral/brs-desktop/releases/tag/v2.5.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.5.2/MarceloLvCabral.BrightScriptEmulator.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update MarceloLvCabral.BrightScriptEmulator to version 2.5.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426479)