### PR TITLE
New package: shep-pm.shep version 0.1.25

### DIFF
--- a/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.installer.yaml
+++ b/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: shep-pm.shep
+PackageVersion: 0.1.25
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: shep.exe
+    PortableCommandAlias: shep
+  InstallerUrl: https://github.com/shep-pm/shep/releases/download/shep-v0.1.25/shep-x86_64-pc-windows-msvc.zip
+  InstallerSha256: F504675394903E71407E7CB157DCF3C12EA061B4B6C3081231C0820418AD84D1
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.locale.en-US.yaml
+++ b/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: shep-pm.shep
+PackageVersion: 0.1.25
+PackageLocale: en-US
+Publisher: shep-pm
+PublisherUrl: https://github.com/shep-pm
+PublisherSupportUrl: https://github.com/shep-pm/shep/issues
+PackageName: shep
+PackageUrl: https://shep-pm.com
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/shep-pm/shep#license
+Copyright: Copyright (c) TurtIeSocks
+ShortDescription: A process manager that keeps a flock of long-running processes alive
+Description: |-
+  shep is a process manager written in Rust. One binary runs a daemon called the
+  shepherd, which keeps a flock of your long-running processes alive, restarts them
+  when they die, captures what they print, and says plainly when something is wrong.
+
+  It also restarts on file changes, on a cron schedule, or over a memory limit, ships
+  a terminal dashboard, and can alert a webhook when a process misbehaves.
+
+  Three things it will not do on Windows. `shep startup` is not built, because
+  boot-time supervision there means a Service Control Manager service rather than
+  another unit template. There is nothing SIGTERM-shaped that can be delivered to an
+  arbitrary process, so `shep stop` waits out the process's whole kill_timeout unless
+  the app opts into the shepherd channel. The user and group Flockfile fields refuse
+  permanently.
+
+  Only shep.exe is linked onto PATH. The archive also carries shep-runtime.exe and
+  shep-dev.exe, which are container entrypoint aliases with no desktop use case.
+Moniker: shep
+Tags:
+- cli
+- daemon
+- process-manager
+- rust
+- supervisor
+ReleaseNotesUrl: https://github.com/shep-pm/shep/releases/tag/shep-v0.1.25
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.yaml
+++ b/manifests/s/shep-pm/shep/0.1.25/shep-pm.shep.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: shep-pm.shep
+PackageVersion: 0.1.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `shep-pm.shep` version 0.1.25. shep is a process manager written in Rust: one daemon keeps a flock of long-running processes alive, with logs, watch and cron restarts, and webhook alerts. This submits the portable x64 zip from the project's own GitHub release.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

The two unticked manifest boxes are honest rather than skipped. These manifests were written on macOS, so neither `winget validate` nor `winget install` was run. Checked instead:

- all three files validate against the published 1.12.0 JSON schemas
- `InstallerSha256` matches a locally downloaded copy of the zip, byte for byte
- every URL in the manifests returns 200
- the archive is flat, so `RelativeFilePath: shep.exe` is right and no `NestedInstallerRoot` is needed
- `shep.exe` imports `VCRUNTIME140.dll`, which is why `Microsoft.VCRedist.2015+.x64` is declared

Happy to fix anything the validation pipeline turns up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427115)