### PR TITLE
New package: imalisherbekenov.WinBoost version 3.1

### DIFF
--- a/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.installer.yaml
+++ b/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: imalisherbekenov.WinBoost
+PackageVersion: "3.1"
+MinimumOSVersion: 10.0.19041.0
+InstallerType: portable
+Commands:
+- winboost
+ReleaseDate: 2026-08-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/imalisherbekenov/winboost/releases/download/v3.1/WinBoost-3.1.exe
+  InstallerSha256: B9AAC2087665E8E6D31CC97C4DEC12126BB7B83C0FC0FA3357E0048AF45BA6AB
+  ElevationRequirement: elevatesSelf
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.locale.ru-RU.yaml
+++ b/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.locale.ru-RU.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: imalisherbekenov.WinBoost
+PackageVersion: "3.1"
+PackageLocale: ru-RU
+Publisher: Alisher Bekenov
+PublisherUrl: https://github.com/imalisherbekenov
+PublisherSupportUrl: https://github.com/imalisherbekenov/winboost/issues
+PackageName: WinBoost
+PackageUrl: https://winboost.vercel.app
+License: MIT
+LicenseUrl: https://github.com/imalisherbekenov/winboost/blob/main/LICENSE
+ShortDescription: Оптимизатор Windows с предпросмотром изменений и откатом
+Description: |-
+  WinBoost анализирует систему, показывает список изменений до их применения
+  и умеет откатить сделанное.
+
+  Любое применение проходит через экран проверки: список действий с уровнем
+  риска, отдельная секция необратимых и сводка того, что попадёт в снимок.
+
+  Снимок покрывает значения реестра, тип запуска и состояние служб, задачи
+  планировщика, план электропитания, DNS и список UWP-пакетов. Первичный
+  снимок создаётся один раз и не перезаписывается, поэтому вернуться можно
+  и к предыдущему состоянию, и к исходному.
+
+  Удаление UWP-приложений и очистка файлов необратимы — такие действия
+  помечены и вынесены отдельно.
+Moniker: winboost
+Tags:
+- optimizer
+- privacy
+- windows
+- оптимизация
+- приватность
+ReleaseNotesUrl: https://github.com/imalisherbekenov/winboost/releases/tag/v3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.yaml
+++ b/manifests/i/imalisherbekenov/WinBoost/3.1/imalisherbekenov.WinBoost.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: imalisherbekenov.WinBoost
+PackageVersion: "3.1"
+DefaultLocale: ru-RU
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been manually validated?

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

---

**WinBoost** — a Windows optimizer that previews every change before applying it and can roll changes back.

- Homepage: https://winboost.vercel.app
- Repository: https://github.com/imalisherbekenov/winboost
- Release: https://github.com/imalisherbekenov/winboost/releases/tag/v3.1
- License: MIT

`InstallerType: portable` — WinBoost is a standalone executable rather than an installer. `ElevationRequirement: elevatesSelf` reflects that the app requests administrator rights itself on launch.

Validated locally on Windows 11 x64: `winget validate` passed, and installing from the manifest downloaded the release asset, verified the SHA256, registered the `winboost` alias and launched the application.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427255)