### PR TITLE
Update: Anysphere.Cursor version 3.18.25

### DIFF
--- a/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.installer.yaml
+++ b/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.installer.yaml
@@ -1,0 +1,176 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Anysphere.Cursor
+PackageVersion: 3.18.25
+InstallerType: inno
+InstallerSwitches:
+  Custom: /mergetasks=!runcode
+UpgradeBehavior: install
+Protocols:
+- cursor
+FileExtensions:
+- ascx
+- asp
+- aspx
+- bash
+- bash_login
+- bash_logout
+- bash_profile
+- bashrc
+- bib
+- bowerrc
+- c
+- c++
+- cc
+- cfg
+- cjs
+- clj
+- cljs
+- cljx
+- clojure
+- cls
+- cmake
+- code-workspace
+- coffee
+- config
+- containerfile
+- cpp
+- cs
+- cshtml
+- csproj
+- css
+- csv
+- csx
+- ctp
+- cxx
+- dart
+- diff
+- dockerfile
+- dot
+- dtd
+- editorconfig
+- edn
+- erb
+- eyaml
+- eyml
+- fs
+- fsi
+- fsscript
+- fsx
+- gemspec
+- gitattributes
+- gitconfig
+- gitignore
+- go
+- gradle
+- groovy
+- h
+- h++
+- handlebars
+- hbs
+- hh
+- hpp
+- hxx
+- ini
+- ipynb
+- jade
+- jav
+- java
+- js
+- jscsrc
+- jshintrc
+- jshtm
+- json
+- jsp
+- jsx
+- less
+- log
+- lua
+- m
+- makefile
+- markdown
+- md
+- mdoc
+- mdown
+- mdtext
+- mdtxt
+- mdwn
+- mjs
+- mk
+- mkd
+- mkdn
+- ml
+- mli
+- npmignore
+- php
+- phtml
+- pl
+- pl6
+- plist
+- pm
+- pm6
+- pod
+- pp
+- profile
+- properties
+- ps1
+- psd1
+- psgi
+- psm1
+- py
+- pyi
+- r
+- rb
+- rhistory
+- rprofile
+- rs
+- rst
+- rt
+- sass
+- scss
+- sh
+- shtml
+- sql
+- svgz
+- t
+- tex
+- toml
+- ts
+- tsx
+- txt
+- vb
+- vue
+- wxi
+- wxl
+- wxs
+- xaml
+- xhtml
+- xml
+- yaml
+- yml
+- zsh
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://downloads.cursor.com/production/280eca2911f1774689696e5f1efa5a4f97a87af3/win32/x64/user-setup/CursorUserSetup-x64-3.18.25.exe
+  InstallerSha256: 004C1C1325ABA630D9A20FBF24B7071B4A694EF63C02E4DD9971A92B22C4AB1A
+  ProductCode: '{DADADADA-ADAD-ADAD-ADAD-ADADADADADAD}}_is1'
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://downloads.cursor.com/production/280eca2911f1774689696e5f1efa5a4f97a87af3/win32/x64/system-setup/CursorSetup-x64-3.18.25.exe
+  InstallerSha256: F0C21149D50A0AC399C12E8A9A924738ECCF688D841CB83EE30E17B29CD4146F
+  ProductCode: '{D7D7D7D7-7D7D-7D7D-7D7D-7D7D7D7D7D7D}}_is1'
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://downloads.cursor.com/production/280eca2911f1774689696e5f1efa5a4f97a87af3/win32/arm64/user-setup/CursorUserSetup-arm64-3.18.25.exe
+  InstallerSha256: 0CF45449AEF086F2F302CAEBDEC5BDB18C59013214B7CA241D0E4514107935AE
+  ProductCode: '{DBDBDBDB-BDBD-BDBD-BDBD-BDBDBDBDBDBD}}_is1'
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://downloads.cursor.com/production/280eca2911f1774689696e5f1efa5a4f97a87af3/win32/arm64/system-setup/CursorSetup-arm64-3.18.25.exe
+  InstallerSha256: FE2075365DD4D17EDB41E79AA08E1422BE8508B7BCCECC797372E0D1346F2ED2
+  ProductCode: '{D8D8D8D8-8D8D-8D8D-8D8D-8D8D8D8D8D8D}}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.locale.en-US.yaml
+++ b/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Anysphere.Cursor
+PackageVersion: 3.18.25
+PackageLocale: en-US
+Publisher: Anysphere
+PublisherUrl: https://www.cursor.com/
+PublisherSupportUrl: https://forum.cursor.com/
+PrivacyUrl: https://www.cursor.com/privacy
+Author: Anysphere Inc.
+PackageName: Cursor
+PackageUrl: https://www.cursor.com/
+License: Proprietary
+LicenseUrl: https://www.cursor.com/terms-of-service
+ShortDescription: The AI Code Editor
+Description: Cursor is a new, intelligent IDE, empowered by seamless integrations with AI. Built upon VSCode, Cursor is quick to learn, but can make you extraordinarily productive.
+Tags:
+- ai
+- code
+- coding
+- develop
+- development
+- programming
+ReleaseNotesUrl: https://changelog.cursor.com/
+PurchaseUrl: https://www.cursor.com/pricing
+Documentations:
+- DocumentLabel: Docs
+  DocumentUrl: https://docs.cursor.com/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.locale.zh-CN.yaml
+++ b/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.locale.zh-CN.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Anysphere.Cursor
+PackageVersion: 3.18.25
+PackageLocale: zh-CN
+License: 专有软件
+ShortDescription: AI 代码编辑器
+Description: Cursor 是一款全新的智能 IDE，可与 AI 无缝集成。Cursor 以 VSCode 为基础，上手很快，但却能让你的工作效率超乎寻常。
+Tags:
+- ai
+- 代码
+- 开发
+- 编程
+Documentations:
+- DocumentLabel: 文档
+  DocumentUrl: https://docs.cursor.com/
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.yaml
+++ b/manifests/a/Anysphere/Cursor/3.18.25/Anysphere.Cursor.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Anysphere.Cursor
+PackageVersion: 3.18.25
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates the Anysphere.Cursor package to version **3.18.25**.

- Updated `PackageVersion` to `3.18.25` across all manifest files
- Updated `InstallerUrl` for all four installer variants (x64/arm64 x user/machine)
- Updated `InstallerSha256` with verified hashes computed by streaming download from the official CDN
- Updated `ReleaseDate` to `2026-09-01`
- `InstallerType` remains `inno` with `/mergetasks=!runcode` silent switch unchanged

Build hash: `280eca2911f1774689696e5f1efa5a4f97a87af3`

Installer URLs sourced from `https://cursor.com/api/download` (stable release track). SHA256 hashes independently verified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428132)