### PR TITLE
New package: OpticQuiz.Corrector version 1.1.0

### DIFF
--- a/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.installer.yaml
+++ b/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: OpticQuiz.Corrector
+PackageVersion: 1.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- opticquizcorrector
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vince-gonzalez/opticquiz.com/releases/download/v1.1.0-desktop/OpticQuizCorrector.exe
+  InstallerSha256: 213A4D015AA13E697A36EA71BB9DA3DDDF1275A280CEFA0A0AFDD99AD8220DF1
+ManifestType: installer
+ManifestVersion: 1.6.0
+ReleaseDate: 2026-08-05

--- a/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.locale.en-US.yaml
+++ b/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.locale.en-US.yaml
@@ -1,0 +1,53 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: OpticQuiz.Corrector
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: OpticQuiz
+PublisherUrl: https://opticquiz.com
+PublisherSupportUrl: https://github.com/vince-gonzalez/opticquiz.com/issues
+PrivacyUrl: https://opticquiz.com/privacy/
+Author: Vince Gonzalez
+PackageName: OpticQuiz Corrector
+PackageUrl: https://opticquiz.com/setup/
+License: MIT
+LicenseUrl: https://github.com/vince-gonzalez/opticquiz.com/blob/main/LICENSE
+Copyright: Copyright (c) Vince Gonzalez
+ShortDescription: Colour-blindness correction for the entire Windows screen.
+Description: |-
+  OpticQuiz Corrector re-colours your whole display so colours that collapse together for
+  colour-vision deficiency become distinguishable. It applies to everything on screen -
+  games, PDFs, video, and other applications - not only web pages, and runs from the
+  system tray.
+
+  Three correction modes (deuteranopia, protanopia, tritanopia) plus a balanced mode for
+  people who do not know their type. The transform is a published, open-access method
+  (Machado 2009 simulation with CIEDE2000, DOI 10.5281/zenodo.21310578).
+
+  The matrices used here are derived specifically for the colour space Windows applies
+  them in, which differs from the browser. Reusing the browser matrices measured worse,
+  so this ships its own.
+
+  This is an accessibility aid, not a cure or a medical device. It makes colours easier
+  to tell apart; it does not restore colour vision.
+Moniker: opticquiz
+Tags:
+- accessibility
+- a11y
+- colorblind
+- color-blindness
+- colour-blindness
+- daltonization
+- deuteranopia
+- protanopia
+- tritanopia
+- vision
+ReleaseNotesUrl: https://github.com/vince-gonzalez/opticquiz.com/releases/tag/v1.1.0-desktop
+Documentations:
+- DocumentLabel: Set-up guide
+  DocumentUrl: https://opticquiz.com/setup/
+- DocumentLabel: Published method
+  DocumentUrl: https://doi.org/10.5281/zenodo.21310578
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.yaml
+++ b/manifests/o/OpticQuiz/Corrector/1.1.0/OpticQuiz.Corrector.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: OpticQuiz.Corrector
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Replaces #412468, which I opened under a previous GitHub account. Same package and same version; this one is filed under the account that owns the repository the manifest points at.

The four `github.com` URLs now reference `vince-gonzalez/opticquiz.com` directly rather than resolving through the account-rename redirect: installer, support, licence and release notes.

`InstallerSha256` is unchanged. GitHub reports the asset digest for `OpticQuizCorrector.exe` on tag `v1.1.0-desktop` as `sha256:213a4d015aa13e697a36ea71bb9da3dddf1275a280cefa0a0afdd99ad8220df1`, which matches the value in the manifest.

`winget validate --manifest` passes.

I have not ticked an installation test box: I have not run `winget install --manifest` against this copy, so I am not asserting it.

#412468 is closed in favour of this one.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427462)