### PR TITLE
New version: HELIOSOFT.Subnetlens version 1.1.0

### DIFF
--- a/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.installer.yaml
+++ b/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: HELIOSOFT.Subnetlens
+PackageVersion: 1.1.0
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Subnetlens 1.1.0
+  Publisher: HELIOSOFT LTD
+  DisplayVersion: 1.1.0
+  ProductCode: 70117820-109f-528f-954d-0a232ae2f4c5
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JerryCat101/network-mapper-releases/releases/download/v1.1.0/Subnetlens-Setup-1.1.0.exe
+  InstallerSha256: 039C6F4D8DFB3259B934E7970ADD31D81C1A5907CD3B13CC59B68C16FCDD6AE8
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.locale.en-US.yaml
+++ b/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: HELIOSOFT.Subnetlens
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: HELIOSOFT LTD
+PublisherUrl: https://subnetlens.com
+PublisherSupportUrl: https://subnetlens.com/contact
+PackageName: Subnetlens
+PackageUrl: https://subnetlens.com
+License: Proprietary
+LicenseUrl: https://subnetlens.com/terms.html
+Copyright: Copyright (c) 2026 HELIOSOFT LTD
+ShortDescription: Local-first Windows LAN scanner with live discovery, topology mapping, per-device port history, and 26 built-in IT tools.
+Description: |-
+  Subnetlens is a local-first Windows desktop app for LAN discovery, network mapping, and IT troubleshooting. It helps IT admins, small businesses, MSPs, and home-lab users see what is on their network without deploying a cloud service or server stack.
+  It scans and classifies devices, builds an interactive topology map, tracks open ports and service history per device, listens for mDNS and SSDP device activity in real time, and includes built-in tools such as ping, traceroute, DNS lookup, port scan, WHOIS, GeoIP, TLS checks, and HTTP header inspection.
+  The free tier includes single-subnet network scanning, topology mapping, device inventory, and core diagnostic tools. Subnetlens Pro (one-time purchase) adds Radar monitoring, Prometheus metrics, scheduled scans, risk scoring, HTML reports, IP address management, webhooks, an encrypted credential vault, SNMP topology, an embedded terminal, and multi-network profiles.
+  Scan data stays on the user's machine unless explicitly exported. The installer is code-signed by HELIOSOFT LTD and contains no adware, bundles, or third-party offers.
+Moniker: subnetlens
+Tags:
+- ip-scanner
+- it-tools
+- lan
+- network
+- network-map
+- network-monitoring
+- network-scanner
+- port-scanner
+- subnet
+- topology
+ReleaseNotesUrl: https://github.com/JerryCat101/network-mapper-releases/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.yaml
+++ b/manifests/h/HELIOSOFT/Subnetlens/1.1.0/HELIOSOFT.Subnetlens.yaml
@@ -1,0 +1,8 @@
+# Created for submission to microsoft/winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: HELIOSOFT.Subnetlens
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (not re-tested for this version; identical installer pattern to the merged 1.0.0/1.0.1 manifests, which passed the pipeline's sandbox install test)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Version update for HELIOSOFT.Subnetlens: 1.0.1 -> 1.1.0. Same publisher, same signed NSIS installer pattern as the merged 1.0.0/1.0.1 manifests (versioned immutable GitHub release asset URL, SHA-256 recomputed from the published asset).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426754)