### PR TITLE
New version: StruisICT.ClutterCutter version 0.12.0

### DIFF
--- a/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.installer.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.12.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet LAUNCHAFTERINSTALL=1
+  SilentWithProgress: /passive LAUNCHAFTERINSTALL=1
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+ProductCode: '{8566912E-98B3-42F3-B19D-8494F5168D3A}'
+AppsAndFeaturesEntries:
+- ProductCode: '{8566912E-98B3-42F3-B19D-8494F5168D3A}'
+  UpgradeCode: '{FADE883B-0102-4A40-A367-3E96BD9692F7}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\ClutterCutter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/ClutterCutter/releases/download/v0.12.0/ClutterCutter.msi
+  InstallerSha256: C6107C00F05B0382FFB34620F53DF153098FDCFBA8A4F5A5243E8C81F302EE66
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.installer.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.installer.yaml
@@ -14,6 +14,8 @@ InstallerSwitches:
   Silent: /quiet LAUNCHAFTERINSTALL=1
   SilentWithProgress: /passive LAUNCHAFTERINSTALL=1
 UpgradeBehavior: install
+Commands:
+- cluttercutter
 ReleaseDate: 2026-09-01
 ProductCode: '{8566912E-98B3-42F3-B19D-8494F5168D3A}'
 AppsAndFeaturesEntries:

--- a/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.locale.en-US.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.12.0
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/StruisICT/ClutterCutter/issues
+PackageName: ClutterCutter
+PackageUrl: https://github.com/StruisICT/ClutterCutter
+License: MIT
+LicenseUrl: https://github.com/StruisICT/ClutterCutter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast disk-usage browser with NTFS MFT scanning.
+Description: |-
+  ClutterCutter is a lightweight Windows disk-usage browser. On NTFS drives it
+  reads the Master File Table directly for very fast full-drive scans (roughly
+  one million files in six seconds), with a parallel FindFirstFileEx walker as
+  a fallback for non-NTFS drives and non-admin runs. Includes a treeview
+  drill-in, a Top-largest-files view, an Oldest-files (by date modified) view,
+  and a safe-to-delete temp/cache files view. Installs per-machine to Program Files with a Start
+  Menu entry; no .NET runtime required.
+Moniker: cluttercutter
+Tags:
+- disk
+- disk-usage
+- ntfs
+- mft
+- treesize
+- utility
+- windows
+ReleaseNotes: |-
+  See the full release notes at https://github.com/StruisICT/ClutterCutter/releases/tag/v0.12.0
+ReleaseNotesUrl: https://github.com/StruisICT/ClutterCutter/releases/tag/v0.12.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.12.0/StruisICT.ClutterCutter.yaml
@@ -1,0 +1,8 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: StruisICT.ClutterCutter version 0.12.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Version **0.12.0** for `StruisICT.ClutterCutter`.

This release moves the package from the portable exe to the project's **MSI** installer (`InstallerType: wix`), so ClutterCutter now installs per-machine to `Program Files` with a Start Menu entry and an Add/Remove Programs entry, consistent with the same publisher's `StruisICT.InLook`. Installer URL and SHA256 point at the `v0.12.0` GitHub release asset; ProductCode/UpgradeCode are set for clean upgrade detection. `winget validate` and a local `winget install --manifest` both pass.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427660)