### PR TITLE
New version: Pithflow.Pithflow version 1.33.0

### DIFF
--- a/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.installer.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.33.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-30
+Installers:
+- Architecture: x64
+  InstallerUrl: https://pithflow.com/downloads/Pithflow_1.33.0_x64-setup.exe
+  InstallerSha256: E879CCD4E1C7068B364B56DD4ADD4C5A3720EB6D8BE520A1E41FB5A15B2E84EE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.locale.en-US.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.33.0
+PackageLocale: en-US
+Publisher: Pithflow
+PublisherUrl: https://pithflow.com/?utm_source=winget&utm_medium=listing
+PublisherSupportUrl: https://pithflow.com/faq/
+PrivacyUrl: https://pithflow.com/privacy/
+PackageName: Pithflow
+PackageUrl: https://pithflow.com/?utm_source=winget&utm_medium=listing
+License: Proprietary (free tier available)
+LicenseUrl: https://pithflow.com/terms/
+PurchaseUrl: https://pithflow.com/pricing/?utm_source=winget&utm_medium=listing
+ShortDescription: Windows-native AI voice dictation. Hold Ctrl+Space, speak, release - your words land as cleaned-up text in whatever Windows app you are already using.
+Description: |-
+  Pithflow is a Windows-native voice dictation app built in Rust - a ~5 MB installer, not an Electron wrapper. Hold Ctrl+Space, speak, release: your words come back as cleaned-up text, placed straight into whatever app has focus.
+
+  Privacy-first by design: your session is DPAPI-encrypted on your machine and audio is never stored. Transcription runs in the cloud, so an internet connection is required.
+
+  Because audio is captured on your local machine and nothing is installed inside the remote session, Pithflow works where most dictation tools fail - including RDP, Citrix, and VDI.
+
+  Native bilingual Spanish/English, including mid-sentence Spanglish code-switching. Handles 100+ other languages too.
+
+  Free tier: 2,000 words per week, no card required. Pro is $9.99/month or $99/year. Windows 10/11.
+Moniker: pithflow
+Tags:
+- dictation
+- speech-to-text
+- voice-typing
+- accessibility
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.33.0/Pithflow.Pithflow.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📄 Description

Version update for `Pithflow.Pithflow`: **1.23.2 → 1.33.0**.

- `InstallerUrl` points at the immutable versioned filename.
- `InstallerSha256` was verified against the bytes actually served by the CDN on 2026-08-31 (5,696,488 bytes), not against a local build artifact.
- The installer is Authenticode-signed via Microsoft Trusted Signing (`CN=Jesus Zamudio Parra`); signature status verifies as Valid with a Microsoft timestamp.

This version also corrects two inaccuracies in the locale description that shipped with 1.23.2: the previous text misdescribed how transcribed text is delivered to the focused application, and overstated end-to-end latency. Both statements are now accurate. Added `PrivacyUrl`, `LicenseUrl`, `PublisherSupportUrl` and `PurchaseUrl`, all resolving 200.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> Note on the one unchecked box: `winget validate` passes, but I did not run `winget install --manifest` on this machine, so I am not claiming that step. The installer URL and hash are verified as described above.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426966)