### PR TITLE
Update: ynjmxn.Gengchou to 2.5.0

### DIFF
--- a/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.installer.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.0
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gengchou.exe
+  PortableCommandAlias: gengchou
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ynjmxn/gengchou/releases/download/v2.5.0/gengchou-windows-x64.zip
+  InstallerSha256: E8236D677BA176B69E9F02CE79008388ACCB8379E0D9CA673680EAB2F89D750C
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-31

--- a/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.locale.en-US.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: ynjmxn
+PublisherUrl: https://github.com/ynjmxn
+PublisherSupportUrl: https://github.com/ynjmxn/gengchou/issues
+PrivacyUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.0/README.md#data--privacy
+Author: ynjmxn, lvfeinan and contributors
+PackageName: Gengchou
+PackageUrl: https://github.com/ynjmxn/gengchou
+License: MIT
+LicenseUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.0/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 Jianxin Yin
+CopyrightUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.0/LICENSE
+ShortDescription: A Windows taskbar and tray AI quota monitor for Claude, Codex, Antigravity, and Grok.
+Description: Gengchou is a lightweight native Windows taskbar widget and system-tray app for viewing the quota windows reported by Claude, Codex, Google Antigravity, and Grok without opening a provider dashboard. On first start it asks once for permission, then detects which providers are signed in on this machine and shows only those. Nothing is read before permission is granted, and access can be revoked per provider at any time. It has no analytics, telemetry, or separate backend service, and it does not store provider tokens.
+Moniker: gengchou
+Tags:
+- antigravity
+- claude-code
+- codex
+- grok
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: Adds Grok as a fourth provider, reading the session that grok login already stored and the billing period the provider itself reports. Fixes credential probes inside WSL for every provider, where the probe script was handed to the distribution login shell and re-parsed, so a credential that existed only inside WSL was reported as absent. Also persists Grok in the usage cache and stops an unknown provider name from rejecting the whole settings file.
+ReleaseNotesUrl: https://github.com/ynjmxn/gengchou/releases/tag/v2.5.0
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "gengchou", then answer the one-time permission prompt that covers every provider. Access can be revoked for a single provider later under "Provider access"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.0/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.locale.zh-CN.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.locale.zh-CN.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.0
+PackageLocale: zh-CN
+Publisher: ynjmxn
+PackageName: 更筹 Gengchou
+License: MIT
+ShortDescription: 面向 Windows 的 Claude、Codex、Antigravity 和 Grok 配额监视器，提供任务栏组件、浮窗和托盘图标。
+Description: 更筹是轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台 即可查看 Claude、Codex、Google Antigravity 和 Grok 实际报告的配额窗口。 首次启动只请求一次授权，随后探测本机有哪些服务商已登录，并只显示探测到的。 未获授权前不读取任何凭据，且可随时按服务商单独撤销。 应用不包含分析、遥测或独立后端服务，也不会保存服务商令牌。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“gengchou”，并回答那一次覆盖全部服务商的授权提示；之后可在“服务商访问权限”菜单中按服务商单独撤销。如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.0/ynjmxn.Gengchou.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `ynjmxn.Gengchou` from 2.4.2 to 2.5.0.

Upstream release: https://github.com/ynjmxn/gengchou/releases/tag/v2.5.0

This version adds Grok as a fourth supported quota provider, so the
`ShortDescription`, `Description`, and `Tags` are updated accordingly, and a
`grok` tag is added. `InstallerUrl`, `InstallerSha256`, `ReleaseDate`,
`ReleaseNotes`, `ReleaseNotesUrl`, and the tag-pinned `LicenseUrl`,
`CopyrightUrl`, `PrivacyUrl`, and README `DocumentUrl` all move to `v2.5.0`.
The installer type, nested portable layout, and package identity are unchanged.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

`winget install --manifest` is left unchecked because it requires the
`LocalManifestFiles` setting, which needs an elevated policy change that was
not made on this machine. The installer was verified another way instead: the
release asset was downloaded from the URL in the manifest, its SHA-256 was
recomputed and matches `InstallerSha256`, and the archive was confirmed to
contain `gengchou.exe` at the declared `RelativeFilePath`. The release asset
also passes `gh attestation verify`, which reports it was built by
`.github/workflows/release.yml` at `refs/tags/v2.5.0`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426809)