### PR TITLE
New package: QuantEcon.Jupyteach version 0.3.10

### DIFF
--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
@@ -1,0 +1,19 @@
+# Created for the Windows Package Manager Community Repository
+PackageIdentifier: QuantEcon.Jupyteach
+PackageVersion: 0.3.10
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/QuantEcon/jupyteach/releases/download/agent/jupyteach-v0.3.10/jupyteach-installer-x64-setup.exe
+    InstallerSha256: 69426CD060A6BF5D6F77D535ACD37F52204DB598D9907133D6469A5D79E456ED
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
 # Created for the Windows Package Manager Community Repository
 PackageIdentifier: QuantEcon.Jupyteach
 PackageVersion: 0.3.10

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.installer.yaml
@@ -4,6 +4,7 @@ PackageIdentifier: QuantEcon.Jupyteach
 PackageVersion: 0.3.10
 InstallerType: nullsoft
 Scope: user
+ElevationRequirement: elevationProhibited
 InstallModes:
   - interactive
   - silent

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.locale.en-US.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 # Created for the Windows Package Manager Community Repository
 PackageIdentifier: QuantEcon.Jupyteach
 PackageVersion: 0.3.10

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.locale.en-US.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created for the Windows Package Manager Community Repository
+PackageIdentifier: QuantEcon.Jupyteach
+PackageVersion: 0.3.10
+PackageLocale: en-US
+Publisher: QuantEcon
+PublisherUrl: https://quantecon.org
+PublisherSupportUrl: https://github.com/QuantEcon/jupyteach/issues
+PackageName: Jupyteach
+PackageUrl: https://github.com/QuantEcon/jupyteach
+License: BSD-3-Clause
+Copyright: Copyright (c) 2026, Valorum Data
+ShortDescription: Run local Jupyter kernels for the Jupyteach learning platform.
+Description: Jupyteach runs Python, Julia, and TypeScript Jupyter kernels on the student's computer and relays notebook messages to the Jupyteach learning platform over an outbound WebSocket connection.
+Moniker: jupyteach
+Tags:
+  - education
+  - jupyter
+  - julia
+  - notebooks
+  - python
+  - typescript
+ReleaseNotesUrl: https://github.com/QuantEcon/jupyteach/releases/tag/agent%2Fjupyteach-v0.3.10
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.yaml
@@ -1,0 +1,6 @@
+# Created for the Windows Package Manager Community Repository
+PackageIdentifier: QuantEcon.Jupyteach
+PackageVersion: 0.3.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.yaml
+++ b/manifests/q/QuantEcon/Jupyteach/0.3.10/QuantEcon.Jupyteach.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
 # Created for the Windows Package Manager Community Repository
 PackageIdentifier: QuantEcon.Jupyteach
 PackageVersion: 0.3.10


### PR DESCRIPTION
Adds the Jupyteach 0.3.10 per-user NSIS installer from the official QuantEcon GitHub release.

- Package identifier: `QuantEcon.Jupyteach`
- Architecture: x64
- Installer type: Nullsoft/NSIS
- Scope: current user
- Installer SHA-256 matches the published release sidecar
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426944)