### PR TITLE
Added ARM64: Dell.CommandUpdate version 5.7.0

### DIFF
--- a/manifests/d/Dell/CommandUpdate/5.7.0/Dell.CommandUpdate.installer.yaml
+++ b/manifests/d/Dell/CommandUpdate/5.7.0/Dell.CommandUpdate.installer.yaml
@@ -34,5 +34,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://dl.dell.com/FOLDER14424243M/1/Dell-Command-Update-Application_RXT5N_WIN64_5.7.0_A00.EXE
   InstallerSha256: B6D0D06EDF25A7D9092208B2686502E031DEDA5CCB2D283BA8A434B27891F3CF
+- Architecture: arm64
+  InstallerUrl: https://dl.dell.com/FOLDER14428036M/1/Dell-Command-Update_71G67_WINARM64_5.7.0_A00.EXE
+  InstallerSha256: A53ACCF112DC622C4448402B85877BBD3CAC023FE2B1BE30879AAA9A09D31DEF
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the native **ARM64** installer to the existing `Dell.CommandUpdate` 5.7.0 manifest. No other fields are changed.

Dell publishes a separate ARM64 build of the same 5.7.0 (A00) release for its Snapdragon X systems, but only the x64 installer was present in winget, so Windows on ARM devices fall back to the emulated x64 build.

| | |
|---|---|
| Architecture | `arm64` |
| File | `Dell-Command-Update_71G67_WINARM64_5.7.0_A00.EXE` |
| Size | 92,505,648 bytes (88.2 MB) |
| SHA256 | `A53ACCF112DC622C4448402B85877BBD3CAC023FE2B1BE30879AAA9A09D31DEF` |
| Source | [Dell driver ID 71G67](https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=71G67) |

The download is Authenticode-signed by `CN=Dell Technologies Inc.`, its PE header reports `CPU = ARM64`, and its `package.xml` declares version `5.7.0` / `A00` with supported systems Latitude 7455 and Latitude 5455.

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not possible on x64 hardware; this is an ARM64-only installer. The existing x64 installer entry is unchanged.
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-cmd/tree/main/schemas/JSON/manifests/v1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427253)