### PR TITLE
New package: Logic647.MemorySQL version 0.4.0

### DIFF
--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.installer.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: Logic647.MemorySQL
 PackageVersion: 0.4.0
 MinimumOSVersion: 10.0.0.0

--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.installer.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Logic647.MemorySQL
+PackageVersion: 0.4.0
+MinimumOSVersion: 10.0.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/Logic647/MemorySQL/releases/download/v0.4.0/MemorySQL-Setup-0.4.0.exe
+    InstallerSha256: 774419546c21876512daa47790263cdf182c266cfd701926912cca290fa6dc32
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+    Platform:
+      - Windows.Desktop
+    UpgradeBehavior: install
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.locale.en-US.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: Logic647.MemorySQL
 PackageVersion: 0.4.0
 PackageLocale: en-US

--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.locale.en-US.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: Logic647.MemorySQL
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Logic647
+PublisherUrl: https://github.com/Logic647
+PublisherSupportUrl: https://github.com/Logic647/MemorySQL/issues
+Author: Logic647
+PackageName: MemorySQL
+PackageUrl: https://github.com/Logic647/MemorySQL
+License: MIT
+LicenseUrl: https://github.com/Logic647/MemorySQL/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Logic647
+ShortDescription: Local-first knowledge base for personal developers — agent sessions, memories and persona, MCP connect-and-continue.
+Description: |-
+  MemorySQL captures AI agent sessions (Codex, ZCode, Claude Code, Gemini, Cursor, OpenCode, Hermes), stores persona and long-term memories, and serves everything over a local MCP server so any agent can pick up exactly where the last one left off.
+
+  Full-text plus local semantic search (sqlite-vec + bge-small-zh, fully offline), project handoff briefs, structured end-of-work progress reports and auto-generated project devlogs. All data stays on your machine; outbound exports pass a redaction module.
+Tags:
+  - mcp
+  - ai-agent
+  - knowledge-base
+  - local-first
+  - electron
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Logic647.MemorySQL
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0

--- a/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.yaml
+++ b/manifests/l/Logic647/MemorySQL/0.4.0/Logic647.MemorySQL.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: Logic647.MemorySQL
 PackageVersion: 0.4.0
 DefaultLocale: en-US


### PR DESCRIPTION
## New package

- **Package**: Logic647.MemorySQL v0.4.0
- **Installer**: NSIS x64, published on GitHub Releases (https://github.com/Logic647/MemorySQL/releases/tag/v0.4.0)
- **SHA256**: verified locally against the released artifact (`774419546c21876512daa47790263cdf182c266cfd701926912cca290fa6dc32`)

### What is MemorySQL

Local-first knowledge base for personal developers: captures AI agent sessions (Codex, ZCode, Claude Code, Gemini, Cursor, OpenCode, Hermes), stores persona and long-term memories, and serves everything over a local MCP server (127.0.0.1:8642/mcp) so any agent can continue exactly where the last one left off. MIT licensed, open source.

### Checklist for adding a new package ✔

- [x] Have you checked that the package is not already in the Microsoft community repository?
- [x] Have you checked that the package is not already submitted in another PR?
- [x] Have you tested the installation and uninstallation locally with `winget install` and `winget uninstall`?
- [x] Have you signed your commits? (not signed — network-constrained environment; will amend if required)

### Notes for reviewers

- The installer is produced by electron-builder (NSIS, fixed appId `org.memorysql.app`), version 0.4.0 tagged on the same commit that this manifest points to.
- The upstream repository publishes releases with `.exe.blockmap` + `latest.yml` for electron-updater; future version bumps will follow the standard autoupdate flow.
