### PR TITLE
VictorMagne.ClaudTray version 1.4.0

### DIFF
--- a/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.installer.yaml
+++ b/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.ClaudTray
+PackageVersion: 1.4.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Victor-Magne/claudtray/releases/download/v1.4.0/ClaudTray-1.4.0-Setup.exe
+    InstallerSha256: 809E2C6E5274F43AA23FF3500F5423FAF72FCDB251DB162637676C77D0998556
+    ProductCode: '{F3A7B2C1-8D4E-4F9A-B6C2-1E5D7A3F8B9C}_is1'
+    InstallerSwitches:
+      Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+      SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.locale.en-US.yaml
+++ b/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.ClaudTray
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Victor Magne
+PublisherUrl: https://github.com/Victor-Magne
+PublisherSupportUrl: https://github.com/Victor-Magne/claudtray/issues
+PackageName: ClaudTray
+PackageUrl: https://github.com/Victor-Magne/claudtray
+License: MIT
+LicenseUrl: https://github.com/Victor-Magne/claudtray/blob/master/LICENSE
+Copyright: Copyright (c) 2025 Victor Magne
+ShortDescription: Real-time AI usage monitor in the Windows system tray
+Description: |-
+  ClaudTray for Windows monitors your remaining quota for Claude Code and other AI
+  assistants (GitHub Copilot, Codex, Antigravity) directly from the system tray.
+  The tray icon changes colour (green / yellow / red / grey) based on your worst
+  remaining quota, and a click opens a detailed popover dashboard with per-provider
+  cards and reset countdowns. No admin rights required.
+Tags:
+  - ai
+  - claude
+  - claude-code
+  - copilot
+  - tray
+  - usage
+  - monitor
+ReleaseNotesUrl: https://github.com/Victor-Magne/claudtray/releases/tag/v1.4.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.yaml
+++ b/manifests/v/VictorMagne/ClaudTray/1.4.0/VictorMagne.ClaudTray.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: VictorMagne.ClaudTray
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add manifests for VictorMagne.ClaudTray 1.4.0.

- Type: New version
- Installer: Inno Setup, machine scope, x64
- Manifests validated locally against the accepted 1.3.0 set (only version, InstallerUrl, InstallerSha256 and ReleaseNotesUrl differ)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426938)