### PR TITLE
Added ARM64: Dell.CommandUpdate.Universal version 5.7.0

### DIFF
--- a/manifests/d/Dell/CommandUpdate/Universal/5.7.0/Dell.CommandUpdate.Universal.installer.yaml
+++ b/manifests/d/Dell/CommandUpdate/Universal/5.7.0/Dell.CommandUpdate.Universal.installer.yaml
@@ -34,5 +34,8 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://dl.dell.com/FOLDER14424601M/1/Dell-Command-Update-Windows-Universal-Application_FGK9X_WIN64_5.7.0_A00.EXE
   InstallerSha256: 98C20D9809D7469A760B42A9A258E8C67A35C6CF46AA6A9C173E29D39A056D89
+- Architecture: arm64
+  InstallerUrl: https://dl.dell.com/FOLDER14428078M/1/Dell-Command-Update-Windows-Universal-Application_522NN_WINARM64_5.7.0_A00.EXE
+  InstallerSha256: D45D24E0870134EC78F5CB9CECF8F54E4DA9F6198E1DD47C8E405F0E9068BACB
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the native **ARM64** installer to the existing `Dell.CommandUpdate.Universal` 5.7.0 manifest. No other fields are changed.

Dell publishes a separate ARM64 build of the same 5.7.0 (A00) release for its Snapdragon X systems, but only the x64 installer was present in winget, so Windows on ARM devices fall back to the emulated x64 build.

| | |
|---|---|
| Architecture | `arm64` |
| File | `Dell-Command-Update-Windows-Universal-Application_522NN_WINARM64_5.7.0_A00.EXE` |
| Size | 101,801,872 bytes (97.1 MB) |
| SHA256 | `D45D24E0870134EC78F5CB9CECF8F54E4DA9F6198E1DD47C8E405F0E9068BACB` |
| Source | [Dell driver ID 522NN](https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=522NN) |

The download is Authenticode-signed by `CN=Dell Technologies Inc.`, its PE header reports `CPU = ARM64`, and its version resource reads `Command | Update Windows Universal Application, 5.7.0, A00`.

-----

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not possible on x64 hardware; this is an ARM64-only installer. The existing x64 installer entry is unchanged.
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-cmd/tree/main/schemas/JSON/manifests/v1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427254)