### PR TITLE
New version: ZiCode.ZiFile version 0.1.15

### DIFF
--- a/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.installer.yaml
+++ b/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.installer.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ZiCode.ZiFile
+PackageVersion: 0.1.15
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: msix
+Scope: user
+UpgradeBehavior: install
+FileExtensions:
+- zip
+- zipx
+- cbz
+- epub
+- 7z
+- cb7
+- rar
+- cbr
+- cab
+- tar
+- cbt
+- gz
+- tar.gz
+- tgz
+- zst
+- tar.zst
+- tzst
+- xz
+- tar.xz
+- txz
+- tar.lzma
+- lzma
+- bz
+- bz2
+- tar.bz2
+- tbz
+- tbz2
+- tar.lz4
+- tlz4
+- lz4
+- br
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ax2/zifile/releases/download/v0.1.15/ZiFile-0.1.15.0-windows.msixbundle
+  InstallerSha256: 8E5FF86ACDC01EF3FE04211A754961314B86A7EF995CD898ABD8E358D300A4FB
+- Architecture: arm64
+  InstallerUrl: https://github.com/ax2/zifile/releases/download/v0.1.15/ZiFile-0.1.15.0-windows.msixbundle
+  InstallerSha256: 8E5FF86ACDC01EF3FE04211A754961314B86A7EF995CD898ABD8E358D300A4FB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.locale.en-US.yaml
+++ b/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ZiCode.ZiFile
+PackageVersion: 0.1.15
+PackageLocale: en-US
+Publisher: ZiCode
+PublisherUrl: https://zicode.com/
+PublisherSupportUrl: https://github.com/ax2/zifile/issues
+Author: ZiCode
+PackageName: ZiFile
+PackageUrl: https://github.com/ax2/zifile
+License: MIT
+LicenseUrl: https://github.com/ax2/zifile/blob/main/LICENSE
+ShortDescription: A modern, safe archive manager for Windows written primarily in Rust.
+Description: Create, browse, verify, and safely extract common archive and compression formats from a modern Windows desktop interface or command line.
+Moniker: zifile
+Tags:
+- archive
+- compression
+- rust
+- sevenzip
+- tar
+- zip
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.locale.zh-CN.yaml
+++ b/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.locale.zh-CN.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: ZiCode.ZiFile
+PackageVersion: 0.1.15
+PackageLocale: zh-CN
+Publisher: ZiCode
+PackageName: ZiFile
+ShortDescription: 以 Rust 为主实现的现代、安全 Windows 压缩文件管理器。
+Description: 通过现代 Windows 桌面界面或命令行创建、浏览、校验并安全解压常见归档与压缩格式。
+Tags:
+- 压缩
+- 归档
+- 解压
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.yaml
+++ b/manifests/z/ZiCode/ZiFile/0.1.15/ZiCode.ZiFile.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ZiCode.ZiFile
+PackageVersion: 0.1.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Add ZiCode.ZiFile version 0.1.15 from the published all-in-one MSIX bundle. Local winget validate passed; x64 and arm64 use the same public GitHub Release asset and SHA-256.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427332)