### PR TITLE
Fix: LocalSend.LocalSend version 1.18.2

### DIFF
--- a/manifests/l/LocalSend/LocalSend/1.18.2/LocalSend.LocalSend.installer.yaml
+++ b/manifests/l/LocalSend/LocalSend/1.18.2/LocalSend.LocalSend.installer.yaml
@@ -10,7 +10,6 @@ ProductCode: '{00809252-FEC6-448E-83B4-E7F55AE7E47D}_is1'
 ReleaseDate: 2026-08-24
 AppsAndFeaturesEntries:
 - ProductCode: '{00809252-FEC6-448E-83B4-E7F55AE7E47D}_is1'
-ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x64
   Scope: user
@@ -18,12 +17,15 @@ Installers:
   InstallerSha256: F53856750AD087A17B996309171262FA7D89071C350E0DC5DF6530F34DD8A2AE
   InstallerSwitches:
     Custom: /CURRENTUSER
+    Upgrade: /FORCECLOSEAPPLICATIONS
 - Architecture: x64
   Scope: machine
+  ElevationRequirement: elevatesSelf
   InstallerUrl: https://github.com/localsend/localsend/releases/download/v1.18.2/LocalSend-1.18.2-windows-x86-64-unsigned.exe
   InstallerSha256: F53856750AD087A17B996309171262FA7D89071C350E0DC5DF6530F34DD8A2AE
   InstallerSwitches:
     Custom: /ALLUSERS
+    Upgrade: /FORCECLOSEAPPLICATIONS
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%\LocalSend'
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description

Fixes LocalSend 1.18.2 upgrades when LocalSend is running and corrects the user-scope elevation metadata.

- Passes /FORCECLOSEAPPLICATIONS only during upgrades for both installer scopes. This prevents the silent Inno installer from defaulting to Abort when Restart Manager cannot close the tray application.
- Restricts ElevationRequirement: elevatesSelf to the machine-scoped /ALLUSERS installer. The /CURRENTUSER installer runs without elevation.

Related upstream issue: https://github.com/localsend/localsend/issues/1549

## ✅ Checklist

- [x] Signed the Contributor License Agreement
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest change
- [x] This PR only modifies one manifest
- [x] Validated the manifest locally with winget validate --manifest <path>
- [x] Tested the manifest locally with winget install --manifest <path>
- [x] Manifest conforms to the 1.12 schema

### Validation performed

- winget validate completed successfully.
- Reproduced the current exit-code-5 failure with LocalSend running: Restart Manager detected LocalSend, could not close it, and the suppressed Abort/Retry/Ignore dialog defaulted to Abort.
- Tested the exact /FORCECLOSEAPPLICATIONS argument against the running 1.18.2 installer through a local manifest; installation completed successfully and remained registered as version 1.18.2.
- Confirmed the user-scoped manifest path no longer announces or requests elevation.

Because 1.18.2 was already installed, winget would not execute a same-version package as an upgrade. The upgrade-specific switch was therefore validated through the local-manifest override path; InstallerSwitches.Upgrade is separately covered by manifest validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427629)