### PR TITLE
New package: Cosmosfarm.JoripSpaceCLI version 0.3.0

### DIFF
--- a/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.installer.yaml
+++ b/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Cosmosfarm.JoripSpaceCLI
+PackageVersion: 0.3.0
+InstallerType: portable
+UpgradeBehavior: install
+Commands:
+  - joripspace
+ReleaseDate: 2026-08-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://joripspace.com/download/cli/v0.3.0/JoripSpace-Setup.exe
+    InstallerSha256: 83738C457D32F258169C1F391FC076FAAA554321A4E7EE1A0CA2CCCDA02DC0CC
+  - Architecture: arm64
+    InstallerUrl: https://joripspace.com/download/cli/v0.3.0/JoripSpace-Setup-ARM64.exe
+    InstallerSha256: 1F8C8EB429E1D837AE72089437266425BC14866B4CF7050E7AB7C77572C46410
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.locale.en-US.yaml
+++ b/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Cosmosfarm.JoripSpaceCLI
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Cosmosfarm Software
+PublisherUrl: https://joripspace.com/
+PublisherSupportUrl: https://joripspace.com/
+PrivacyUrl: https://joripspace.com/privacy/
+PackageName: JoripSpace CLI
+PackageUrl: https://joripspace.com/download
+License: Proprietary
+Copyright: Copyright (c) 2026 Cosmosfarm. All rights reserved.
+ShortDescription: CLI for deploying and operating projects on JoripSpace.
+Description: Command-line interface for connecting projects, managing project databases and storage, deploying servers, and viewing usage and logs on JoripSpace.
+Moniker: joripspace
+Tags:
+  - cli
+  - cloudflare
+  - deployment
+  - developer-tools
+  - joripspace
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.locale.ko-KR.yaml
+++ b/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.locale.ko-KR.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Cosmosfarm.JoripSpaceCLI
+PackageVersion: 0.3.0
+PackageLocale: ko-KR
+Publisher: 코스모스팜 소프트웨어
+PackageName: JoripSpace CLI
+ShortDescription: JoripSpace 프로젝트를 배포하고 운영하는 CLI입니다.
+Description: JoripSpace 프로젝트 연결, 프로젝트 DB와 스토리지 관리, 서버 배포, 사용량 및 로그 조회를 제공하는 명령줄 인터페이스입니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.yaml
+++ b/manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0/Cosmosfarm.JoripSpaceCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Cosmosfarm.JoripSpaceCLI
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the JoripSpace CLI 0.3.0 portable package for Windows x64 and ARM64 using official version-specific download URLs.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable for this routine new manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same package and version
- [x] This PR only modifies one (1) package manifest set
- [x] Validated locally with `winget validate --manifest manifests/c/Cosmosfarm/JoripSpaceCLI/0.3.0`
- [ ] Tested locally with `winget install --manifest <path>`
  - Local installation testing could not be run because enabling `LocalManifestFiles` requires administrator privileges on the available Windows environment. The public installers, SHA-256 hashes, `--version`, and portable command behavior were verified separately.
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427935)