### PR TITLE
New package: MomoSoft.nvd version 1.5.2

### DIFF
--- a/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.installer.yaml
+++ b/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MomoSoft.nvd
+PackageVersion: 1.5.2
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-08-21
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Adam1313943/nvd-public/releases/download/v1.5.2/nvd-1.5.2-setup.exe
+    InstallerSha256: 243690BAAD2E293F5E388CC593EBFC94D49C0488F9707FA1A4D5F67B6D741281
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.locale.en-US.yaml
+++ b/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MomoSoft.nvd
+PackageVersion: 1.5.2
+PackageLocale: en-US
+Publisher: MomoSoft
+PublisherUrl: https://www.momosoft.one
+PublisherSupportUrl: https://github.com/Adam1313943/nvd-public/issues
+PrivacyUrl: https://www.momosoft.one/Privacy.html
+Author: MomoSoft
+PackageName: nvd
+PackageUrl: https://www.momosoft.one/nvd
+License: Proprietary
+LicenseUrl: https://github.com/Adam1313943/nvd-public/blob/main/LICENSE
+Copyright: Copyright (c) 2026 MomoSoft
+ShortDescription: Video downloader with bundled tools, media library and on-device AI subtitles
+Description: |-
+  nvd is a video downloader for Windows and macOS. Turn any web video into a local file
+  with no external setup required - yt-dlp, ffmpeg and a built-in stream sniffer are
+  bundled inside.
+
+  Works with 1,500+ video sites including YouTube, Vimeo, Twitch, niconico, Bilibili and more.
+
+  Key features:
+  - Ready out of the box: no Python, no package manager, no terminal
+  - Smart stream detection: finds HLS streams even on JavaScript-heavy pages
+  - Media library: organise downloads into sources, collections and playlists with thumbnails
+  - AI subtitles: generate subtitles on-device with whisper, then translate to many languages
+  - Built-in player: speed control, picture-in-picture, resume and a subtitle overlay
+Moniker: nvd
+Tags:
+  - download
+  - downloader
+  - media
+  - subtitles
+  - video
+  - video-downloader
+  - whisper
+  - youtube
+ReleaseNotesUrl: https://github.com/Adam1313943/nvd-public/releases/tag/v1.5.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.yaml
+++ b/manifests/m/MomoSoft/nvd/1.5.2/MomoSoft.nvd.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MomoSoft.nvd
+PackageVersion: 1.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `MomoSoft.nvd` version `1.5.2`

nvd is a video downloader for Windows and macOS with a bundled toolchain (yt-dlp, ffmpeg, stream sniffer), a media library, on-device AI subtitles (whisper) and a built-in player. This is the first submission for this package and publisher.

- Publisher site: https://www.momosoft.one
- Product page: https://www.momosoft.one/nvd
- Release: https://github.com/Adam1313943/nvd-public/releases/tag/v1.5.2

#### Manifest details

| | |
|---|---|
| Installer | `nvd-1.5.2-setup.exe` (NSIS, x64) |
| InstallerType | `nullsoft` |
| SHA256 | `243690BAAD2E293F5E388CC593EBFC94D49C0488F9707FA1A4D5F67B6D741281` |
| Schema | 1.6.0 |

#### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Does your manifest conform to the 1.6 schema?
- [x] Installer SHA256 verified against the published release asset.
- [ ] `winget validate` / `winget install --manifest` — **not run**: the manifest was authored on macOS, so the Windows CLI was unavailable. Happy to run these and push a fix if validation surfaces anything.

#### Notes for reviewers

- The installer is **not code-signed**, so SmartScreen may warn on first run. This is noted in the project's release notes; a code-signing certificate is planned.
- `Scope` has been intentionally omitted rather than guessed. Let me know if you would prefer it stated explicitly and I will confirm the electron-builder NSIS configuration.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426748)