### PR TITLE
New package: sordum.NetDisabler version 1.2

### DIFF
--- a/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.installer.yaml
+++ b/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: sordum.NetDisabler
+PackageVersion: '1.2'
+InstallerType: zip
+NestedInstallerType: portable
+InstallModes:
+- silent
+UpgradeBehavior: uninstallPrevious
+Commands:
+- NetDisabler
+ReleaseDate: 2026-01-26
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.sordum.org/files/download/net-disabler/NetDisabler.zip
+  InstallerSha256: B15670E3B207D3B5141AA475859610773FFDEA85F07EBDDD26DB5CC10350D7E4
+  NestedInstallerFiles:
+  - RelativeFilePath: NetDisabler/NetDisabler.exe
+    PortableCommandAlias: NetDisabler
+- Architecture: x64
+  InstallerUrl: https://www.sordum.org/files/download/net-disabler/NetDisabler.zip
+  InstallerSha256: B15670E3B207D3B5141AA475859610773FFDEA85F07EBDDD26DB5CC10350D7E4
+  NestedInstallerFiles:
+  - RelativeFilePath: NetDisabler/NetDisabler_x64.exe
+    PortableCommandAlias: NetDisabler
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.locale.en-US.yaml
+++ b/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: sordum.NetDisabler
+PackageVersion: '1.2'
+PackageLocale: en-US
+Publisher: Sordum.org
+PublisherUrl: https://www.sordum.org/
+PublisherSupportUrl: https://www.sordum.org/contact-us/
+PackageName: Net Disabler
+PackageUrl: https://www.sordum.org/9660/net-disabler-v1-2/
+License: Proprietary (EULA)
+LicenseUrl: https://www.sordum.org/eula/
+Copyright: Copyright © 2006-2026 Sordum.org. All rights reserved.
+ShortDescription: A portable tool to quickly disable or enable internet access using several blocking methods.
+Description: >-
+  Net Disabler is a portable freeware tool that can disable or enable internet access using the network adapter,
+  DNS, proxy, or Windows Firewall. It also supports password protection and command-line parameters.
+Tags:
+- firewall
+- internet
+- network
+- portable
+ReleaseNotes: |-
+  - Fixed the /E command deleting outbound IP rules from the firewall.
+  - Fixed small text and GUI scaling.
+  - Fixed the program window not remembering its position.
+  - Added IPv6 DNS blocking.
+  - Improved the code and included multiple fixes.
+ReleaseNotesUrl: https://www.sordum.org/9660/net-disabler-v1-2/#:~:text=What%20is%20New
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.yaml
+++ b/manifests/s/sordum/NetDisabler/1.2/sordum.NetDisabler.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: sordum.NetDisabler
+PackageVersion: '1.2'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Net Disabler 1.2 by Sordum.org as a portable package for x86 and x64. The manifest was validated with `winget validate`, and the downloaded executable hashes match the publisher-provided SHA-256 values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427680)