### PR TITLE
New version: Aleckstygit.WayCoder version 0.96.36

### DIFF
--- a/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
@@ -7,7 +7,7 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-x64.zip
-    InstallerSha256: b2f353e49fa89b07b16b54ce554c1c75cb60b24c3f411dce100ba149c62c4f88
+    InstallerSha256: fcca2fd7a486a4f3391da4547e7ab6b72345300c25b6377c5532e47e27cc50f3
   - Architecture: arm64
     InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-arm64.zip
     InstallerSha256: bb83976eed13d31b6a5d221b8ec3c58cdbf55f8dddb07d28941abe951b6ada6b

--- a/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
@@ -7,7 +7,7 @@ Commands:
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-x64.zip
-    InstallerSha256: fcca2fd7a486a4f3391da4547e7ab6b72345300c25b6377c5532e47e27cc50f3
+    InstallerSha256: b9902925f43d013b7d27b2411e36cbc6a7dd4d48ec794758a74c7b889db7cf4b
   - Architecture: arm64
     InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-arm64.zip
     InstallerSha256: bb83976eed13d31b6a5d221b8ec3c58cdbf55f8dddb07d28941abe951b6ada6b

--- a/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.36
+InstallerLocale: zh-CN
+InstallerType: portable
+Commands:
+  - waycoder
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-x64.zip
+    InstallerSha256: b2f353e49fa89b07b16b54ce554c1c75cb60b24c3f411dce100ba149c62c4f88
+  - Architecture: arm64
+    InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-arm64.zip
+    InstallerSha256: bb83976eed13d31b6a5d221b8ec3c58cdbf55f8dddb07d28941abe951b6ada6b
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.locale.zh-CN.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.36
+PackageLocale: zh-CN
+Publisher: Aleckstygit
+PublisherUrl: https://gitee.com/aleckstygit/way-coder
+PublisherSupportUrl: https://gitee.com/aleckstygit/way-coder/issues
+PackageName: WayCoder
+PackageUrl: https://gitee.com/aleckstygit/way-coder
+License: MIT
+ShortDescription: 中文编程智能体 CLI Coding Agent
+Tags:
+  - coding
+  - agent
+  - ai
+  - cli
+  - programmer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.36/Aleckstygit.WayCoder.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.36
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- Package: Aleckstygit.WayCoder（WayCoder 道码，中文版编程智能体）
- Installer type: portable (zip)
- Architectures: x64 / arm64
- CLI command: `waycoder`
- Installer URLs (GitHub releases):
  - x64: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-x64.zip
  - arm64: https://github.com/alecksty/waycoder/releases/download/v0.96.36/waycoder-v0.96.36-win-arm64.zip
- Locale: zh-CN
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426613)