### PR TITLE
New package: Kaniff.Kaniff version 0.1.0

### DIFF
--- a/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.installer.yaml
+++ b/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.installer.yaml
@@ -1,0 +1,16 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Kaniff.Kaniff
+PackageVersion: 0.1.0
+ReleaseDate: 2026-08-31
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: kaniff.exe
+    PortableCommandAlias: kaniff
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tgspn/kaniff/releases/download/v0.1.0/kaniff-0.1.0-win-x64.zip
+    InstallerSha256: 7E02B65FBBABFFE0CD03446995811711483323101ADC7E21F450F4669B90B2E2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.locale.en-US.yaml
+++ b/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.locale.en-US.yaml
@@ -1,0 +1,17 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Kaniff.Kaniff
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Kaniff contributors
+PublisherUrl: https://github.com/tgspn/kaniff
+PackageName: Kaniff
+PackageUrl: https://github.com/tgspn/kaniff
+License: MIT
+ShortDescription: 'A developer Swiss Army knife CLI: IP, Base64, JWT, hash, JSON and more.'
+Tags:
+  - cli
+  - devtools
+  - utilities
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.yaml
+++ b/manifests/k/Kaniff/Kaniff/0.1.0/Kaniff.Kaniff.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Kaniff.Kaniff
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest submission

Adds the first version of **Kaniff**, an MIT-licensed offline developer CLI (IP, Base64, JWT, hash, JSON and related tools).

The installer is the `win-x64` zip from the upstream GitHub release, produced by an automated release workflow; the nested `kaniff.exe` is registered as the portable command `kaniff`.

- Upstream repository: https://github.com/tgspn/kaniff
- Release: https://github.com/tgspn/kaniff/releases/tag/v0.1.0
- The `InstallerSha256` matches the `SHA256SUMS.txt` published with that release, and was re-computed from the downloaded archive.

Checklist, stated accurately:

- [x] There are no other open pull requests for this package.
- [x] The manifests validate against the official 1.12.0 JSON schemas (`defaultLocale`, `installer` and `version`).
- [ ] Not verified with `winget validate` / `winget install`: I do not have the Windows Package Manager client available on this machine, so I did not want to claim a local install test I did not run. Happy to run it and report back, or to defer to the automated validation pipeline.

This is a new-package submission, so it is being opened manually; subsequent versions will be submitted automatically by WinGet Releaser.