### PR TITLE
New version: PolyglotI18n.Polyglot version 0.13.10

### DIFF
--- a/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.installer.yaml
+++ b/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PolyglotI18n.Polyglot
+PackageVersion: 0.13.10
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: polyglot.exe
+  PortableCommandAlias: polyglot
+Commands:
+- polyglot
+Installers:
+- Architecture: x64
+  InstallerUrl: https://releases.getpolyglot.ai/v0.13.10/polyglot-v0.13.10-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 0C48E57E7E582B00EF684D033227255390AFE304C306898A6C9947A15C8DE564
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.locale.en-US.yaml
+++ b/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PolyglotI18n.Polyglot
+PackageVersion: 0.13.10
+PackageLocale: en-US
+Publisher: Polyglot i18n, LLC
+PublisherUrl: https://getpolyglot.ai
+PublisherSupportUrl: https://github.com/polyglot-i18n/cli/issues
+PrivacyUrl: https://getpolyglot.ai/privacy
+Author: Polyglot i18n, LLC
+PackageName: Polyglot CLI
+PackageUrl: https://getpolyglot.ai
+License: Proprietary
+LicenseUrl: https://github.com/polyglot-i18n/cli/blob/v0.13.10/LICENSE
+Copyright: Copyright (c) 2026 Polyglot i18n, LLC. All rights reserved.
+ShortDescription: Detect and translate untranslated frontend strings with AI.
+Description: Polyglot is a CLI-first i18n tool that scans frontend applications, wraps hardcoded strings, translates catalogs, validates output, and integrates with CI.
+Moniker: polyglot
+Tags:
+- ai
+- cli
+- i18n
+- localization
+- translation
+ReleaseNotesUrl: https://github.com/polyglot-i18n/cli/releases/tag/v0.13.10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.locale.en-US.yaml
+++ b/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.locale.en-US.yaml
@@ -5,13 +5,13 @@ PackageVersion: 0.13.10
 PackageLocale: en-US
 Publisher: Polyglot i18n, LLC
 PublisherUrl: https://getpolyglot.ai
-PublisherSupportUrl: https://github.com/polyglot-i18n/cli/issues
+PublisherSupportUrl: https://getpolyglot.ai/docs
 PrivacyUrl: https://getpolyglot.ai/privacy
 Author: Polyglot i18n, LLC
 PackageName: Polyglot CLI
 PackageUrl: https://getpolyglot.ai
 License: Proprietary
-LicenseUrl: https://github.com/polyglot-i18n/cli/blob/v0.13.10/LICENSE
+LicenseUrl: https://getpolyglot.ai/terms
 Copyright: Copyright (c) 2026 Polyglot i18n, LLC. All rights reserved.
 ShortDescription: Detect and translate untranslated frontend strings with AI.
 Description: Polyglot is a CLI-first i18n tool that scans frontend applications, wraps hardcoded strings, translates catalogs, validates output, and integrates with CI.
@@ -22,6 +22,5 @@ Tags:
 - i18n
 - localization
 - translation
-ReleaseNotesUrl: https://github.com/polyglot-i18n/cli/releases/tag/v0.13.10
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.yaml
+++ b/manifests/p/PolyglotI18n/Polyglot/0.13.10/PolyglotI18n.Polyglot.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PolyglotI18n.Polyglot
+PackageVersion: 0.13.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Release manifest generated by the Polyglot CLI v0.13.10 release workflow. The Windows x64 portable ZIP is hosted at releases.getpolyglot.ai and the manifest SHA-256 matches the published artifact.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427541)