### PR TITLE
New version: Kaizen3C.KaizenCLI version 1.0.3

### DIFF
--- a/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.installer.yaml
+++ b/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.installer.yaml
@@ -1,0 +1,18 @@
+# winget installer manifest — multi-manifest format (v1.6)
+# File: manifests/k/Kaizen3C/KaizenCLI/<VERSION>/Kaizen3C.KaizenCLI.installer.yaml
+
+PackageIdentifier: Kaizen3C.KaizenCLI
+PackageVersion: 1.0.3
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/Kaizen-3C/kaizen-cli/releases/download/v1.0.3/kaizen-windows-x64.exe
+    InstallerSha256: 748B32F15B71D6186AED722A96497F5130337081986999019F3D6C07EF574330
+    Commands:
+      - kaizen
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.locale.en-US.yaml
+++ b/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# winget default locale manifest — multi-manifest format (v1.6)
+# File: manifests/k/Kaizen3C/KaizenCLI/<VERSION>/Kaizen3C.KaizenCLI.locale.en-US.yaml
+
+PackageIdentifier: Kaizen3C.KaizenCLI
+PackageVersion: 1.0.3
+PackageLocale: en-US
+Publisher: Kaizen 3C
+PublisherUrl: https://kaizen-3c.dev
+PublisherSupportUrl: https://github.com/Kaizen-3C/kaizen-cli/issues
+PrivacyUrl: https://kaizen-3c.dev/privacy
+Author: A. Adame
+PackageName: Kaizen CLI
+PackageUrl: https://github.com/Kaizen-3C/kaizen-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/Kaizen-3C/kaizen-cli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Anthony Adame
+CopyrightUrl: https://github.com/Kaizen-3C/kaizen-cli/blob/main/NOTICE
+ShortDescription: Architecture-driven modernization — decompose legacy codebases into ADRs, recompose to modern stacks.
+Description: |-
+  Kaizen CLI is an architecture-driven modernization tool. It decomposes legacy codebases
+  into editable Architectural Decision Records (ADRs) and recomposes them to modern stacks,
+  with an audit trail by default.
+
+  Key workflows:
+  - kaizen memsafe-roadmap: C/C++ to Rust migration with CISA-format memory-safety roadmaps
+  - kaizen migrate-plan: Framework modernization (AngularJS, .NET Framework, Java 8, etc.)
+
+  Requires ANTHROPIC_API_KEY or OPENAI_API_KEY environment variable.
+Moniker: kaizen
+Tags:
+  - cli
+  - architecture
+  - modernization
+  - refactoring
+  - rust
+  - memory-safety
+  - adr
+  - ai
+  - llm
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.yaml
+++ b/manifests/k/Kaizen3C/KaizenCLI/1.0.3/Kaizen3C.KaizenCLI.yaml
@@ -1,0 +1,8 @@
+# winget version manifest — multi-manifest format (v1.6)
+# File: manifests/k/Kaizen3C/KaizenCLI/<VERSION>/Kaizen3C.KaizenCLI.yaml
+
+PackageIdentifier: Kaizen3C.KaizenCLI
+PackageVersion: 1.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Bumps `Kaizen3C.KaizenCLI` from 1.0.1 to 1.0.3.

**1.0.2 is skipped deliberately.** That version was deprecated upstream on npm because it shipped an installer without checksum verification; there is no reason to publish it here.

The installer is the portable `kaizen-windows-x64.exe` attached to the [v1.0.3 GitHub release](https://github.com/Kaizen-3C/kaizen-cli/releases/tag/v1.0.3). `InstallerSha256` was verified by downloading the artifact and hashing it independently of the `.sha256` sidecar published alongside it; both agree.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? — signed for the 1.0.1 submission from this account; the CLA bot's status is authoritative.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change? — searched, none other than this one.
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? — `Manifest validation succeeded.` (winget v1.29.290)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not run.** The manifest validates and the installer digest was verified against the published artifact, but an end-to-end install was not performed. Flagging rather than ticking.
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)? — `ManifestVersion: 1.6.0`, confirmed by `winget validate`.