### PR TITLE
New package: Steerania.Oryx version 1.0.0

### DIFF
--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.installer.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Steerania.Oryx
 PackageVersion: "1.0.0"
 InstallerType: wix
@@ -29,4 +29,4 @@ Installers:
   AppsAndFeaturesEntries:
   - UpgradeCode: '{8EA2EE23-91F8-46EC-9310-6DFBF39A04C9}'
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.installer.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+PackageIdentifier: Steerania.Oryx
+PackageVersion: "1.0.0"
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+FileExtensions:
+- md
+- markdown
+- txt
+- epub
+- fb2
+- fbz
+- mobi
+- azw3
+- azw
+- cbz
+- cbr
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wmahfoudh/oryx/releases/download/v1.0.0/oryx-1.0.0-windows-x86_64.msi
+  InstallerSha256: F91B280A445B05795A6F5EADB8142F99BD805205CBCF345F759DD72A4729E4FC
+  ProductCode: '{D6308556-0EB9-4585-AB18-8DFD2174D71D}'
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{8EA2EE23-91F8-46EC-9310-6DFBF39A04C9}'
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.locale.en-US.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Steerania.Oryx
 PackageVersion: "1.0.0"
 PackageLocale: en-US
@@ -42,4 +42,4 @@ Documentations:
 - DocumentLabel: Markdown syntax
   DocumentUrl: https://github.com/wmahfoudh/oryx/blob/main/SYNTAX.md
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.locale.en-US.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.locale.en-US.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+PackageIdentifier: Steerania.Oryx
+PackageVersion: "1.0.0"
+PackageLocale: en-US
+Publisher: Steerania
+PublisherUrl: https://steerania.com
+PublisherSupportUrl: https://github.com/wmahfoudh/oryx/issues
+PrivacyUrl: https://github.com/wmahfoudh/oryx/blob/main/PRIVACY.md
+Author: Walid Mahfoudh
+PackageName: Oryx
+PackageUrl: https://github.com/wmahfoudh/oryx
+License: GPL-3.0-only
+LicenseUrl: https://github.com/wmahfoudh/oryx/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Walid Mahfoudh
+ShortDescription: Fast editor for markdown and code, reader for ebooks and comics
+Description: |-
+  Oryx opens markdown, source code and plain text files, and reads ebooks (EPUB, FB2, MOBI and AZW3) and comics (CBZ and CBR). A document displays in under 100 ms, even an 8 MB markdown file or a 200 MB book, and memory stays flat however far you scroll. There are no panes, no toolbars and no menus: everything is done from the keyboard, F1 lists the shortcuts and Esc closes whatever is open.
+
+  Markdown is rendered the way GitHub shows it, with syntax colors for over a hundred languages and typeset TeX math. Over thirty themes with editable colors apply to reading and to PDF export alike, and the exported PDF reproduces the page as read. Fonts for Latin, Arabic and Hebrew are embedded, and right-to-left books read correctly.
+
+  Oryx is a single binary with no browser engine, no runtime and no GPU requirement. It asks for no account and sends no telemetry. The only thing it downloads is the images a markdown file links to. Oryx is also a light editor for markdown and text, and it writes back only the lines that changed.
+Moniker: oryx
+Tags:
+- markdown
+- markdown-editor
+- markdown-viewer
+- editor
+- viewer
+- code
+- ebook
+- epub
+- mobi
+- kindle
+- fb2
+- comics
+- cbz
+- cbr
+- pdf
+- rtl
+ReleaseNotesUrl: https://github.com/wmahfoudh/oryx/releases/tag/v1.0.0
+Documentations:
+- DocumentLabel: Markdown syntax
+  DocumentUrl: https://github.com/wmahfoudh/oryx/blob/main/SYNTAX.md
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: Steerania.Oryx
 PackageVersion: "1.0.0"
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Steerania.Oryx
+PackageVersion: "1.0.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
+++ b/manifests/s/Steerania/Oryx/1.0.0/Steerania.Oryx.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Steerania.Oryx
 PackageVersion: "1.0.0"
 DefaultLocale: en-US


### PR DESCRIPTION
Oryx is a viewer and editor for markdown, code and text, and a reader for
ebooks (EPUB, FB2, MOBI, AZW3) and comics (CBZ, CBR), free software under
GPL-3.0-only. This adds its first winget manifest, installing the x64 MSI
from the project's GitHub release. The manifests are written against the
current 1.28.0 schema and validate against Microsoft's published schemas.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426949)