### PR TITLE
Update version: OpenJS.Electron.42 version 42.11.1

### DIFF
--- a/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.installer.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.1/electron-v42.11.1-win32-ia32.zip
+  InstallerSha256: C4E45BA6CA76E2C158BB36841FD2E860E0E1426DBD3C95E079C16684E122E50E
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.1/electron-v42.11.1-win32-x64.zip
+  InstallerSha256: D0C705D4D63697E37A593897167B428554F6639897BF581A0B714AD597CB66A0
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.1/electron-v42.11.1-win32-arm64.zip
+  InstallerSha256: 74F70CF7AC1B4C7D5152BA723F52F1D04B5BDAEA8916608379D728BAC6503A81
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.1
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: |-
+  # Release Notes for v42.11.1
+
+  ## Fixes
+
+  • Fixed `chrome.tabs.query()` returning tab `url` and `title` to extensions without the `tabs` permission or host access, aligning with `tabs.get`. [#53355](https://github.com/electron/electron/pull/53355) <sup>(Also in [43](https://github.com/electron/electron/pull/53356), [44](https://github.com/electron/electron/pull/53354), [45](https://github.com/electron/electron/pull/53353))</sup>
+  • Fixed a renderer crash when an array with a throwing property getter is passed across `contextBridge`, and several main/utility-process crashes when option objects passed to Electron APIs contain throwing accessors or Proxy traps. [#53329](https://github.com/electron/electron/pull/53329) <sup>(Also in [43](https://github.com/electron/electron/pull/53330), [44](https://github.com/electron/electron/pull/53331))</sup>
+  ## Other Changes
+
+  • Security：backported fixes for CVE-2026-15764, CVE-2026-15765, CVE-2026-15766, CVE-2026-15767, CVE-2026-15768, CVE-2026-15769, CVE-2026-15770, CVE-2026-15771, CVE-2026-15772, CVE-2026-15773, CVE-2026-15774, CVE-2026-15775, CVE-2026-15776, CVE-2026-15777, CVE-2026-15778. [#53344](https://github.com/electron/electron/pull/53344)
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v42.11.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.1/OpenJS.Electron.42.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.42 to version 42.11.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427637)