### PR TITLE
Flyxl.DataZen version 0.1.1

### DIFF
--- a/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.installer.yaml
+++ b/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: Flyxl.DataZen
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/flyxl/datazen/releases/download/v0.1.1/DataZen_0.1.1_x64-setup-windows-x64.exe
+  InstallerSha256: 2C2371D9C710829DE9AAF06B81811647DB8ABD46290A7C7A6939ABA02B91AA9C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.locale.en-US.yaml
+++ b/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: Flyxl.DataZen
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Flyxl
+PublisherUrl: https://github.com/flyxl
+PublisherSupportUrl: https://github.com/flyxl/datazen/issues
+PackageName: DataZen
+PackageUrl: https://github.com/flyxl/datazen
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/flyxl/datazen/blob/main/LICENSE
+ShortDescription: Cross-platform desktop database client with AI assistance
+Description: DataZen is a lightweight, open-source desktop database client (PostgreSQL, MySQL, SQLite, Redis) built with Tauri and Rust, with optional AI-assisted SQL and workflow automation.
+Moniker: datazen
+Tags:
+- database
+- sql
+- mysql
+- postgresql
+- sqlite
+- redis
+ReleaseNotesUrl: https://github.com/flyxl/datazen/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.yaml
+++ b/manifests/f/Flyxl/DataZen/0.1.1/Flyxl.DataZen.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: Flyxl.DataZen
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description

Add [DataZen](https://github.com/flyxl/datazen) — open-source Tauri desktop database client (PostgreSQL, MySQL, SQLite, Redis).

- PackageIdentifier: `Flyxl.DataZen`
- Version: `0.1.1`
- Installer: Basic Windows x64 NSIS from GitHub Releases

## Validation

Manifests follow the in-repo templates at `flyxl/datazen/packaging/winget/`.


Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427129)