### PR TITLE
New version: Cachix.SecretSpec version 0.20.0

### DIFF
--- a/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.installer.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.20.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-31
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: secretspec.exe
+    PortableCommandAlias: secretspec
+  InstallerUrl: https://github.com/cachix/secretspec/releases/download/v0.20.0/secretspec-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 6A515021B79654AA1150C436C75A92D0B08EE6F2CD08C489C66BBBB9C498C7FA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.locale.en-US.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.20.0
+PackageLocale: en-US
+Publisher: Cachix
+PublisherUrl: https://www.cachix.org/
+PublisherSupportUrl: https://github.com/cachix/secretspec/issues
+Author: Domen Kožar
+PackageName: SecretSpec
+PackageUrl: https://secretspec.dev/
+License: Apache-2.0
+LicenseUrl: https://github.com/cachix/secretspec/blob/v0.20.0/LICENSE
+ShortDescription: A declarative interface for every secret provider.
+Description: SecretSpec is a declarative secrets manager for development workflows. It separates secret declarations from storage and resolves them through local keyrings, password managers, cloud secret stores, and other providers.
+Moniker: secretspec
+Tags:
+- cli
+- developer-tools
+- password-manager
+- secrets
+- security
+ReleaseNotesUrl: https://github.com/cachix/secretspec/releases/tag/v0.20.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.yaml
+++ b/manifests/c/Cachix/SecretSpec/0.20.0/Cachix.SecretSpec.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Cachix.SecretSpec
+PackageVersion: 0.20.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates `Cachix.SecretSpec` to 0.20.0 using the official x64 Windows release ZIP. The archive is installed as a portable package and exposes `secretspec` on `PATH`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.com)
- [ ] Linked to an issue (not applicable for this routine version update)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for this package version
- [x] This PR only adds one package version manifest
- [ ] Validated with `winget validate` (WinGet is unavailable in the Linux authoring environment)
- [ ] Tested with `winget install --manifest` (awaiting the repository Windows validation)
- [x] Manifest retains the accepted 1.12 schema and metadata from version 0.18.0

## Additional validation

- The release ZIP SHA-256 was independently verified as `6A515021B79654AA1150C436C75A92D0B08EE6F2CD08C489C66BBBB9C498C7FA`.
- The archive contains `secretspec.exe` at its root.
- All SecretSpec 0.20.0 release workflows completed successfully.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426930)