### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.2.1

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.1
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{29F9BEED-C766-42EC-B01A-A603B8B08077}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{29F9BEED-C766-42EC-B01A-A603B8B08077}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.2.1/GestureSign-V2-18.2.1-x64.msi
+  InstallerSha256: D5396CF9D627F88FF818DA53BD6B8A1BA26F733695A8AB0E54FDAD7FAC56C664
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-01

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created for GestureSign V2 18.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.1
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Fixed per-gesture global action fallback in live previews for app groups such as Edge.
+  - Live action hints now reflect only the current complete path and clear immediately when further drawing invalidates the match.
+  - Releasing or canceling clears the hint layer before final recognition and action execution, preventing flicker and stale labels.
+  - Rejected one-finger touchpad frames no longer create or take ownership of a visual hint lifecycle.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.2.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.1/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# Created for GestureSign V2 18.2.1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- New release: GestureSign V2 18.2.1
- Installer URL and SHA-256 verified against the GitHub Release asset
- MSI ProductCode: {29F9BEED-C766-42EC-B01A-A603B8B08077}
- `winget validate` completed successfully

This supersedes #427199 for version 18.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427385)