### PR TITLE
New version: LuqP2.ImageMetaHub version 0.19.2

### DIFF
--- a/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.installer.yaml
+++ b/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LuqP2.ImageMetaHub
+PackageVersion: 0.19.2
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: "/S"
+  SilentWithProgress: "/S"
+UpgradeBehavior: install
+Protocols:
+- imagemetahub
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LuqP2/Image-MetaHub/releases/download/v0.19.2/ImageMetaHub-Setup-0.19.2.exe
+  InstallerSha256: 86A2D89AEDAAF625E0057EE7EC13B86742941734EB8A55D31033007B6D5D8BF3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.locale.en-US.yaml
+++ b/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LuqP2.ImageMetaHub
+PackageVersion: 0.19.2
+PackageLocale: en-US
+Publisher: LuqP2
+PublisherUrl: https://github.com/LuqP2
+PublisherSupportUrl: https://github.com/LuqP2/Image-MetaHub/issues
+PackageName: Image MetaHub
+PackageUrl: https://www.imagemetahub.com
+License: MPL-2.0
+LicenseUrl: https://github.com/LuqP2/Image-MetaHub/blob/main/LICENSE
+ShortDescription: Local-first search & organizer for AI-generated images (prompt, model, LoRA, seed, ComfyUI workflow). Fully offline.
+Description: |-
+  Image MetaHub is a free, local-first desktop application for browsing, searching, and organizing AI-generated images. It reads the generation metadata embedded in files produced by ComfyUI, Stable Diffusion, and similar tools (prompt, model, LoRA, seed, sampler, and full workflow) and lets you filter and search your entire library instantly. Built for large collections, it runs completely offline and never uploads your images or data.
+Moniker: imagemetahub
+Tags:
+- ai
+- stable-diffusion
+- comfyui
+- metadata
+- image-viewer
+- organizer
+ReleaseNotesUrl: https://github.com/LuqP2/Image-MetaHub/releases/tag/v0.19.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.yaml
+++ b/manifests/l/LuqP2/ImageMetaHub/0.19.2/LuqP2.ImageMetaHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LuqP2.ImageMetaHub
+PackageVersion: 0.19.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates Image MetaHub from 0.18.1 to 0.19.2.

- Homepage: https://www.imagemetahub.com
- Source: https://github.com/LuqP2/Image-MetaHub
- Release: https://github.com/LuqP2/Image-MetaHub/releases/tag/v0.19.2

## Microsoft Reviewers: Open in CodeSpaces

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?

## Manifest Version Compliance

- [x] This PR only modifies one (1) manifest
- [x] This PR only adds and/or updates a pre-existing manifest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427750)