### PR TITLE
General maintenance: Ruffle.Ruffle.Nightly version 0.4.0.26180

### DIFF
--- a/manifests/r/Ruffle/Ruffle/Nightly/0.4.0.26180/Ruffle.Ruffle.Nightly.locale.en-US.yaml
+++ b/manifests/r/Ruffle/Ruffle/Nightly/0.4.0.26180/Ruffle.Ruffle.Nightly.locale.en-US.yaml
@@ -7,11 +7,11 @@ PackageLocale: en-US
 Publisher: Ruffle
 PublisherUrl: https://github.com/ruffle-rs
 PublisherSupportUrl: https://github.com/ruffle-rs/ruffle/issues
-PackageName: Ruffle
+PackageName: Ruffle (Nightly)
 PackageUrl: https://github.com/ruffle-rs/ruffle
 License: Apache-2.0 + MIT
 LicenseUrl: https://github.com/ruffle-rs/ruffle/blob/HEAD/LICENSE.md
-ShortDescription: A Flash Player emulator written in Rust
+ShortDescription: A Flash Player emulator written in Rust.
 Tags:
 - emulator
 - flash


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
* Changed the PackageName: "Ruffle" → "Ruffle (Nightly)", so that the regular `Ruffle.Ruffle` package can be installed with `winget install Ruffle -s winget` instead of showing a disambiguation notice.
* Added trailing dot to ShortDescription for professionality.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427131)