### PR TITLE
New version: rulssss.CloudCostTree version 0.2.13

### DIFF
--- a/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.installer.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.2.13
+InstallerType: portable
+Commands:
+  - cloudcosttree
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.2.13/cloudcosttree-windows-amd64.exe
+    InstallerSha256: 9DF50CF64C50E860CB494148833CE61D76CE56FDC63225C85343E49D5C1A0C61
+  - Architecture: arm64
+    InstallerUrl: https://github.com/rulssss/cloudcosttree/releases/download/v0.2.13/cloudcosttree-windows-arm64.exe
+    InstallerSha256: 6604481A48CA246B89FE4B3188F64A2ECD2B7B22C8C8E47370B612EC12A6140C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.locale.en-US.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.locale.en-US.yaml
@@ -1,0 +1,10 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.2.13
+PackageLocale: en-US
+Publisher: rulssss
+PackageName: CloudCostTree
+License: Proprietary
+ShortDescription: Estimate AWS infrastructure costs in a hierarchical tree before you apply
+PackageUrl: https://cloudcosttree.com
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.yaml
+++ b/manifests/r/rulssss/CloudCostTree/0.2.13/rulssss.CloudCostTree.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: rulssss.CloudCostTree
+PackageVersion: 0.2.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update to 0.2.13. Installer URLs verified reachable; InstallerSha256 computed locally against the published release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427124)