### PR TITLE
New version: StruisICT.ClutterCutter version 0.11.0

### DIFF
--- a/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.installer.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.installer.yaml
@@ -1,0 +1,16 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.11.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- cluttercutter
+ReleaseDate: 2026-08-21
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/ClutterCutter/releases/download/v0.11.0/ClutterCutter.exe
+  InstallerSha256: C9F76B8D75BCF9EC437A069C9AD0321EC195FB55C8E75CB17458E72C769527FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.locale.en-US.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.11.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/StruisICT/ClutterCutter/issues
+PackageName: ClutterCutter
+PackageUrl: https://github.com/StruisICT/ClutterCutter
+License: MIT
+LicenseUrl: https://github.com/StruisICT/ClutterCutter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast disk-usage browser with NTFS MFT scanning.
+Description: |-
+  ClutterCutter is a lightweight Windows disk-usage browser. On NTFS drives it
+  reads the Master File Table directly for very fast full-drive scans (roughly
+  one million files in six seconds), with a parallel FindFirstFileEx walker as
+  a fallback for non-NTFS drives and non-admin runs. Includes a treeview
+  drill-in, a Top-largest-files view, an Oldest-files (by date modified) view,
+  and a safe-to-delete temp/cache files view. Single self-contained exe; no
+  installer, no .NET runtime.
+Moniker: cluttercutter
+Tags:
+- disk
+- disk-usage
+- ntfs
+- mft
+- treesize
+- utility
+- windows
+ReleaseNotes: |-
+  See the full release notes at https://github.com/StruisICT/ClutterCutter/releases/tag/v0.11.0
+ReleaseNotesUrl: https://github.com/StruisICT/ClutterCutter/releases/tag/v0.11.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.11.0/StruisICT.ClutterCutter.yaml
@@ -1,0 +1,8 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: StruisICT.ClutterCutter version 0.11.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Version update **0.9.2 → 0.11.0** for `StruisICT.ClutterCutter`.

Same application and publisher; this bumps the packaged portable `ClutterCutter.exe` to the current release. Changes since 0.9.2: an egui UI polish pass and (for enterprise/GPO deployment, distributed separately, not via winget) an MSI installer. The winget package remains the single self-contained portable exe.

Installer URL and SHA256 point at the `v0.11.0` GitHub release asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427360)