### PR TITLE
New package: TallboyConsulting.Yachito version 0.2.10

### DIFF
--- a/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.installer.yaml
+++ b/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TallboyConsulting.Yachito
+PackageVersion: 0.2.10
+InstallerLocale: en-US
+InstallerType: nsis
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://dl.yachito.com/Yachito_0.2.10_x64-setup.exe
+    InstallerSha256: A6378209C6B5111171DBD6E9FD9BBE915DA81EFCBB655570AF66DE91C39FE806
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.installer.yaml
+++ b/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.installer.yaml
@@ -2,7 +2,7 @@
 PackageIdentifier: TallboyConsulting.Yachito
 PackageVersion: 0.2.10
 InstallerLocale: en-US
-InstallerType: nsis
+InstallerType: nullsoft
 Scope: user
 InstallModes:
   - interactive

--- a/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.locale.en-US.yaml
+++ b/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TallboyConsulting.Yachito
+PackageVersion: 0.2.10
+PackageLocale: en-US
+Publisher: Tallboy Consulting, Inc
+PublisherUrl: https://yachito.com
+PublisherSupportUrl: mailto:hello@yachito.com
+Author: Tallboy Consulting, Inc
+PackageName: Yachito
+PackageUrl: https://yachito.com
+License: Proprietary
+Copyright: Copyright (c) 2026 Tallboy Consulting, Inc
+ShortDescription: A private AI companion for your Mac and Windows that reads your notes and keeps your plans honest.
+Description: >-
+  Yachito is an AI companion that lives on your computer, reads your plain-markdown
+  notebook, prepares morning briefs from your real plans, and helps you decide what
+  matters today. It works with the AI you trust, including local models that never
+  leave your machine. Calendar, reminders, and dictation are macOS-only for now.
+Moniker: yachito
+Tags:
+  - ai
+  - assistant
+  - productivity
+  - notes
+  - companion
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.locale.en-US.yaml
+++ b/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.locale.en-US.yaml
@@ -4,7 +4,6 @@ PackageVersion: 0.2.10
 PackageLocale: en-US
 Publisher: Tallboy Consulting, Inc
 PublisherUrl: https://yachito.com
-PublisherSupportUrl: mailto:hello@yachito.com
 Author: Tallboy Consulting, Inc
 PackageName: Yachito
 PackageUrl: https://yachito.com

--- a/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.yaml
+++ b/manifests/t/TallboyConsulting/Yachito/0.2.10/TallboyConsulting.Yachito.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TallboyConsulting.Yachito
+PackageVersion: 0.2.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package submission

- **Package:** TallboyConsulting.Yachito
- **Version:** 0.2.10
- **Publisher:** Tallboy Consulting, Inc
- **Installer:** signed NSIS (Authenticode via Azure Artifact Signing), x64, served from the app's own CDN (dl.yachito.com)

Yachito is a private AI companion for Mac and Windows that reads your plain-markdown notebook and helps plan your day. This is the first winget submission for the package.

#### Checklist
- [x] Manifests validate against schema 1.6.0 (version + installer + en-US locale)
- [x] InstallerSha256 verified against the file served at the InstallerUrl
- [x] Installer supports silent install (NSIS `/S`)
- [x] Have signed the [Microsoft CLA] if required

Automated validation should be able to download and install cleanly in the sandbox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428003)