### PR TITLE
New package: UniRateAPI.UniRate version 0.1.0

### DIFF
--- a/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.installer.yaml
+++ b/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.installer.yaml
@@ -1,0 +1,22 @@
+# Created with the UniRate campaign manifest authoring flow
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: UniRateAPI.UniRate
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: unirate.exe
+  PortableCommandAlias: unirate
+Commands:
+- unirate
+ReleaseDate: 2026-06-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/UniRate-API/unirate-cli/releases/download/v0.1.0/unirate_0.1.0_windows_amd64.zip
+  InstallerSha256: 667F111DCAF53FEA600E677DFEB8871A32EB019137EF2A407ADC4E0CEFB1957F
+- Architecture: arm64
+  InstallerUrl: https://github.com/UniRate-API/unirate-cli/releases/download/v0.1.0/unirate_0.1.0_windows_arm64.zip
+  InstallerSha256: 8105C43EE2E96A5DF97392B469C941CDB492CBD39363582DE95AAA55D5DDFACC
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.locale.en-US.yaml
+++ b/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: UniRateAPI.UniRate
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: UniRateAPI
+PublisherUrl: https://unirateapi.com
+PublisherSupportUrl: https://github.com/UniRate-API/unirate-cli/issues
+PackageName: UniRate CLI
+PackageUrl: https://github.com/UniRate-API/unirate-cli
+License: MIT
+LicenseUrl: https://github.com/UniRate-API/unirate-cli/blob/main/LICENSE
+Copyright: Copyright (c) UniRateAPI
+ShortDescription: Currency exchange rates, conversion, and VAT lookups from the UniRate API, straight from your terminal.
+Description: |-
+  unirate is a command-line interface for the UniRate API. It provides real-time
+  exchange rates between 170+ currencies (fiat and crypto), currency conversion,
+  all-rates tables, supported-currency listing, and VAT rates for countries
+  worldwide. Every command supports --json for clean piping into tools like jq.
+  It ships as a single static binary with zero third-party dependencies beyond
+  the official Go client. A free tier is available with no credit card required.
+Moniker: unirate
+Tags:
+- cli
+- command-line
+- conversion
+- currency
+- currency-converter
+- exchange-rates
+- finance
+- forex
+- fx
+- vat
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.yaml
+++ b/manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: UniRateAPI.UniRate
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** `UniRateAPI.UniRate`
- **Version:** `0.1.0`
- **Upstream:** https://github.com/UniRate-API/unirate-cli

`unirate` is a small, single-binary CLI for currency exchange rates, conversion, and VAT lookups from the [UniRate API](https://unirateapi.com). It is distributed as a portable `zip` (containing `unirate.exe`) for `x64` and `arm64`, published on the project's GitHub releases.

#### Manifests
- `manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.installer.yaml`
- `manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.locale.en-US.yaml`
- `manifests/u/UniRateAPI/UniRate/0.1.0/UniRateAPI.UniRate.yaml`

#### Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] This PR only modifies one (1) manifest.

Installer `InstallerType: zip` with `NestedInstallerType: portable`; SHA256 values verified against the release `checksums.txt`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427121)