### PR TITLE
New version: io.github.frathe.picfetch version 0.2.13

### DIFF
--- a/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.installer.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.13
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: picfetch.exe
+  PortableCommandAlias: picfetch
+ReleaseDate: "2026-08-30"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.13/picfetch-windows-amd64.zip
+  InstallerSha256: 344B85949E7DB135AF71DF398A36278BE8457F059C6280DD1F1AE2E4D541E47D
+- Architecture: arm64
+  InstallerUrl: https://github.com/frathe/picfetch/releases/download/v0.2.13/picfetch-windows-arm64.zip
+  InstallerSha256: E08EFA604EF6438952E622034677E37843A5AB89162169220F5317CC2427D2DC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.locale.en-US.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.13
+PackageLocale: en-US
+Publisher: Florian Rathe
+PublisherUrl: https://github.com/frathe
+PublisherSupportUrl: https://github.com/frathe/picfetch/issues
+Author: Florian Rathe
+PackageName: PicFetch
+PackageUrl: https://frathe.github.io/picfetch/
+License: MIT
+LicenseUrl: https://github.com/frathe/picfetch/blob/v0.2.13/LICENSE
+Copyright: Copyright (c) 2026 Florian Rathe
+ShortDescription: A small multi-platform desktop app for quickly viewing and browsing images.
+Description: |-
+  A small Fyne desktop app for quickly viewing images. Drop one or more images onto the window to view them, and step through the set with the keyboard.
+
+  Supports JPEG, PNG, GIF, WebP, BMP, TIFF, ICO, XPM, HEIC, AVIF, SVG, and camera RAW previews.
+Moniker: picfetch
+Tags:
+- image-viewer
+- pictures
+- photos
+- fyne
+- go
+- portable
+ReleaseNotes: |-
+  New Features
+  - Settings shows the current app version and build number
+  - Settings split into General, Appearance, and Updates tabs
+  - Settings → Check now: verify, download, apply, and relaunch on demand
+  - Appearance: Light, Dark, or System default
+  - Keep a fixed window size instead of resizing to each image
+
+  Bugfix
+  - Windows: in-app updates no longer fail under Controlled Folder Access
+  - Adding or deleting a Mac favorite no longer wrecks the native menu bar
+
+  Full Changelog: https://github.com/frathe/picfetch/compare/v0.2.12...v0.2.13
+ReleaseNotesUrl: https://github.com/frathe/picfetch/releases/tag/v0.2.13
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.yaml
+++ b/manifests/i/io/github/frathe/picfetch/0.2.13/io.github.frathe.picfetch.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: io.github.frathe.picfetch
+PackageVersion: 0.2.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update: PicFetch 0.2.13 (`io.github.frathe.picfetch`). Same portable zip layout (`picfetch.exe` at archive root, x64 and arm64).

Supersedes https://github.com/microsoft/winget-pkgs/pull/426516 (0.2.12, closed; latest GitHub release is v0.2.13).
First package: https://github.com/microsoft/winget-pkgs/pull/425898 (0.2.11, merged).

Installers:
- https://github.com/frathe/picfetch/releases/download/v0.2.13/picfetch-windows-amd64.zip
- https://github.com/frathe/picfetch/releases/download/v0.2.13/picfetch-windows-arm64.zip

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426517)