### PR TITLE
New package: JDE-Projects.SimpleProjectManager version 1.3.5

### DIFF
--- a/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.installer.yaml
+++ b/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleProjectManager
+PackageVersion: 1.3.5
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Simple Project Manager version v1.3.5
+  Publisher: JDE Projects
+  DisplayVersion: v1.3.5
+  ProductCode: 9c6da3fc-e0ce-4e6f-9119-00efc3e4119f_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JDE-Projects/Simple-Project-Manager/releases/download/v1.3.5/SimpleProjectManager-v1.3.5-setup.exe
+  InstallerSha256: F31AA62DD509D357459750F432D6EAACC453236BF24C64810962CAC944C74496
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-01

--- a/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.locale.en-US.yaml
+++ b/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleProjectManager
+PackageVersion: 1.3.5
+PackageLocale: en-US
+Publisher: JDE-Projects
+PublisherUrl: https://github.com/JDE-Projects
+PublisherSupportUrl: https://github.com/JDE-Projects/Simple-Project-Manager/issues
+PackageName: Simple Project Manager
+PackageUrl: https://github.com/JDE-Projects/Simple-Project-Manager
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/JDE-Projects/Simple-Project-Manager/blob/main/LICENSE
+Copyright: Copyright (c) 2026 JDE-Projects
+ShortDescription: Plan and track IT projects as a nested checklist of phases, steps, and actions, saved as Excel files.
+Description: "Simple Project Manager is a standalone desktop tool to plan, track, and manage IT projects as a nested checklist: phases hold steps, and steps hold actions and contacts. Every item carries an owner and co-owner, a deadline, a status, a priority, tags, and notes, with progress rolling up automatically. Projects are saved as ordinary Excel .xlsx files you can reopen in the app or in Excel. It has dark and light teal themes, filtering and reordering, and an update check against GitHub Releases."
+Moniker: simple-project-manager
+Tags:
+- checklist
+- excel
+- planning
+- project-management
+- task-management
+- xlsx
+ReleaseNotesUrl: https://github.com/JDE-Projects/Simple-Project-Manager/releases/tag/v1.3.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.yaml
+++ b/manifests/j/JDE-Projects/SimpleProjectManager/1.3.5/JDE-Projects.SimpleProjectManager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JDE-Projects.SimpleProjectManager
+PackageVersion: 1.3.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Initial submission of JDE-Projects.SimpleProjectManager version 1.3.5. Manifest passes `winget validate`. Installer is the publisher's signed-provenance GitHub release asset (Inno Setup, per-user scope).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427335)