### PR TITLE
New package: KaliLeo.InterestModel version 2.1.0

### DIFF
--- a/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.installer.yaml
+++ b/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: KaliLeo.InterestModel
+PackageVersion: "2.1.0"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: interest-model\interest-model.exe
+    PortableCommandAlias: interest-model
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Kali-Leo/feed-mode/releases/download/v2.1.0/interest-model-windows.zip
+    InstallerSha256: "5483395ab2b22ddbddb7cf70929b24ea30e85215fdb8cdd7bfdd54df60a60bfd"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.locale.en-US.yaml
+++ b/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: KaliLeo.InterestModel
+PackageVersion: "2.1.0"
+PackageLocale: en-US
+Publisher: Kali-Leo
+PackageName: Interest Model
+PackageUrl: https://github.com/Kali-Leo/feed-mode
+License: GPL-3.0
+ShortDescription: Companion app for the Feed Mode userscripts; a local dashboard of your browsing interests.
+Moniker: interest-model
+Tags:
+  - bilibili
+  - youtube
+  - userscript
+  - dashboard
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.locale.zh-CN.yaml
+++ b/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.locale.zh-CN.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: KaliLeo.InterestModel
+PackageVersion: "2.1.0"
+PackageLocale: zh-CN
+Publisher: Kali-Leo
+PackageName: 个人兴趣模型
+PackageUrl: https://github.com/Kali-Leo/feed-mode
+License: GPL-3.0
+ShortDescription: Feed Mode 用户脚本的配套程序，在本机仪表盘展示浏览兴趣。
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.yaml
+++ b/manifests/k/KaliLeo/InterestModel/2.1.0/KaliLeo.InterestModel.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: KaliLeo.InterestModel
+PackageVersion: "2.1.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validated structurally; built and published via CI)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (portable zip verified on Windows via CI build)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

New package: a local-first personal interest model companion app for the Feed Mode userscripts. Open source (GPL-3.0): https://github.com/Kali-Leo/feed-mode — the installer asset and its SHA256 are produced by the repository's release CI.

https://claude.ai/code/session_01PEd5G5mp6KMyTY7S3jN4dJ
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426956)