### PR TITLE
New package: talkdedsec.TlkRecord version 0.1.0

### DIFF
--- a/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.installer.yaml
+++ b/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: talkdedsec.TlkRecord
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.18362.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: tlk-record.exe
+    PortableCommandAlias: tlk-record
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Talkdedsec/tlk-record/releases/download/v0.1.0/tlk-record-0.1.0-windows-x64.zip
+    InstallerSha256: 26204c25f593f5b67bb14831e81aecf061bee51dd9fb6654d86d242d570c76b2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.locale.en-US.yaml
+++ b/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: talkdedsec.TlkRecord
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: talkdedsec
+PublisherUrl: https://github.com/Talkdedsec
+PublisherSupportUrl: https://github.com/Talkdedsec/tlk-record/issues
+PackageName: TLK Record
+PackageUrl: https://github.com/Talkdedsec/tlk-record
+License: MIT
+LicenseUrl: https://github.com/Talkdedsec/tlk-record/blob/main/LICENSE
+Copyright: Copyright (c) 2026 talkdedsec
+ShortDescription: Lightweight screen recorder for Windows, one executable with no runtime to install.
+Description: |-
+  TLK Record captures a display, a window or a region through Windows.Graphics.Capture,
+  composites it on the GPU and encodes it with the hardware encoder. NVIDIA cards are
+  driven through a native NVENC backend; everything else goes through Media Foundation.
+  MP4 is written in fragments and Matroska in clusters, so an interrupted recording
+  still plays. It also records system and microphone audio, keeps an instant replay
+  buffer, overlays a camera, and composes scenes with filters.
+Moniker: tlk-record
+Tags:
+  - screen-recorder
+  - recorder
+  - capture
+  - screencast
+  - nvenc
+  - video
+ReleaseNotesUrl: https://github.com/Talkdedsec/tlk-record/releases/tag/v0.1.0
+Documentations:
+  - DocumentLabel: Architecture
+    DocumentUrl: https://github.com/Talkdedsec/tlk-record/blob/main/docs/architecture.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.yaml
+++ b/manifests/t/talkdedsec/TlkRecord/0.1.0/talkdedsec.TlkRecord.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: talkdedsec.TlkRecord
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

TLK Record 0.1.0 — a screen recorder for Windows, published at
https://github.com/Talkdedsec/tlk-record

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

`winget validate` passes. The local install test is not ticked because
`LocalManifestFiles` is not enabled on the machine the manifest was prepared on;
the installer hash was verified by downloading the published archive and
comparing it against the SHA256SUMS.txt from the same release. The CLA reply is
still to come.

The installer is the release zip: a single portable executable, no dependencies
and no runtime to install.