### PR TITLE
Nabukodonozor.NabuSQL version 1.0.95

### DIFF
--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.installer.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Nabukodonozor.NabuSQL
+PackageVersion: 1.0.95
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://nabusql.nabu.work/releases/NabuSQL_1.0.95_x64-setup.exe
+  InstallerSha256: 6DDAC9D85B9032196280E01580ECE9340F8BA78660AF414F2F5779E1D559AB13
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2026-09-01

--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.installer.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.installer.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Nabukodonozor.NabuSQL
 PackageVersion: 1.0.95
@@ -15,5 +15,5 @@ Installers:
   InstallerUrl: https://nabusql.nabu.work/releases/NabuSQL_1.0.95_x64-setup.exe
   InstallerSha256: 6DDAC9D85B9032196280E01580ECE9340F8BA78660AF414F2F5779E1D559AB13
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 ReleaseDate: 2026-09-01

--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.locale.en-US.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Nabukodonozor.NabuSQL
+PackageVersion: 1.0.95
+PackageLocale: en-US
+Publisher: Nabukodonozor d.o.o.
+PublisherUrl: https://nabukodonozor.hr
+PublisherSupportUrl: https://nabusql.nabu.work/
+PrivacyUrl: https://nabusql.nabu.work/legal.php?doc=privacy&lang=en
+Author: Nabukodonozor d.o.o.
+PackageName: NabuSQL
+PackageUrl: https://nabusql.nabu.work/
+License: Proprietary
+LicenseUrl: https://nabusql.nabu.work/legal.php?doc=eula&lang=en
+Copyright: Copyright (c) 2026 Nabukodonozor d.o.o.
+CopyrightUrl: https://nabusql.nabu.work/legal.php?doc=eula&lang=en
+ShortDescription: Lightweight database manager for MySQL, PostgreSQL, SQLite and MSSQL
+Description: |-
+  NabuSQL is a fast, lightweight desktop database manager built with Rust and Tauri.
+  It connects to MySQL, PostgreSQL, SQLite and Microsoft SQL Server from a single
+  interface and includes a visual query builder, schema browsing, data import/export,
+  SSH tunneling and cross-engine data transfers.
+
+  A built-in AI assistant turns plain-language questions into SQL and works with
+  OpenAI, Anthropic and Google Gemini, or with a local model such as Ollama.
+
+  The application runs fully offline — no account, no telemetry and no cloud
+  dependency. A 40-day trial is included; the full licence is a one-time purchase.
+Moniker: nabusql
+Tags:
+- database
+- database-manager
+- sql
+- sql-client
+- mysql
+- mariadb
+- postgresql
+- sqlite
+- mssql
+- developer-tools
+InstallationNotes: The 40-day trial starts on first launch. A licence key can be purchased at https://nabusql.nabu.work/#buy
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.locale.en-US.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Nabukodonozor.NabuSQL
 PackageVersion: 1.0.95
@@ -41,4 +41,4 @@ Tags:
 - developer-tools
 InstallationNotes: The 40-day trial starts on first launch. A licence key can be purchased at https://nabusql.nabu.work/#buy
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Nabukodonozor.NabuSQL
+PackageVersion: 1.0.95
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.yaml
+++ b/manifests/n/Nabukodonozor/NabuSQL/1.0.95/Nabukodonozor.NabuSQL.yaml
@@ -1,8 +1,8 @@
 # Created using wingetcreate 1.12.13.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Nabukodonozor.NabuSQL
 PackageVersion: 1.0.95
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: Nabukodonozor.NabuSQL version 1.0.95

NabuSQL is a desktop database manager for MySQL, PostgreSQL, SQLite and
Microsoft SQL Server, built with Rust and Tauri.

The installer is EV code-signed and hosted on the publisher's own domain
(https://nabusql.nabu.work/releases/), at a versioned URL that is never
overwritten or reused. Manifest was validated and installed locally before
submission.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427304)