### PR TITLE
New package: uqitong.UQTUsbBootCreator version 10.3.3.3

### DIFF
--- a/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.installer.yaml
+++ b/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTUsbBootCreator
+PackageVersion: 10.3.3.3
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+UnsupportedOSArchitectures:
+- arm64
+ProductCode: '{5A7B1552-8ECF-4991-ADBA-8524CDD4DA7B}_is1'
+AppsAndFeaturesEntries:
+- DisplayName: 优启通U盘启动盘制作工具
+  Publisher: 兴宁市优启电子商务信息咨询服务部
+  ProductCode: '{5A7B1552-8ECF-4991-ADBA-8524CDD4DA7B}_is1'
+ReleaseDate: 2026-08-15
+Installers:
+- Architecture: x86
+  InstallerUrl: https://down123.uqitong.com/uqt/store/10.3.3.3-20260815-C9882E5E-0732D7E1/UQitongSetup-10.3.3.3.exe
+  InstallerSha256: 78990894213607238371427FDE4BD762EB1249C4F688E44939E2D5015479DEA7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.locale.en-US.yaml
+++ b/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTUsbBootCreator
+PackageVersion: 10.3.3.3
+PackageLocale: en-US
+Publisher: 兴宁市优启电子商务信息咨询服务部
+PublisherUrl: https://www.uqitong.com/
+PublisherSupportUrl: https://www.uqitong.com/
+PackageName: uqitong USB Boot Disk Creator
+PackageUrl: https://www.uqitong.com/
+License: Proprietary
+ShortDescription: Creates and verifies bootable Windows USB drives with BIOS and UEFI support.
+Description: uqitong USB Boot Disk Creator is an offline Windows utility for creating and maintaining bootable USB media. It identifies physical USB disks, excludes system and other unsafe targets, creates the required boot and data partitions, and verifies the result after writing. It also provides local WinPE installation and ISO export modes. Administrator privileges are required. Creating or initializing a USB drive erases all data on the selected drive, so users should back it up first.
+Tags:
+- bootable-usb
+- recovery
+- system
+- uefi
+- usb
+- winpe
+ReleaseNotes: Improved USB disk safety checks, GPT and UEFI boot-media creation, read-only result verification, local WinPE mode, and ISO export workflows.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.locale.zh-CN.yaml
+++ b/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.locale.zh-CN.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTUsbBootCreator
+PackageVersion: 10.3.3.3
+PackageLocale: zh-CN
+Publisher: 兴宁市优启电子商务信息咨询服务部
+PublisherUrl: https://www.uqitong.com/
+PublisherSupportUrl: https://www.uqitong.com/
+PackageName: 优启通U盘启动盘制作工具
+PackageUrl: https://www.uqitong.com/
+License: 专有软件
+ShortDescription: 制作并校验支持 BIOS 与 UEFI 启动的 Windows U 盘
+Description: 优启通U盘启动盘制作工具是一款离线运行的 Windows 启动介质制作与维护工具。软件识别真实 USB 物理磁盘，排除系统盘和其他不安全目标，创建启动分区与数据分区，并在写入后校验结果；同时提供本地 WinPE 安装和 ISO 导出模式。软件需要管理员权限。制作或初始化会清除所选 U 盘的全部数据，请先备份并确认目标磁盘。
+Tags:
+- BIOS
+- UEFI
+- WinPE
+- U盘
+- 启动盘
+- 系统工具
+ReleaseNotes: 完善 USB 磁盘安全识别、GPT 与 UEFI 启动介质制作、制作结果只读校验、本地 WinPE 模式和 ISO 导出流程。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.yaml
+++ b/manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3/uqitong.UQTUsbBootCreator.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: uqitong.UQTUsbBootCreator
+PackageVersion: 10.3.3.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## ?? Description

Adds the first WinGet community manifest for uqitong USB Boot Disk Creator 10.3.3.3 using the publisher's official version-specific Inno Setup installer.

Local verification:
- `winget validate --manifest manifests/u/uqitong/UQTUsbBootCreator/10.3.3.3` succeeded.
- The official installer URL returned HTTP 200 and exact byte-range responses.
- The installer hash, version, Authenticode signature, and RFC 3161 timestamp match the publisher's release manifest.
- Both declared non-interactive modes (`/VERYSILENT` and `/SILENT`) completed installation without user interaction.
- The installed application, ARP product code, version, publisher, and SHA-256 were verified; silent uninstall returned 0 and removed the application, shortcut, and ARP entry.

## ? Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one package version
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested with `winget install --manifest <path>` (the same 1.9 GB installer and both manifest switch sets were tested directly to avoid an unnecessary duplicate full download)
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426610)