### PR TITLE
New version: Stellary.Stellary version 0.1.6

### DIFF
--- a/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.installer.yaml
+++ b/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Stellary.Stellary
+PackageVersion: 0.1.6
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-08-31
+AppsAndFeaturesEntries:
+- DisplayName: Stellary
+  Publisher: Stellary
+Installers:
+- Architecture: x64
+  InstallerUrl: https://stellary.co/downloads/desktop/Stellary-0.1.6-x64.exe
+  InstallerSha256: 8DA579B23A520C2BD45C6BBF443EC6AA94CAEB0E84014CC22B92E1DF60F395D2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.locale.en-US.yaml
+++ b/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Stellary.Stellary
+PackageVersion: 0.1.6
+PackageLocale: en-US
+Publisher: Stellary
+PublisherUrl: https://stellary.co
+PrivacyUrl: https://stellary.co/privacy
+PackageName: Stellary
+PackageUrl: https://stellary.co/download
+License: Proprietary
+LicenseUrl: https://stellary.co/terms
+Copyright: Copyright © 2026 Stellary
+ShortDescription: Stellary desktop shell for Windows and local developer capabilities.
+Description: |-
+  Stellary is a commercial open-beta SaaS product for AI project management for teams and AI agents.
+  This package installs the Windows x64 desktop app, an Electron shell that can connect to a Stellary account, link local folders, and run eligible local agent missions.
+  During the open beta the product is free; paid plans are expected after the beta.
+Moniker: stellary
+Tags:
+- ai
+- desktop
+- electron
+- project-management
+- saas
+ReleaseNotesUrl: https://stellary.co/docs/changelog
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://stellary.co/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.yaml
+++ b/manifests/s/Stellary/Stellary/0.1.6/Stellary.Stellary.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Stellary.Stellary
+PackageVersion: 0.1.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
New package: Stellary.Stellary version 0.1.6

Adds the Stellary Windows x64 desktop installer (NSIS / Nullsoft). Publisher, product name, and version were read from the installer PE version resource (`CompanyName=Stellary`, `ProductName=Stellary`, `ProductVersion=0.1.6`). SHA256 was computed from the downloaded official installer.

Installer URL: https://stellary.co/downloads/desktop/Stellary-0.1.6-x64.exe
SHA256: 8DA579B23A520C2BD45C6BBF443EC6AA94CAEB0E84014CC22B92E1DF60F395D2

Silent flags: NSIS `/S` (InstallerType: nullsoft).

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

Local `winget validate` / `winget install` were not run because this submission was authored on Linux. Validation pipeline on this PR should cover installer download, hash, and unattended NSIS install.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427916)