### PR TITLE
Updated EULA URL in GTN locale manifest

### DIFF
--- a/manifests/a/Asep1582/GTN-Easymode/1.2.1/Asep1582.GTN-Easymode.locale.en-US.yaml
+++ b/manifests/a/Asep1582/GTN-Easymode/1.2.1/Asep1582.GTN-Easymode.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://asep3192.com/contactme
 Author: Asep1582
 PackageName: GTN-Easymode
 PackageUrl: https://asep3192.com/Easy
-License: All Rights Reserved. 
+License: All Rights Reserved.
 Copyright: (c) Copyright 2024 Asep1582
 ShortDescription: GTN (Guess The Number) - Easy mode is a fun game where you guess a randomly generated number between 0-100 in 7 attempts. The number range increases the more difficult it gets, and the number of guesses you have decreases.
 Description: GTN (Guess The Number) - Easy mode is a fun game where you guess a randomly generated number between 0-100 in 7 attempts. The number range increases the more difficult it gets, and the number of guesses you have decreases. The next two difficulties after easy are medium easy and medium.

--- a/manifests/a/Asep1582/GTN-Easymode/1.2.1/Asep1582.GTN-Easymode.locale.en-US.yaml
+++ b/manifests/a/Asep1582/GTN-Easymode/1.2.1/Asep1582.GTN-Easymode.locale.en-US.yaml
@@ -24,7 +24,7 @@ Tags:
 - command-line
 Agreements:
 - AgreementLabel: End User License Agreement
-  AgreementUrl: https://download.asep3192.com/GTN/Easy/installer/winget/EULA-winget.html
+  AgreementUrl: https://asep3192.com/winget/winget-EULA
 ReleaseNotesUrl: https://asep3192.com/downloads/GTN-Easygamemode-V1.2.1-OfficalRelease/GTN_EASY_V1.2_UpdateNotes.txt
 InstallationNotes: You may see windows smartscreen pop up saying "Windows Protected your PC" that is normal. Windows does that because GTN is not signed and is not widely downloaded enough for Windows to recognize it.
 ManifestType: defaultLocale


### PR DESCRIPTION
In my last proposal of change on 9/1/26 I accidentally put the wrong path to the EULA, I'm not sure if it went through and was approved. There should only one proposal of change for 9/1/26 from me. 

<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->
This pull request changes the EULA agreement URL to a redirecting link instead of a static path. 

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427566)