### PR TITLE
New version: Joedsonalves.Vacuon version 0.6.0

### DIFF
--- a/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.installer.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.installer.yaml
@@ -1,0 +1,15 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.6.0
+MinimumOSVersion: 10.0.19044.0
+InstallerType: portable
+Commands:
+- vacuon
+ReleaseDate: 2026-08-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/joedsonalves/vacuon/releases/download/v0.6.0/Vacuon-0.6.0-win-x64.exe
+  InstallerSha256: 340949D7488C975F6317BE61220FED91D4372321E624EB9055E184D79C765838
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.locale.en-US.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.locale.en-US.yaml
@@ -1,0 +1,57 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Joedson Alves
+PublisherUrl: https://github.com/joedsonalves
+PublisherSupportUrl: https://github.com/joedsonalves/vacuon/issues
+PackageName: Vacuon
+PackageUrl: https://joedsonalves.github.io/vacuon/
+License: MIT
+LicenseUrl: https://github.com/joedsonalves/vacuon/blob/main/LICENSE
+ShortDescription: Disk space analyzer that reads the NTFS MFT directly and shows what it is about to delete.
+Description: |-
+  Vacuon finds where the space on a Windows disk went. It reads the NTFS Master File
+  Table straight off the volume, which indexes a million files in seconds instead of
+  minutes, and falls back to the Windows API on volumes where that is not possible.
+
+  Images and videos are shown as thumbnails in six sizes, so you can tell which of five
+  large renders is the final one without opening any of them. Deletion goes to the Recycle
+  Bin by default, and permanently only behind a confirmation you have to tick, with a
+  protection list that refuses the volume root, Windows, System32 and kernel-owned files.
+
+  It also finds files with identical content, draws the volume as a treemap where every
+  box is sized by what it occupies, and can set files aside in a quarantine it can restore
+  them from, instead of deleting them.
+
+  It cleans by rule as well, and where the work belongs inside Windows it calls Microsoft's
+  own tools rather than deleting files by hand. A live monitor reads the NTFS change journal
+  and shows which folders are growing right now. Pictures that look alike are grouped by a
+  perceptual fingerprint, and a preview panel shows media details, text and images without
+  leaving the app.
+
+  Every scan cross-checks the space it attributed to files against what the volume reports
+  as used, and says so when the two disagree.
+
+  The interface is available in English and Portuguese. The fast path needs Administrator;
+  without it the app still works through the slower traversal and says which one it used.
+Moniker: vacuon
+Tags:
+- disk
+- disk-analyzer
+- disk-cleanup
+- disk-space
+- disk-usage
+- duplicate-finder
+- mft
+- ntfs
+- similar-images
+- storage
+- treemap
+ReleaseNotesUrl: https://github.com/joedsonalves/vacuon/releases/tag/v0.6.0
+Documentations:
+- DocumentLabel: Readme
+  DocumentUrl: https://github.com/joedsonalves/vacuon/blob/main/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.locale.pt-BR.yaml
@@ -1,0 +1,36 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.6.0
+PackageLocale: pt-BR
+Publisher: Joedson Alves
+PackageName: Vacuon
+License: MIT
+ShortDescription: Analisador de espaco em disco que le a MFT do NTFS direto e mostra o que voce esta apagando.
+Description: |-
+  O Vacuon encontra para onde foi o espaco de um disco no Windows. Ele le a Master File
+  Table do NTFS direto do volume, o que indexa um milhao de arquivos em segundos em vez de
+  minutos, e cai para a API do Windows nos volumes onde isso nao e possivel.
+
+  Imagens e videos aparecem como miniaturas em seis tamanhos, para voce saber qual de cinco
+  renderizacoes grandes e a final sem abrir nenhuma. A exclusao vai para a Lixeira por
+  padrao, e definitiva so atras de uma confirmacao que voce precisa marcar, com uma lista
+  de protecao que recusa a raiz do volume, Windows, System32 e arquivos do kernel.
+
+  Ele tambem acha arquivos com conteudo identico, desenha o volume como um treemap onde
+  cada caixa tem o tamanho do que ocupa, e guarda arquivos numa quarentena de onde da para
+  restaurar, em vez de apagar de uma vez.
+
+  Limpa por regra tambem, e onde o trabalho fica dentro do Windows chama as ferramentas da
+  propria Microsoft em vez de apagar arquivo na mao. Um monitor ao vivo le o diario de
+  mudancas do NTFS e mostra quais pastas estao crescendo agora. Imagens parecidas sao
+  agrupadas por uma impressao perceptual, e um painel de previa mostra ficha tecnica de
+  midia, texto e imagem sem sair do app.
+
+  Toda varredura confere o espaco atribuido a arquivos contra o que o volume declara em uso,
+  e avisa quando os dois nao batem.
+
+  Interface em ingles e portugues. O caminho rapido exige Administrador; sem ele o app
+  funciona pela travessia mais lenta e diz qual dos dois usou.
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.yaml
+++ b/manifests/j/Joedsonalves/Vacuon/0.6.0/Joedsonalves.Vacuon.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Joedsonalves.Vacuon
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 manifest schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not ticked on purpose, see below**

---

Version bump for `Joedsonalves.Vacuon`, 0.5.0 → 0.6.0. Four files under
`manifests/j/Joedsonalves/Vacuon/0.6.0/`. Same publisher, same portable installer type, same
GitHub release hosting as the four versions before it.

**What changed in the manifest, in full:**

| field | from | to |
|---|---|---|
| `PackageVersion` | 0.5.0 | 0.6.0 |
| `ReleaseDate` | 2026-08-23 | 2026-08-31 |
| `InstallerUrl` | .../v0.5.0/... | .../v0.6.0/Vacuon-0.6.0-win-x64.exe |
| `InstallerSha256` | 1A17D039… | `340949D7488C975F6317BE61220FED91D4372321E624EB9055E184D79C765838` |
| `PackageUrl` | the GitHub repository | `https://joedsonalves.github.io/vacuon/` |

`Description`, `ShortDescription` and `Tags` are unchanged, byte for byte, from the 0.5.0
manifest that was merged.

**On `PackageUrl`:** it now points at the project's own page rather than at the repository.
The page is served from the repository itself (GitHub Pages) and carries the project's
favicon, which is what package listing sites read to show an icon.

**The SHA256 was taken from the published asset, not from a local build.** The file was
downloaded back from the release and hashed, so the value in the manifest is the hash of
exactly the bytes `InstallerUrl` serves.

**Why the install checkbox is not ticked.** This machine's Vacuon is a user-scope portable
package, and `winget` refuses to install or uninstall user-scope packages from an elevated
session — which is the session this was prepared in. Rather than tick a box for a test that
did not run, it is left unticked. Happy to run `winget install --manifest` against the
published URL from an ordinary session and report the result here if that would help.

`winget validate` passes with no warnings.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426960)