### PR TITLE
New package: ChevalGrand520.LlamaDesktop 1.1.0

### DIFF
--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.installer.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: ChevalGrand520.LlamaDesktop
 PackageVersion: 1.1.0
 InstallerType: zip

--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.installer.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.installer.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: ChevalGrand520.LlamaDesktop
+PackageVersion: 1.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: LlamaDesktop.exe
+ReleaseDate: 2026-08-29
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ChevalGrand520/llama-desktop/releases/download/v1.1.0/llama-desktop-win-x64-v1.1.0.zip
+  InstallerSha256: 559E751B74165FF6BA1E4B73DEE775222E98A321B97E3CB9DDF7C3B5CEB90BC9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.locale.en-US.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: ChevalGrand520.LlamaDesktop
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: ChevalGrand520
+PublisherUrl: https://github.com/ChevalGrand520
+PublisherSupportUrl: https://github.com/ChevalGrand520/llama-desktop/issues
+Author: ChevalGrand520
+PackageName: Llama Desktop
+PackageUrl: https://github.com/ChevalGrand520/llama-desktop
+License: MIT
+LicenseUrl: https://github.com/ChevalGrand520/llama-desktop/blob/master/LICENSE
+ShortDescription: Portable zero-dependency Windows desktop shell for llama.cpp llama-server with embedded official Web UI, hardware auto-tuning and PID-verified safe process lifecycle.
+Moniker: llama-desktop
+Tags:
+- llama
+- llama.cpp
+- llama-server
+- gguf
+- local-llm
+- wpf
+- webview2
+- portable
+- windows
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.locale.en-US.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: ChevalGrand520.LlamaDesktop
 PackageVersion: 1.1.0
 PackageLocale: en-US

--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ChevalGrand520.LlamaDesktop
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.yaml
+++ b/manifests/c/ChevalGrand520/LlamaDesktop/1.1.0/ChevalGrand520.LlamaDesktop.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: ChevalGrand520.LlamaDesktop
 PackageVersion: 1.1.0
 DefaultLocale: en-US


### PR DESCRIPTION
## 📖 Description

New package: **ChevalGrand520.LlamaDesktop** version 1.1.0.

Llama Desktop is an open-source (MIT) Windows desktop application (C#/.NET 8 WPF, x64, Windows 10/11) that acts as a local GUI shell for [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server`, embedding the official Web UI and handling model loading, hardware auto-tuning, and process lifecycle management.

This submission is for the portable build distributed as a zip archive:

- Installer URL: https://github.com/ChevalGrand520/llama-desktop/releases/download/v1.1.0/llama-desktop-win-x64-v1.1.0.zip
- Installer SHA-256: `559E751B74165FF6BA1E4B73DEE775222E98A321B97E3CB9DDF7C3B5CEB90BC9`
- The zip contains the application files at its root (no outer folder). Per the winget manifest convention for portable apps distributed as archives, the manifest uses `InstallerType: zip` with `NestedInstallerType: portable`, pointing `NestedInstallerFiles` at the main `LlamaDesktop.exe`.

Project repository: https://github.com/ChevalGrand520/llama-desktop (MIT license).

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - No issue; routine manifest submission per the contributor guide.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428122)