### PR TITLE
New version: io.github.frathe.picfetch version 0.2.12

### DIFF
--- a/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.installer.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.12
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: picfetch.exe
+  PortableCommandAlias: picfetch
+ReleaseDate: "2026-08-30"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.12/picfetch-windows-amd64.zip
+  InstallerSha256: 7AA78275A1A337B8007B419B0B91DA81C6C2641B8E742C3E0A8AA439C8BEF4D5
+- Architecture: arm64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.12/picfetch-windows-arm64.zip
+  InstallerSha256: DFE69D401F9E327230460373B5D3C9DFAC366027075FCAA4EB8C78AA806D38E7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.locale.en-US.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.12
+PackageLocale: en-US
+Publisher: Florian Rathe
+PublisherUrl: https://github.com/frathe
+PublisherSupportUrl: https://github.com/frathe/picfetch/issues
+Author: Florian Rathe
+PackageName: PicFetch
+PackageUrl: https://frathe.github.io/picfetch/
+License: MIT
+LicenseUrl: https://github.com/frathe/picfetch/blob/v0.2.12/LICENSE
+Copyright: Copyright (c) 2026 Florian Rathe
+ShortDescription: A small multi-platform desktop app for quickly viewing and browsing images.
+Description: |-
+  A small Fyne desktop app for quickly viewing images. Drop one or more images onto the window to view them, and step through the set with the keyboard.
+
+  Supports JPEG, PNG, GIF, WebP, BMP, TIFF, ICO, XPM, HEIC, AVIF, SVG, and camera RAW previews.
+Moniker: picfetch
+Tags:
+- image-viewer
+- pictures
+- photos
+- fyne
+- go
+- portable
+ReleaseNotes: |-
+  New Features
+  - Settings → Check now: verify, download, apply, and relaunch a new build on demand (works with auto-check off)
+
+  Bugfix
+  - Adding or deleting a Mac favorite no longer wrecks the native menu bar
+
+  Full Changelog: https://github.com/frathe/picfetch/compare/v0.2.11...v0.2.12
+ReleaseNotesUrl: https://github.com/frathe/picfetch/releases/tag/v0.2.12
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.12/io.github.frathe.picfetch.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update: PicFetch 0.2.12 (`io.github.frathe.picfetch`). Same portable zip layout as 0.2.11 (`picfetch.exe` at archive root, x64 and arm64).

Installers:
- https://github.com/frathe/picfetch/releases/download/v0.2.12/picfetch-windows-amd64.zip
- https://github.com/frathe/picfetch/releases/download/v0.2.12/picfetch-windows-arm64.zip

First package: https://github.com/microsoft/winget-pkgs/pull/425898 (merged).

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426516)