### PR TITLE
astral-sh.uv version 0.12.7: Remove redundant DisplayVersion

### DIFF
--- a/manifests/a/astral-sh/uv/0.12.7/astral-sh.uv.installer.yaml
+++ b/manifests/a/astral-sh/uv/0.12.7/astral-sh.uv.installer.yaml
@@ -20,7 +20,6 @@ ReleaseDate: 2026-08-27
 AppsAndFeaturesEntries:
 - DisplayName: uv
   Publisher: Astral Software Inc.
-  DisplayVersion: 0.12.7
 Installers:
 - Architecture: x86
   InstallerUrl: https://github.com/astral-sh/uv/releases/download/0.12.7/uv-i686-pc-windows-msvc.zip


### PR DESCRIPTION
astral-sh.uv version 0.12.7: Remove redundant DisplayVersion

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Follow up to the previous AppsAndFeaturesEntries PR [https://github.com/microsoft/winget-pkgs/pull/426812](url) for astral-sh.uv 0.12.7. The winget-pkgs validation bot flagged that DisplayVersion (0.12.7) matches the top level PackageVersion which is redundant.

This PR removes the redundant DisplayVersion line.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `manifests/a/astral-sh/uv/0.12.7/astral-sh.uv.installer.yaml` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427099)