### PR TITLE
New version: thxnlo.tether version 3.0.4

### DIFF
--- a/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.installer.yaml
+++ b/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: thxnlo.tether
+PackageVersion: 3.0.4
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- tether
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/thxnlo/tether/releases/download/v3.0.4/tether.exe
+  InstallerSha256: 4F003C3A4F0AD90A70FDEBA9EB60E0FD45B4A8CD86637AC5AD7EEA22D5C487C5
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.locale.en-US.yaml
+++ b/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: thxnlo.tether
+PackageVersion: 3.0.4
+PackageLocale: en-US
+Publisher: thxnlo
+PublisherUrl: https://github.com/thxnlo
+PublisherSupportUrl: https://github.com/thxnlo/tether/issues
+PackageName: tether
+PackageUrl: https://github.com/thxnlo/tether
+License: MIT
+LicenseUrl: https://github.com/thxnlo/tether/blob/main/LICENSE
+Copyright: (c) 2026 thxnlo
+ShortDescription: Tray bridge between Windows and your SSH hosts - clipboard, files, tunnels, ADB.
+Description: |-
+  tether keeps your Windows machine tethered to your SSH hosts. Screenshots
+  and files copied to the clipboard upload over SSH and the remote path lands
+  on your clipboard, ready to paste into Claude Code, Codex, or any SSH
+  session. It also supervises SSH port forwards with keep-alive and automatic
+  reconnection, shares local Android (adb) devices with a server, and fetches
+  files a server drops in an outbox directory back to the local clipboard.
+  Requires the built-in Windows OpenSSH client and key-based auth.
+Moniker: tether
+Tags:
+- adb
+- claude-code
+- clipboard
+- port-forwarding
+- screenshot
+- ssh
+- tray
+- tunnel
+ReleaseNotesUrl: https://github.com/thxnlo/tether/releases/tag/v3.0.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.yaml
+++ b/manifests/t/thxnlo/tether/3.0.4/thxnlo.tether.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: thxnlo.tether
+PackageVersion: 3.0.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Version bump of an existing portable package: same manifests as 3.0.3 with the new `InstallerUrl`, `InstallerSha256` (computed from the published asset) and `ReleaseDate`. Release: https://github.com/thxnlo/tether/releases/tag/v3.0.4
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/427979)