### PR TITLE
New package: Outcasts.Lorekeel version 0.5.19

### DIFF
--- a/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.installer.yaml
+++ b/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Outcasts.Lorekeel
+PackageVersion: 0.5.19
+# InstallerLocale は書かない (Fuseforks 2026-08-29 の裁定)。en-US を宣言すると日本語環境の
+# インストール記録 (ja-JP) と突き合わされて winget upgrade が UPDATE_NOT_APPLICABLE で落ちる。
+# 宣言が無ければ winget-cli の preference 枝が空ロケールを素通しするので構造的に起きない。
+Platform:
+- Windows.Desktop
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{32111BC6-AB44-45B3-9189-D9838CD05895}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/betyourluck/Lorekeel/releases/download/v0.5.19/Lorekeel_0.5.19_x64_en-US.msi
+  InstallerSha256: 27724A318DBEB4D2D59108E5B76511D12C195E6A00B9E771E86D3810189DCB68
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.locale.en-US.yaml
+++ b/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Outcasts.Lorekeel
+PackageVersion: 0.5.19
+PackageLocale: en-US
+Publisher: Outcasts
+PublisherUrl: https://outcasts.jp
+PublisherSupportUrl: https://github.com/betyourluck/Lorekeel/issues
+PackageName: Outcasts Lorekeel
+PackageUrl: https://github.com/betyourluck/Lorekeel
+License: MIT
+LicenseUrl: https://github.com/betyourluck/Lorekeel/blob/main/LICENSE
+ShortDescription: A TRPG game master that never forgets or contradicts - an LLM narrates while a deterministic Rust engine owns the game state.
+Description: Lorekeel is a desktop TRPG game master. A cloud or local LLM writes the narration, while a deterministic Rust engine owns the game state - HP, inventory, flags, dice rolls, and location. The engine adjudicates every change the model proposes, so the GM cannot forget what you carry, who died, or what was decided last turn. Because the engine backs up the model's mistakes, coherent play does not require a frontier model. Scenario packages are plain YAML folders you can write, share, and download from a community archive.
+Moniker: lorekeel
+Tags:
+- ai
+- game-master
+- llm
+- narrative
+- roleplaying
+- rpg
+- storytelling
+- tabletop
+- trpg
+- ttrpg
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.yaml
+++ b/manifests/o/Outcasts/Lorekeel/0.5.19/Outcasts.Lorekeel.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Outcasts.Lorekeel
+PackageVersion: 0.5.19
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `Outcasts.Lorekeel` version `0.5.19`

Outcasts Lorekeel is a desktop TRPG game master: a cloud or local LLM writes the narration while a deterministic Rust engine owns the game state (HP, inventory, flags, dice, location).

- Homepage: https://github.com/betyourluck/Lorekeel
- Publisher: Outcasts (https://outcasts.jp) — same publisher namespace as the existing `Outcasts.Fuseforks`
- Installer: MSI only (x64, machine scope). The NSIS `-setup.exe` is intentionally not submitted; the MSI carries `ProductCode` / `UpgradeCode` so upgrade and uninstall correlation is structural.
- `InstallerLocale` is intentionally omitted so that upgrades are not rejected on non-en-US systems.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427244)