### PR TITLE
New version: SerZhyAle.FastMediaSorter version 26.9.1.1550

### DIFF
--- a/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.installer.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# NOTE: This is the shape that PASSED validation in PR microsoft/winget-pkgs#386820.
+# Do NOT add `Scope`, `Dependencies`, or `NestedInstallerType` here - each one
+# fails winget validation. See docs/specifications/done/SPECIFICATION_WINGET_PUBLISHING.md before editing.
+#
+# Do NOT add `MinimumOSVersion` for the .NET 10 mainline. The x64 viewer needs
+# Windows 10 1607, but this setup.exe is NOT x64-only inside: it also installs the
+# 32-bit net48 sibling and, on Windows 7/8.1, points the shortcut and the file
+# associations at it (installer MinVersion=6.1; see `UseModernExe` in
+# installer/FastMediaSorter.iss). Declaring 10.0.14393 here would wrongly hide the
+# package from the machines the sibling exists to serve. `Architecture: x64` stays
+# as validated - it matches the release asset name and the mainline target.
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: "26.9.1.1550"
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/download/v26.9.1.1550/FastMediaSorter-26.9.1.1550-windows-x64-setup.exe
+  InstallerSha256: CCB9F293F285371F7920E97B178E161E2A983F882897A69C50106425CFC57E92
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-01

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.locale.en-US.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: "26.9.1.1550"
+PackageLocale: en-US
+Publisher: SZA
+PublisherUrl: https://github.com/SerZhyAle
+PublisherSupportUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/issues
+Author: Serhii Zhyhunenko
+# PackageName is FROZEN as "FastMediaSorter LITE" (it matches the installed ARP
+# DisplayName, which is how winget correlates `winget upgrade`) - do NOT rename it.
+# Only ShortDescription/Description are refreshed with the new brand name; the
+# product is described as "Fast Media Sorter for Windows (published as
+# FastMediaSorter LITE)". See SPECIFICATION_RENAME_FAST_MEDIA_SORTER_FOR_WINDOWS.md.
+PackageName: FastMediaSorter LITE
+PackageUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite
+License: MIT
+LicenseUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/LICENSE
+Copyright: Copyright (c) 2025 SZA
+ShortDescription: Fast Media Sorter for Windows - keyboard-driven viewer and sorter for images and videos, now a modern 64-bit build that needs no .NET Framework.
+Description: |-
+  Fast Media Sorter for Windows (published here as "FastMediaSorter LITE") is a fast, keyboard-driven
+  viewer and sorter for images and video on Windows. Tick folders to browse, then move, copy, rename or
+  delete files with single-key hotkeys - built for photographers and creators who triage large media
+  folders quickly. It handles a wide range of formats, slideshow and random modes, EXIF auto-rotate, an
+  Ambilight-style background fill, and optional on-image OCR translation.
+
+  The main program is now a 64-bit .NET 10 build that carries its own runtime - there is nothing extra
+  to install and no .NET Framework requirement. It replaces the previous version in place and keeps
+  your settings. Video always plays through the built-in VLC engine (H.264/MP4, AVI, MKV, VP9, ZMBV and
+  more), and static and animated WEBP images open on their own, without the Windows "WebP Image
+  Extensions" codec that some editions of Windows lack.
+
+  A 32-bit build with the same feature set ships alongside it for Windows 7/8.1 and 32-bit machines.
+  The installer picks the right one for your PC automatically and points the shortcut and file
+  associations at it, so there is nothing to choose. The 64-bit main program requires Windows 10
+  version 1607 or newer, Windows 11, or Windows Server 2016 or newer.
+
+  The interface is available in 13 languages - English, Russian, Ukrainian, German, Italian,
+  Spanish, French, Portuguese, Arabic, Hindi, Bengali, Urdu and Chinese - and picks the one your
+  Windows display language uses on first run; a button on the toolbar switches it at any time.
+  The bundled Share Manager speaks the same 13 languages and follows the same choice. Only
+  English, Russian and Ukrainian are proofread by the author; the rest are machine translations,
+  and corrections are welcome through the issue tracker. The setup wizard itself stays English.
+Moniker: fastmediasorter
+Tags:
+- file-manager
+- hotkeys
+- images
+- media
+- organizer
+- photos
+- pictures
+- slideshow
+- sorter
+- triage
+- utility
+- videos
+- viewer
+- winforms
+ReleaseNotesUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.9.1.1550
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SerZhyAle/FastMediaSorter_Lite/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.yaml
+++ b/manifests/s/SerZhyAle/FastMediaSorter/26.9.1.1550/SerZhyAle.FastMediaSorter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SerZhyAle.FastMediaSorter
+PackageVersion: "26.9.1.1550"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Version update for **SerZhyAle.FastMediaSorter** (Fast Media Sorter for Windows, published as `FastMediaSorter LITE`): `26.8.19.0130` -> `26.9.1.1550`.

Only `PackageVersion`, `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and `ReleaseNotesUrl` changed - the last one had been left pointing at an older release and now points at this one. The installer shape is unchanged from the manifest that passed validation previously: the Inno `setup.exe` is referenced directly (`InstallerType: inno`), with **no** `Dependencies`, **no** `Scope` and **no** `NestedInstallerType`.

**What's new in this version** (full text: [CHANGELOG](https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md)):

- Music files get a screen of their own: an MP3, WAV, M4A, WMA or OGG shows its embedded album cover - or a wave-and-particle animation when it has none - with the title, artist, album, codec, bitrate and length along the bottom. A new Audio settings section owns what happens when a track ends, whether the transport panel stays visible, and a sleep timer of up to three hours.
- Video and audio can each be left out of paging entirely, so a folder of photographs stays a folder of photographs even when it also holds clips and music. The preferred audio and subtitle track language is now a plain setting rather than only the last pick being remembered.
- A ZIP or CBZ can now be opened and closed straight from the folder menu, the file-open dialog gained an "Archives" filter, and the archive cache limit is genuinely enforced: least-recently-used extracted pages are dropped once the budget is reached, always sparing the page on screen and its immediate neighbours.
- An animated WEBP, APNG or GIF can be turned into an ordinary MP4 that replaces it - the encoder (FFmpeg, GPL) is downloaded only if you ask for it - and those same slow formats (animated WEBP, AVIF, HEIC) now keep their decoded result on disk and reopen instantly.
- A destination folder that is switched off, asleep or gone says so on the first press instead of on the twentieth timeout, a failed file operation names the folder instead of quoting .NET, and a destination whose last folder does not exist yet is created on the first transfer.

Links:
- Release: https://github.com/SerZhyAle/FastMediaSorter_Lite/releases/tag/v26.9.1.1550
- Changelog: https://github.com/SerZhyAle/FastMediaSorter_Lite/blob/main/CHANGELOG.md

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
