### PR TITLE
New package: ChristopherUthe.SendspinForWindows version 2.2.5

### DIFF
--- a/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.installer.yaml
+++ b/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ChristopherUthe.SendspinForWindows
+PackageVersion: 2.2.5
+InstallerType: inno
+Scope: user
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-08-31
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/chrisuthe/windowsSpin/releases/download/v2.2.5/Sendspin.Windows-2.2.5-Setup-SelfContained.exe
+    InstallerSha256: F41921C23D04EA0DD36DE1F6BA24F24D4C86240C128806391D51E3EB349AAEFA
+    ProductCode: '{8E7F4A2B-5C3D-4E6F-9A1B-2C3D4E5F6A7B}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.locale.en-US.yaml
+++ b/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ChristopherUthe.SendspinForWindows
+PackageVersion: 2.2.5
+PackageLocale: en-US
+Publisher: Christopher Uthe
+PublisherUrl: https://github.com/chrisuthe
+PublisherSupportUrl: https://github.com/chrisuthe/windowsSpin/issues
+Author: Christopher Uthe
+PackageName: Sendspin for Windows
+PackageUrl: https://github.com/chrisuthe/windowsSpin
+License: MIT
+LicenseUrl: https://github.com/chrisuthe/windowsSpin/blob/master/LICENSE
+Copyright: Copyright (c) 2024 WindowsSpin Contributors
+CopyrightUrl: https://github.com/chrisuthe/windowsSpin/blob/master/LICENSE
+ShortDescription: Turn any Windows PC into a synchronized multi-room audio player.
+Description: |-
+  Sendspin for Windows connects a Windows PC to Music Assistant, letting an old laptop,
+  home theater PC, or desktop workstation become part of a whole-home audio system and
+  play music in perfect sync with other Sendspin players on the network.
+
+  Features:
+  - Synchronized multi-room playback with sub-millisecond sync accuracy
+  - Low-latency WASAPI audio output with selectable output device
+  - Automatic server discovery over mDNS, or manual connection by address
+  - System tray integration, Windows toast notifications, and Discord Rich Presence
+  - Static delay tuning to compensate for Bluetooth speakers and AV receivers
+
+  This is an independent, unofficial project and is not affiliated with, endorsed by,
+  or associated with the Music Assistant project or the official Sendspin protocol
+  maintainers.
+Tags:
+  - audio
+  - multi-room
+  - music
+  - music-assistant
+  - sendspin
+  - streaming
+  - sync
+  - wasapi
+ReleaseNotesUrl: https://github.com/chrisuthe/windowsSpin/releases/tag/v2.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.yaml
+++ b/manifests/c/ChristopherUthe/SendspinForWindows/2.2.5/ChristopherUthe.SendspinForWindows.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ChristopherUthe.SendspinForWindows
+PackageVersion: 2.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `ChristopherUthe.SendspinForWindows` version 2.2.5

Sendspin for Windows turns a Windows PC into a synchronized multi-room audio player for Music Assistant.

- **Homepage:** https://github.com/chrisuthe/windowsSpin
- **License:** MIT
- **Installer:** Inno Setup, x64, user scope, self-contained (bundles the .NET runtime, so no external dependency)
- **Signature:** Authenticode valid — `CN=Christopher Uthe`, issued by Microsoft ID Verified CS EOC CA 03 (Azure Trusted Signing)

#### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the 1.12.0 manifest format spec?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?

Note: `winget validate` passes. The local `winget install --manifest` test has not been run against this exact manifest; the installer binary itself is the published, signed release artifact from https://github.com/chrisuthe/windowsSpin/releases/tag/v2.2.5.

This is an independent, unofficial project and is not affiliated with or endorsed by the Music Assistant project or the Sendspin protocol maintainers, as stated in the package description and project README.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426824)