### PR TITLE
New package: OnjLouis.SensorReadout version 6.3.0

### DIFF
--- a/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.installer.yaml
+++ b/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: OnjLouis.SensorReadout
+PackageVersion: 6.3.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: exe
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --install-silent
+  SilentWithProgress: --install-silent
+UpgradeBehavior: install
+FileExtensions:
+- srconnection
+ProductCode: Sensor Readout
+ElevationRequirement: elevationRequired
+AppsAndFeaturesEntries:
+- DisplayName: Sensor Readout
+  Publisher: Andre Louis
+  DisplayVersion: 6.3.0
+  ProductCode: Sensor Readout
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: Sensor Readout.exe
+  InstallerUrl: https://github.com/OnjLouis/accessible-sensor-readout/releases/download/v6.3.0/SensorReadout-6.3.0.zip
+  InstallerSha256: 2BD823A6BB87AAD16170A5B35019A25D7026948EFAC29B38DD33355DB41F5164
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.locale.en-US.yaml
+++ b/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: OnjLouis.SensorReadout
+PackageVersion: 6.3.0
+PackageLocale: en-US
+Publisher: Andre Louis
+PublisherUrl: https://onj.me/
+PublisherSupportUrl: https://github.com/OnjLouis/accessible-sensor-readout/issues
+Author: Andre Louis
+PackageName: Sensor Readout
+PackageUrl: https://github.com/OnjLouis/accessible-sensor-readout
+License: MIT
+LicenseUrl: https://github.com/OnjLouis/accessible-sensor-readout/blob/main/LICENSE.txt
+Copyright: Copyright (c) 2026 Andre Louis
+ShortDescription: Accessible Windows hardware information, monitoring, reporting, and troubleshooting.
+Description: Sensor Readout is an accessibility-first Windows hardware information and troubleshooting tool for reading sensors, checking connected devices, investigating audio latency, reviewing system and accessibility details, creating support reports, monitoring remote computers, and controlling supported fans with a keyboard-first, screen-reader-friendly interface.
+Moniker: sensor-readout
+Tags:
+- accessibility
+- fan-control
+- hardware
+- monitoring
+- screen-reader
+- sensors
+- system-information
+- troubleshooting
+ReleaseNotes: |-
+  - Adds signed, unattended installation, upgrading, and removal for Windows package managers.
+  - Preserves settings and user data during package-manager upgrades and removal.
+  - Preserves user-created language files during signed updates without repeated backups.
+ReleaseNotesUrl: https://github.com/OnjLouis/accessible-sensor-readout/releases/tag/v6.3.0
+InstallationNotes: Sensor Readout requests administrator permission so it can read hardware sensors and use supported fan controls.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.yaml
+++ b/manifests/o/OnjLouis/SensorReadout/6.3.0/OnjLouis.SensorReadout.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: OnjLouis.SensorReadout
+PackageVersion: 6.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### What this adds

- Adds Sensor Readout 6.3.0 as a new WinGet community package.
- Uses the versioned, signed release ZIP from the publisher's GitHub repository.
- Installs and upgrades silently through the application's package-manager path.
- Registers matching Apps and Features metadata and `.srconnection` files.

### Validation

- `winget validate --manifest manifests/o/OnjLouis/SensorReadout/6.3.0` succeeds locally.
- The published ZIP SHA-256 matches the installer manifest.
- Silent install, upgrade, uninstall, preservation, rollback, and cleanup paths passed the application's isolated release checks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426561)