### PR TITLE
Update: LifetimeLabs.PrivacyNotes version 0.491.2

### DIFF
--- a/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.installer.yaml
+++ b/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.installer.yaml
@@ -1,0 +1,25 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LifetimeLabs.PrivacyNotes
+PackageVersion: 0.491.2
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: PrivacyNotes
+  Publisher: Lifetime Labs LLC
+  ProductCode: PrivacyNotes
+  InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://releases.privacynotes.app/0.491.2/PrivacyNotes_x64-setup.exe
+  InstallerSha256: 76B9ECDF6FE9F93E724BE716092560293267C00D15F14AFA6D410E3F9A2E44CF
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-31

--- a/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.locale.en-US.yaml
+++ b/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LifetimeLabs.PrivacyNotes
+PackageVersion: 0.491.2
+PackageLocale: en-US
+Publisher: Lifetime Labs LLC
+PublisherUrl: https://lifetimelabs.dev/
+PublisherSupportUrl: https://github.com/LifetimeLabsDev/PrivacyNotes.app/issues
+PrivacyUrl: https://lifetimelabs.dev/privacy/
+Author: Lifetime Labs LLC
+PackageName: PrivacyNotes
+PackageUrl: https://privacynotes.app/
+License: AGPL-3.0
+LicenseUrl: https://github.com/LifetimeLabsDev/PrivacyNotes.app/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Lifetime Labs LLC
+CopyrightUrl: https://lifetimelabs.dev/terms/
+ShortDescription: End-to-end encrypted notes, tasks, and journal
+Description: |-
+  PrivacyNotes is an end-to-end encrypted notes, tasks and journal app. A 12-word BIP-39 phrase is your identity and your key, so there is no email, no password and no account to leak. Notes, journal entries, tasks, a password vault and file attachments are encrypted on your device with XChaCha20-Poly1305 before they sync, and the server stores only ciphertext and a nonce.
+  Importers read exports from Evernote, Apple Notes, Apple Journal, Obsidian, Notesnook, Standard Notes, Simplenote, Google Keep, Samsung Notes, Bitwarden and plain Markdown, and every one of them is parsed on your device.
+  PrivacyNotes is open source: the client apps, the encryption core and the threat model are published at github.com/LifetimeLabsDev/PrivacyNotes.app, so the privacy claims can be checked rather than taken on faith.
+Moniker: privacynotes
+Tags:
+- e2ee
+- encrypted
+- encryption
+- end-to-end-encryption
+- journal
+- notes
+- note-taking
+- privacy
+- tasks
+- zero-knowledge
+ReleaseNotesUrl: https://privacynotes.app/changelog
+Documentations:
+- DocumentLabel: Help and FAQ
+  DocumentUrl: https://privacynotes.app/help
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.yaml
+++ b/manifests/l/LifetimeLabs/PrivacyNotes/0.491.2/LifetimeLabs.PrivacyNotes.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LifetimeLabs.PrivacyNotes
+PackageVersion: 0.491.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates `LifetimeLabs.PrivacyNotes` from 0.305.6 to 0.491.2, and corrects two pieces of metadata that went stale since the package was first submitted:

- `License` was `Proprietary`. The application is AGPL-3.0, and `LicenseUrl` now points at the LICENSE file rather than the terms page.
- The description said the database schema is published. That is no longer accurate, so the sentence now names what is published: the client apps, the encryption core and the threat model.

Submitted by the publisher.

## Checklist

- [x] Signed the Contributor License Agreement (on the account that submitted #416239)
- [x] Checked that there are no other open pull requests for this manifest
- [x] This PR only modifies one manifest
- [x] Manifest conforms to the 1.12 schema

Not run locally: `winget validate` and `winget install` need a Windows machine, and this manifest was prepared on macOS. The installer it points at was downloaded and its SHA256 checked against the checksum we publish beside it at `https://releases.privacynotes.app/0.491.2/PrivacyNotes_x64-setup.exe.sha256`. Everything except the version, URL, hash and release date is carried over unchanged from the merged 0.305.6 manifest, apart from the two metadata corrections described above.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/426980)