### PR TITLE
New version: HiggX.QFCLI version 0.3.1-beta

### DIFF
--- a/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.installer.yaml
+++ b/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: HiggX.QFCLI
+PackageVersion: 0.3.1-beta
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: qfc.exe
+    PortableCommandAlias: qfc
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/quotationfactory/qf_cli/releases/download/v0.3.1-beta/qfc-win-x64.zip
+    InstallerSha256: 77DD6B11B88F7A9E9327564DF08F1354F264C6F344004A75C76C5F91F8CCBED9
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.locale.en-US.yaml
+++ b/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: HiggX.QFCLI
+PackageVersion: 0.3.1-beta
+PackageLocale: en-US
+Publisher: Quotation Factory
+PublisherUrl: https://github.com/quotationfactory/qf_cli
+PublisherSupportUrl: https://github.com/quotationfactory/qf_cli/issues
+PackageName: HiggX - Quotation Factory CLI
+PackageUrl: https://github.com/quotationfactory/qf_cli
+License: Proprietary
+LicenseUrl: https://github.com/quotationfactory/qf_cli
+Copyright: Copyright (c) Quotation Factory
+ShortDescription: CLI for the Quotation Factory manufacturing API.
+Description: A self-contained command-line tool for discovering, describing, and calling Quotation Factory API endpoints with structured JSON output.
+Moniker: qfc
+Tags:
+  - quotation-factory
+  - qfcli
+  - rhodium24
+  - manufacturing
+  - cli
+  - api
+  - higgx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.yaml
+++ b/manifests/h/HiggX/QFCLI/0.3.1-beta/HiggX.QFCLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: HiggX.QFCLI
+PackageVersion: 0.3.1-beta
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Adds Quotation Factory CLI 0.3.1-beta.
- Installer URL points to the GitHub release asset for qfc-win-x64.zip.
- Manifest was generated by the Azure DevOps release pipeline after manual approval.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427017)