### PR TITLE
New package: TechyGeeksHome.CutGeek version 1.0.1

### DIFF
--- a/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.installer.yaml
+++ b/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.installer.yaml
@@ -1,0 +1,20 @@
+# Created with the TechyGeeksHome manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TechyGeeksHome.CutGeek
+PackageVersion: 1.0.1
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/techygeekshome/CutGeek/releases/download/v1.0.1/CutGeekSetup.exe
+  InstallerSha256: C9A6292ADD292F1DC6248A9E60A1A66E3DDB92662A6E00A058F5DF0B6DF67A99
+  ProductCode: '{C91CA6F5-D34D-4C62-AC50-8388F15CD452}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.locale.en-GB.yaml
+++ b/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.locale.en-GB.yaml
@@ -1,0 +1,26 @@
+# Created with the TechyGeeksHome manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TechyGeeksHome.CutGeek
+PackageVersion: 1.0.1
+PackageLocale: en-GB
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/CutGeek/issues
+PackageName: CutGeek
+PackageUrl: https://techygeekshome.info/cutgeek/
+License: GPL-3.0
+LicenseUrl: https://github.com/techygeekshome/CutGeek/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+ShortDescription: Removes photo backgrounds locally, at full resolution and without a watermark.
+Description: >-
+  CutGeek removes the background from a photo on your own machine and hands it back at the original
+  resolution as a transparent PNG. The free web services downsize the result, watermark it, or keep
+  the full-size version behind a subscription; this one does none of those. It can work through a
+  folder of images in one run and needs no internet connection once installed.
+Moniker: cutgeek
+Tags:
+- background-removal\n- cutout\n- image-editing\n- transparent-png\n- photo\n- offline\n- windows\n- free\n- open-source
+ReleaseNotesUrl: https://github.com/techygeekshome/CutGeek/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.locale.en-GB.yaml
+++ b/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.locale.en-GB.yaml
@@ -20,7 +20,15 @@ Description: >-
   folder of images in one run and needs no internet connection once installed.
 Moniker: cutgeek
 Tags:
-- background-removal\n- cutout\n- image-editing\n- transparent-png\n- photo\n- offline\n- windows\n- free\n- open-source
+- background-removal
+- cutout
+- image-editing
+- transparent-png
+- photo
+- offline
+- windows
+- free
+- open-source
 ReleaseNotesUrl: https://github.com/techygeekshome/CutGeek/releases/tag/v1.0.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.yaml
+++ b/manifests/t/TechyGeeksHome/CutGeek/1.0.1/TechyGeeksHome.CutGeek.yaml
@@ -1,0 +1,8 @@
+# Created with the TechyGeeksHome manifest generator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TechyGeeksHome.CutGeek
+PackageVersion: 1.0.1
+DefaultLocale: en-GB
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

First submission of **TechyGeeksHome.TranscribeGeek**, version 1.0.1.

TranscribeGeek is a free, open source (GPL-3.0) offline speech-to-text tool for Windows. It runs Whisper models locally, so audio and video files are never uploaded anywhere. Installer is Inno Setup, per-user scope, no elevation required.

- Product page: https://techygeekshome.info/transcribegeek/
- Source: https://github.com/techygeekshome/TranscribeGeek
- Release: https://github.com/techygeekshome/TranscribeGeek/releases/tag/v1.0.1

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

The two boxes above about `winget validate` and `winget install` are left unticked deliberately: the manifest was generated against the 1.12 schema and the installer has been tested on Windows, but I have not run those two commands, so I am not going to claim I did. The SHA-256 is GitHub’s own digest for the release asset.

The two boxes above about `winget validate` and `winget install` are left unticked deliberately: the manifest was generated against the 1.12 schema and the installer has been tested on Windows, but I have not run those two commands, so I am not going to claim I did. The SHA-256 is GitHub’s own digest for the release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426514)