### PR TITLE
New version: Inbjo.MirrorProxy version 1.4.1

### DIFF
--- a/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.installer.yaml
+++ b/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Inbjo.MirrorProxy
+PackageVersion: 1.4.1
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+- mirrorproxy
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: mirrorproxy.exe
+    PortableCommandAlias: mirrorproxy
+  InstallerUrl: https://github.com/inbjo/MirrorProxy/releases/download/v1.4.1/mirrorproxy-client-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 049DC5C93C0DF9562C5C845498DEECDF9AC186D48C0C721B171B8429BC055660
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.locale.en-US.yaml
+++ b/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Inbjo.MirrorProxy
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: MirrorProxy contributors
+PublisherUrl: https://github.com/inbjo/MirrorProxy
+PublisherSupportUrl: https://github.com/inbjo/MirrorProxy/issues
+PackageName: MirrorProxy
+PackageUrl: https://github.com/inbjo/MirrorProxy
+License: MIT
+LicenseUrl: https://github.com/inbjo/MirrorProxy/blob/main/LICENSE
+ShortDescription: Standalone source manager for MirrorProxy
+Description: Configure package managers and development tools to use MirrorProxy or supported public mirrors, with safe preview, write, and rollback operations.
+Moniker: mirrorproxy
+Tags:
+- cli
+- mirror
+- package-manager
+- source-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.yaml
+++ b/manifests/i/Inbjo/MirrorProxy/1.4.1/Inbjo.MirrorProxy.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Inbjo.MirrorProxy
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary
- Update `Inbjo.MirrorProxy` from version 1.3.0 to 1.4.1
- Point the portable x64 installer at the v1.4.1 Windows release asset
- Update the installer SHA256 to match the published archive

#### Test plan
- [x] Compared the generated manifests with the accepted 1.3.0 manifests
- [x] Downloaded the Windows archive and verified SHA256 `049DC5C93C0DF9562C5C845498DEECDF9AC186D48C0C721B171B8429BC055660`

Generated with [Devin](https://devin.ai)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427128)