### PR TITLE
New version: Netpack.XFB version 3.1422

### DIFF
--- a/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.installer.yaml
+++ b/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1422"
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1422/XFB-3.1422-Setup.exe
+  InstallerSha256: 8DD3BA2200D28E2DE19CAE8343CFCCF7078C2DBFAEA4A6FE31C9A2A8437F60A2
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (x64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+- Architecture: arm64
+  InstallerUrl: https://github.com/netpack/XFB/releases/download/v3.1422/XFB-3.1422-arm64-Setup.exe
+  InstallerSha256: A24569B1FC7E1EFFC90C4B15EC069B81C4B1605A9CAF1CA74174FFCA9A5A4E53
+  ProductCode: XFB
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: XFB (arm64) - XFB Radio Automation Software
+    Publisher: Netpack - Online Solutions
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.locale.en-US.yaml
+++ b/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1422"
+PackageLocale: en-US
+Publisher: Netpack - Online Solutions
+PublisherUrl: https://netpack.pt/
+PublisherSupportUrl: https://github.com/netpack/XFB/issues
+Author: Frédéric Bogaerts
+PackageName: XFB
+PackageUrl: https://github.com/netpack/XFB
+License: GPL-3.0
+LicenseUrl: https://github.com/netpack/XFB/blob/main/LICENSE
+ShortDescription: Open-source radio automation software
+Description: |-
+  XFB is an open-source radio automation suite for broadcasters. It provides
+  scheduled playlists, jingles and advertising rotation, a live audio FX
+  engine (10-band equalizer, compressor, 432 Hz retune), DJ decks with
+  scratchable jog wheels, an Icecast/Shoutcast streaming client, playlist
+  waveform views with crossfade preparation and volume automation, and
+  comprehensive accessibility support including screen-reader integration
+  and full keyboard navigation.
+Moniker: xfb
+Tags:
+- accessibility
+- audio
+- automation
+- broadcast
+- open-source
+- radio
+ReleaseNotesUrl: https://github.com/netpack/XFB/releases/tag/v3.1422
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.yaml
+++ b/manifests/n/Netpack/XFB/3.1422/Netpack.XFB.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Netpack.XFB
+PackageVersion: "3.1422"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New version of XFB, an open-source radio automation suite.

- Installers: x64 and arm64 NSIS, published at https://github.com/netpack/XFB/releases/tag/v3.1422
- Both InstallerSha256 values were computed from the released assets as downloaded from GitHub.
- Manifests carried over from 3.1421 with only the version, URLs, hashes and ReleaseNotesUrl changed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426553)