### PR TITLE
New package: RobertasTa.PhotoHome version 1.0.0

### DIFF
--- a/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.installer.yaml
+++ b/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.PhotoHome
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: PhotoHome\PhotoHome.exe
+  PortableCommandAlias: PhotoHome
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/RobertasTa/foto-namai/releases/download/v1.0.0/PhotoHome-1.0.0-win64.zip
+  InstallerSha256: 1B34B9C671BCA2C1FFD57CB9D441FBA745E90E01250A4A5561DE32E459A15DBF
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-08-29

--- a/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.locale.en-US.yaml
+++ b/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.PhotoHome
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Robertas & Claude
+PublisherUrl: https://github.com/RobertasTa
+PublisherSupportUrl: https://github.com/RobertasTa/foto-namai/issues
+Author: Robertas & Claude
+PackageName: PHOTO home
+PackageUrl: https://github.com/RobertasTa/foto-namai
+License: GPL-3.0-only
+LicenseUrl: https://github.com/RobertasTa/foto-namai/blob/master/LICENSE
+Copyright: (c) Robertas & Claude
+ShortDescription: Honest home photo archive organizer - it tells you when your photos were really taken and never deletes anything.
+Description: |-
+  An honest catalog for the family photo chaos on your disks - it tells you
+  what you have, where it lives and when it was really taken. Nothing moves
+  until you say so.
+  Tier A only reads: check folders or disks, the program builds an index and
+  answers with search (date, event label, camera, file name) and a thumbnail
+  grid that works even when the drive is unplugged. Every indexing run ends
+  with an Archive X-ray report: where your dates come from, how many files
+  lack a reliable date, and your "line in time".
+  Dates are resolved honestly and the source is recorded for every file:
+  camera EXIF (with backup fields) - file name (WhatsApp style) - folder
+  name - modification time with an explicit "unreliable" label. Competitors
+  silently file undated photos into today's date; this program labels them
+  and keeps them in a separate _UNDATED work zone instead.
+  Tier B - organizing - runs only when you press the button: the program
+  proposes a Year\Month plan with event labels, you review it, the default
+  is COPY, and every action lands in a full UNDO journal with a one-click
+  rollback. The same content is never copied twice (verified byte for byte).
+  Android phone import over the USB cable: the program finds photo locations
+  itself (DCIM, WhatsApp, screenshots), copies them to your disk and never
+  writes a byte to the phone.
+  Fully offline: no cloud, no telemetry, no accounts, no ads. Free software,
+  GPL v3. UI in English and Lithuanian. Working data lives in
+  %LOCALAPPDATA%\PhotoHome; portable mode via a marker file next to the exe.
+Moniker: photo-home
+Tags:
+- photo
+- photos
+- photo-organizer
+- photo-archive
+- exif
+- family
+- offline
+- open-source
+- privacy
+- portable
+- undo
+ReleaseNotesUrl: https://github.com/RobertasTa/foto-namai/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.yaml
+++ b/manifests/r/RobertasTa/PhotoHome/1.0.0/RobertasTa.PhotoHome.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobertasTa.PhotoHome
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **PHOTO home** (RobertasTa.PhotoHome) version 1.0.0 - an offline home photo archive organizer (indexes the user's own photo folders, resolves real capture dates from EXIF / file name / folder name, proposes a Year\Month layout with a full undo journal). No network access, no accounts, no bundled content.

Resubmission of #426156 (closed by author) with complete metadata: `Author`, `Tags` and `ReleaseNotesUrl` added. **Installer URL and SHA256 are unchanged** from the previous submission, which already passed the Azure pipeline.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change (#426156 is closed)
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` - "Manifest validation succeeded"
- [x] Tested manifest locally with `winget install --manifest <path>` - installer section is byte-identical to #426156, which was install-tested live
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427975)