### PR TITLE
New package: Tengolabs.kbCalc version 1.1.0

### DIFF
--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Tengolabs.kbCalc
 PackageVersion: 1.1.0
 Platform:
@@ -16,4 +16,4 @@ Installers:
   InstallerUrl: https://github.com/tengolabs/kbcalc/releases/download/v1.1.0/kbCalc.Setup.1.1.0.exe
   InstallerSha256: A7F12FD122FFB3CE22D4FC0954440E5717AAEA5E627628C788B9F2FF1697814D
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Tengolabs.kbCalc
+PackageVersion: 1.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nsis
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tengolabs/kbcalc/releases/download/v1.1.0/kbCalc.Setup.1.1.0.exe
+  InstallerSha256: A7F12FD122FFB3CE22D4FC0954440E5717AAEA5E627628C788B9F2FF1697814D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.installer.yaml
@@ -4,7 +4,7 @@ PackageVersion: 1.1.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
-InstallerType: nsis
+InstallerType: nullsoft
 InstallModes:
 - interactive
 - silent
@@ -13,7 +13,11 @@ UpgradeBehavior: install
 ReleaseDate: 2026-09-01
 Installers:
 - Architecture: x64
+  Scope: user
   InstallerUrl: https://github.com/tengolabs/kbcalc/releases/download/v1.1.0/kbCalc.Setup.1.1.0.exe
   InstallerSha256: A7F12FD122FFB3CE22D4FC0954440E5717AAEA5E627628C788B9F2FF1697814D
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.locale.en-US.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Tengolabs.kbCalc
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: Tengo s.r.o.
+PublisherUrl: https://killbottleneck.com
+PublisherSupportUrl: https://github.com/tengolabs/kbcalc/issues
+Author: Richard Pobrislo
+PackageName: kbCalc
+PackageUrl: https://github.com/tengolabs/kbcalc
+License: MIT
+LicenseUrl: https://github.com/tengolabs/kbcalc/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Richard Pobrislo
+ShortDescription: Floating translucent calculator with a built-in Winamp-style MP3 player.
+Description: |-
+  kbCalc is an open source (MIT) floating, translucent calculator with a built-in
+  Winamp-style MP3 player. It behaves like the classic Windows Standard calculator,
+  adds an auto-saved mini notepad and calculation history, and the player brings a
+  real-time visualizer, a 5-band equalizer, named playlists, ID3 tags, podcasts
+  and internet radio. Czech and English UI.
+Moniker: kbcalc
+Tags:
+- calculator
+- electron
+- equalizer
+- mp3
+- music
+- open-source
+- podcast
+- radio
+- winamp
+ReleaseNotesUrl: https://github.com/tengolabs/kbcalc/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.locale.en-US.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Tengolabs.kbCalc
 PackageVersion: 1.1.0
 PackageLocale: en-US
@@ -31,4 +31,4 @@ Tags:
 - winamp
 ReleaseNotesUrl: https://github.com/tengolabs/kbcalc/releases/tag/v1.1.0
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Tengolabs.kbCalc
 PackageVersion: 1.1.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.yaml
+++ b/manifests/t/Tengolabs/kbCalc/1.1.0/Tengolabs.kbCalc.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Tengolabs.kbCalc
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: **Tengolabs.kbCalc** version 1.1.0

kbCalc is an open source (MIT) floating, translucent calculator with a built-in Winamp-style MP3 player (Electron). First submission of this package.

- [ ] `winget validate` / `winget install --manifest` were **not** run locally (authored on Linux, no winget available) — relying on the pipeline validation; happy to fix anything it flags.
- [x] Manifests authored against the [1.6.0 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0).
- [x] Installer is the official GitHub Release asset of [tengolabs/kbcalc v1.1.0](https://github.com/tengolabs/kbcalc/releases/tag/v1.1.0); SHA256 matches the published `SHA256SUMS-windows-latest.txt`. Standard electron-builder NSIS installer (silent `/S` supported). The app itself was click-tested on Windows.
