### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.2

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{AFE6A928-DCBC-4A22-90CE-B7253CFA08B2}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{AFE6A928-DCBC-4A22-90CE-B7253CFA08B2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.2/GestureSign-V2-18.2-x64.msi
+  InstallerSha256: 1C07694F9803EEFDC3EB7C7F6EED421D74FFE47657ACE20DE9FB01305A3301ED
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-01

--- a/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# Created for GestureSign V2 18.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Added volume up, volume down, and vertical or horizontal scrolling to all four touchpad and touchscreen edges.
+  - Added a switch between slider-like continuous volume adjustment and one action per swipe; mute always fires once.
+  - Added direction-aware continuous edge scrolling.
+  - Improved multi-finger retrace checks to reduce false Smart Close triggers during intensive web-page scrolling.
+  - Fixed the false-positive guard incorrectly blocking normal two-, three-, and four-finger gestures.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.2
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# Created for GestureSign V2 18.2
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the official GestureSign V2 18.2 manifests. This release adds configurable continuous or one-shot edge volume control, direction-aware edge scrolling, improved Smart Close false-trigger protection, and fixes the regression that blocked normal multi-finger gestures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427199)