### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.1.9

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.1.9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.9
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{EFDA0650-5BBB-4303-9B13-6E0D357ACC71}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{EFDA0650-5BBB-4303-9B13-6E0D357ACC71}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.1.9/GestureSign-V2-18.1.9-x64.msi
+  InstallerSha256: 3D6127EB0C100B036DCC034AAB8670596509B4C5E51BB3DFB825BF240423B739
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-01

--- a/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created for GestureSign V2 18.1.9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.9
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Added volume up, volume down, and vertical or horizontal scrolling to all four touchpad and touchscreen edges.
+  - Added a switch between slider-like continuous volume adjustment and one action per swipe; mute always fires once.
+  - Added direction-aware continuous edge scrolling.
+  - Improved multi-finger retrace and loop checks to reduce false triggers during intensive web-page scrolling.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.1.9
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.1.9/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# Created for GestureSign V2 18.1.9
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the official GestureSign V2 18.1.9 manifests. This release adds configurable continuous or one-shot edge volume control on all touchpad and touchscreen edges, direction-aware edge scrolling, and stronger multi-finger false-trigger protection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427077)