### PR TITLE
New package: hhrsc.Clipboard version 0.1.0

### DIFF
--- a/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.installer.yaml
+++ b/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: hhrsc.Clipboard
+PackageVersion: 0.1.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hhrsc/clipboard/releases/download/v0.1.0/Clipboard_0.1.0_x64-setup.exe
+    InstallerSha256: C5BE35E575E698696C376DF46247D4A670D0C8880098F5F2EAD5B7F921B8AE4C
+    AppsAndFeaturesEntries:
+      - DisplayName: Clipboard
+        DisplayVersion: 0.1.0
+        Publisher: hhrsc
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.locale.en-US.yaml
+++ b/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: hhrsc.Clipboard
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: hhrsc
+PublisherUrl: https://github.com/hhrsc
+PublisherSupportUrl: https://github.com/hhrsc/clipboard/issues/new/choose
+PrivacyUrl: https://hhrsc.github.io/website/privacy-policy/
+Author: hhrsc
+PackageName: Clipboard
+PackageUrl: https://hhrsc.github.io/website/
+License: MIT
+LicenseUrl: https://github.com/hhrsc/clipboard/blob/main/LICENSE
+Copyright: Copyright © 2026 hhrsc
+ShortDescription: A local-first clipboard manager for Windows.
+Description: Clipboard keeps text, rich text, and image history on your Windows device, with search, categories, pinning, selected-text copying, and multiple output formats.
+Tags:
+  - clipboard
+  - clipboard-history
+  - clipboard-manager
+  - local-first
+  - productivity
+  - windows
+ReleaseNotesUrl: https://github.com/hhrsc/clipboard/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.locale.zh-CN.yaml
+++ b/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.locale.zh-CN.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: hhrsc.Clipboard
+PackageVersion: 0.1.0
+PackageLocale: zh-CN
+Publisher: hhrsc
+PackageName: Clipboard
+License: MIT
+ShortDescription: 一款本地优先的 Windows 剪贴板管理工具。
+Description: Clipboard 在 Windows 本机保存文字、富文本和图片历史，支持搜索、分类、置顶、自由选取文字以及多种格式复制。
+Tags:
+  - 剪贴板
+  - 剪贴板历史
+  - 效率
+  - 本地优先
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.yaml
+++ b/manifests/h/hhrsc/Clipboard/0.1.0/hhrsc.Clipboard.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: hhrsc.Clipboard
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for Clipboard 0.1.0, a local-first Windows clipboard manager published by hhrsc.

Official installer: https://github.com/hhrsc/clipboard/releases/download/v0.1.0/Clipboard_0.1.0_x64-setup.exe
Product page: https://hhrsc.github.io/website/

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for a routine manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

Local manifest installation could not be enabled on the current host because Windows requires administrator approval for `LocalManifestFiles`. The NSIS installer itself was independently tested with silent installation and silent uninstallation; its Apps & Features name, version, publisher, install scope, and installed executable were verified. This draft is intentionally leaving the local-manifest checkbox unchecked until the repository validation pipeline or an elevated clean test environment confirms it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427963)