### PR TITLE
Update: hdosys.herdr-win version 2026.08.31.4

### DIFF
--- a/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.installer.yaml
+++ b/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-win
+PackageVersion: 2026.08.31.4
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  Custom: /WINGET
+UpgradeBehavior: install
+Commands:
+- herdr
+ElevationRequirement: elevationProhibited
+UnsupportedArguments:
+- location
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hdosys/herdr-win/releases/download/v2026.08.31.4/herdr-win_v2026.08.31.4_windows_amd64_setup.exe
+  InstallerSha256: 4D9C9129D9436FD5F051580C462F1870202EA58A28D826226E249705A5FF0344
+  AppsAndFeaturesEntries:
+  - DisplayName: Herdr Win
+    Publisher: herdr-win
+    ProductCode: Herdr Win
+    InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.locale.en-US.yaml
+++ b/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-win
+PackageVersion: 2026.08.31.4
+PackageLocale: en-US
+Publisher: herdr-win
+PublisherUrl: https://github.com/hdosys/herdr-win
+PublisherSupportUrl: https://github.com/hdosys/herdr-win/issues
+Author: Herdr contributors
+PackageName: Herdr Win
+PackageUrl: https://github.com/hdosys/herdr-win
+License: Apache-2.0
+LicenseUrl: https://github.com/hdosys/herdr-win/blob/master/LICENSE
+Copyright: Herdr contributors
+ShortDescription: Native Windows distribution of Herdr
+Description: An unofficial, upstream-first Windows distribution of Herdr built from the latest reviewed stable Herdr release plus a small, reviewable Windows patch queue. The executable and command remain herdr.
+Moniker: herdr
+Tags:
+- ai
+- cli
+- multiplexer
+- terminal
+- tui
+- windows
+ReleaseNotesUrl: https://github.com/hdosys/herdr-win/releases/tag/v2026.08.31.4
+Documentations:
+- DocumentLabel: Setup and usage guide
+  DocumentUrl: https://github.com/hdosys/herdr-win#install
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.yaml
+++ b/manifests/h/hdosys/herdr-win/2026.08.31.4/hdosys.herdr-win.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: hdosys.herdr-win
+PackageVersion: 2026.08.31.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates Herdr Win (`hdosys.herdr-win`) to immutable release `2026.08.31.4`. Herdr Win remains a per-user NSIS distribution, and the installed executable and command remain `herdr`.

## Validation

- `winget validate --manifest <path>` succeeded with Windows Package Manager v1.29.290.
- The immutable GitHub release exposes the exact installer URL with SHA-256 `4D9C9129D9436FD5F051580C462F1870202EA58A28D826226E249705A5FF0344`.
- The retained candidate passed the isolated Windows installer and lifecycle matrix plus every supported platform build before publication.
- The public update feed independently exposes build `9eb521456ac0.a52d75a8930d` and the matching installer digest.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] No issue is required for this routine manifest update
- [x] This PR modifies one manifest set for one package version
- [x] Verified the installer URL, SHA-256, display version, and supported schema version
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426921)