### PR TITLE
New package: uqitong.UQTBrowser version 19.25.213

### DIFF
--- a/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.installer.yaml
+++ b/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTBrowser
+PackageVersion: 19.25.213
+MinimumOSVersion: 10.0.10240.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --do-not-launch-chrome
+  SilentWithProgress: --do-not-launch-chrome
+UpgradeBehavior: install
+ProductCode: UQiTong UQTBrowser
+AppsAndFeaturesEntries:
+- DisplayName: 优启通浏览器
+  Publisher: The 优启通浏览器 Authors
+  ProductCode: UQiTong UQTBrowser
+ReleaseDate: 2026-08-23
+Installers:
+- Architecture: x64
+  InstallerUrl: https://browser.uqitong.com/downloads/UQTBrowser_19.25.213_x64_installer.exe
+  InstallerSha256: 7F5FB86A1BC5DEDC7C178C804DA78C655937FA75994AF2E3624DC2802429FFE4
+- Architecture: arm64
+  InstallerUrl: https://browser.uqitong.com/downloads/UQTBrowser_19.25.213_ARM64_installer.exe
+  InstallerSha256: 845C255871E37975C8DE18D957E37DB2C366E5C35D5378C523E8F6A4FCCB4131
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.locale.en-US.yaml
+++ b/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTBrowser
+PackageVersion: 19.25.213
+PackageLocale: en-US
+Publisher: 兴宁市优启电子商务信息咨询服务部
+PublisherUrl: https://www.uqitong.com/
+PublisherSupportUrl: https://browser.uqitong.com/
+PrivacyUrl: https://browser.uqitong.com/privacy.html
+PackageName: UQTBrowser
+PackageUrl: https://browser.uqitong.com/
+License: Proprietary
+LicenseUrl: https://browser.uqitong.com/terms.html
+ShortDescription: A Chromium browser with an AI assistant, downloads, PDF tools, and offline OCR.
+Description: UQTBrowser is a Chromium-based browser for Windows 10 and Windows 11. It includes an AI assistant that can work with webpages and Windows after explicit user authorization, a multi-protocol download manager, 51 PDF tools, and offline Chinese and English OCR. Native x64 and ARM64 editions are available. Core browser features are free; AI Pro and token packages are optional paid services.
+Tags:
+- ai
+- browser
+- chromium
+- download
+- ocr
+- pdf
+ReleaseNotes: Improved continuity and state recovery for long AI tasks, strengthened tool execution, context handoff, and retry stability, and refined download and update reliability with additional compatibility fixes.
+ReleaseNotesUrl: https://browser.uqitong.com/en/changelog.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.locale.zh-CN.yaml
+++ b/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTBrowser
+PackageVersion: 19.25.213
+PackageLocale: zh-CN
+Publisher: 兴宁市优启电子商务信息咨询服务部
+PublisherUrl: https://www.uqitong.com/
+PublisherSupportUrl: https://browser.uqitong.com/
+PrivacyUrl: https://browser.uqitong.com/privacy.html
+PackageName: 优启通浏览器
+PackageUrl: https://browser.uqitong.com/
+License: 专有软件
+LicenseUrl: https://browser.uqitong.com/terms.html
+ShortDescription: 集成 AI 助手、下载、PDF 工具和离线 OCR 的 Chromium 浏览器
+Description: 优启通浏览器是一款面向 Windows 10 和 Windows 11 的 Chromium 浏览器，提供原生 x64 与 ARM64 版本。除常规网页浏览外，还集成在用户明确授权后协助操作网页与 Windows 的 AI 助手、多协议下载器、51 项 PDF 工具，以及离线中英文 OCR。浏览器核心功能免费；AI Pro 与 Token 为可选付费服务。
+Tags:
+- AI
+- Chromium
+- OCR
+- PDF
+- 浏览器
+- 下载
+ReleaseNotes: 优化 AI 长任务的连续执行与状态恢复，提升工具调用、上下文衔接和异常重试稳定性；完善下载与更新流程，并修复若干兼容性问题。
+ReleaseNotesUrl: https://browser.uqitong.com/changelog.html
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.yaml
+++ b/manifests/u/uqitong/UQTBrowser/19.25.213/uqitong.UQTBrowser.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTBrowser
+PackageVersion: 19.25.213
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## ?? Description

Adds the first WinGet community manifest for UQTBrowser 19.25.213 with native x64 and ARM64 installers from the publisher's official version-specific download URLs.

Local verification:
- `winget validate --manifest manifests/u/uqitong/UQTBrowser/19.25.213` succeeded.
- The x64 manifest installation completed silently through WinGet.
- Installer URLs returned HTTP 200 and exact byte-range responses; downloaded x64 bytes passed the declared SHA-256 check.
- ARM64 installer architecture, version, Authenticode signature, timestamp, and SHA-256 were verified on an x64 host; no ARM64 runtime claim is made.

## ? Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one package version
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested the x64 manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426607)