### PR TITLE
New package: TransitAISoftware.Transit version 6.5.1

### DIFF
--- a/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.installer.yaml
+++ b/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TransitAISoftware.Transit
+PackageVersion: 6.5.1
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+Protocols:
+- transit
+ReleaseDate: 2026-08-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.transitai.app/v6.5.1/Transit_6.5.1_x64-setup.exe
+  InstallerSha256: D5C9E3DC7374B39088320C30527B9BAECC73131138F62C63763A3AFAA9F61865
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.installer.yaml
+++ b/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.installer.yaml
@@ -12,5 +12,6 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://downloads.transitai.app/v6.5.1/Transit_6.5.1_x64-setup.exe
   InstallerSha256: D5C9E3DC7374B39088320C30527B9BAECC73131138F62C63763A3AFAA9F61865
+  ProductCode: Transit
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.locale.en-US.yaml
+++ b/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.locale.en-US.yaml
@@ -17,7 +17,7 @@ Description: |-
   Transit is a cross-platform SSH client for network engineers, with an embedded
   AI agent that is architecturally restricted to read-only investigation. The agent
   can read session scrollback and propose commands, but every proposed command is
-  adjudicated by a per-vendor policy gate and then requires an explicit click before
+  adjudicated by a per-vendor policy gate, and then you approve it by hand before
   it runs. Device output is passed through a redaction filter before it reaches the
   model, and the agent has no code path to a stored credential.
 Moniker: transit

--- a/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.locale.en-US.yaml
+++ b/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TransitAISoftware.Transit
+PackageVersion: 6.5.1
+PackageLocale: en-US
+Publisher: Transit AI Software Inc.
+PublisherUrl: https://transitai.app/
+PublisherSupportUrl: https://transitai.app/docs
+PrivacyUrl: https://transitai.app/privacy
+PackageName: Transit
+PackageUrl: https://transitai.app/
+License: Proprietary
+LicenseUrl: https://transitai.app/terms
+Copyright: Copyright (c) Transit AI Software Inc.
+ShortDescription: SSH client with an embedded agentic AI for read-only network investigation
+Description: |-
+  Transit is a cross-platform SSH client for network engineers, with an embedded
+  AI agent that is architecturally restricted to read-only investigation. The agent
+  can read session scrollback and propose commands, but every proposed command is
+  adjudicated by a per-vendor policy gate and then requires an explicit click before
+  it runs. Device output is passed through a redaction filter before it reaches the
+  model, and the agent has no code path to a stored credential.
+Moniker: transit
+Tags:
+- cli
+- network
+- networking
+- ssh
+- sysadmin
+- terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.yaml
+++ b/manifests/t/TransitAISoftware/Transit/6.5.1/TransitAISoftware.Transit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TransitAISoftware.Transit
+PackageVersion: 6.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been manually validated?

- [x] Yes

### Have you checked that there aren't other open pull requests for the same manifest?

- [x] Yes

### Have you validated your manifest locally with `winget validate --manifest <path>`?

- [x] Yes — `Manifest validation succeeded.`

### Have you tested your manifest locally with `winget install --manifest <path>`?

- [x] Yes — installed on Windows: `Successfully verified installer hash` / `Successfully installed`

### Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?

- [x] Yes

---

**Transit** is a cross-platform SSH client for network engineers with an embedded AI agent restricted to read-only investigation.

- Publisher: **Transit AI Software Inc.**
- Homepage: https://transitai.app/

### Verification performed

- `winget validate --manifest` → `Manifest validation succeeded.`
- `winget install --manifest` on Windows → installer downloaded, hash verified by winget, installed successfully.
- All three manifests also validate against the published `1.12.0` JSON schemas.
- `InstallerSha256` was computed from the installer downloaded from the URL in the manifest, rather than copied from a build log.
- The installer is Authenticode-signed; the leaf certificate subject is `O=Transit AI Software Inc., C=US, ST=Louisiana, L=Baton Rouge`, issued by SSL.com Code Signing Intermediate CA RSA R1 — matching the declared publisher.
- Every URL in the locale manifest resolves (`PublisherUrl`, `PublisherSupportUrl`, `PrivacyUrl`, `PackageUrl`, `LicenseUrl`).

### Notes for reviewers

**Only the user-scope NSIS installer is listed, though an MSI is also published.** The application ships a signed in-app updater that swaps the NSIS installer specifically. Listing the per-machine MSI as well would let a user install per-machine and then have the updater place a second, user-scope copy — leaving two installations and winget tracking the wrong one. Offering only the artifact the updater maintains keeps the installed state coherent.

`Protocols: [transit]` is declared because the application registers a `transit://` URL scheme, which its browser-based sign-in depends on.