### PR TITLE
New package: yhirose.culebra version 0.4.0

### DIFF
--- a/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.installer.yaml
+++ b/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: yhirose.culebra
+PackageVersion: 0.4.0
+Platform:
+  - Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: culebra-v0.4.0-windows-x64/culebra.exe
+    PortableCommandAlias: culebra
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/yhirose/culebra/releases/download/v0.4.0/culebra-windows-x64.zip
+    InstallerSha256: 13782265E003D0B9635DC36FEFD0C3588E3A8C1B2DC3EE5290405B686B911429
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.locale.en-US.yaml
+++ b/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: yhirose.culebra
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: Yuji Hirose
+PublisherUrl: https://github.com/yhirose
+PublisherSupportUrl: https://github.com/yhirose/culebra/issues
+PackageName: culebra
+PackageUrl: https://github.com/yhirose/culebra
+License: MIT
+LicenseUrl: https://github.com/yhirose/culebra/blob/master/LICENSE
+Moniker: culebra
+ShortDescription: Programming language with a bytecode VM, JIT, and AOT compiler
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.yaml
+++ b/manifests/y/yhirose/culebra/0.4.0/yhirose.culebra.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: yhirose.culebra
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description
Adds the initial manifest for **culebra**, a programming language with a bytecode VM, JIT, and AOT compiler.

- Homepage: https://github.com/yhirose/culebra
- License: MIT
- Installer: Windows x64 zip containing a portable `culebra.exe`

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

## Note
This manifest was authored and submitted from a non-Windows environment, so local `winget install --manifest` was not run by hand. The pipeline's own "08. Installation Validation" check (which performs that install) completed successfully, so the install path is verified. Happy to address any further validator feedback.