### PR TITLE
New package: InteractorOSS.build version 1.4.0

### DIFF
--- a/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.installer.yaml
+++ b/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.4.0"
+InstallerLocale: en-US
+InstallerType: portable
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://build.interactor.com/api/v1/cli/asset?tag=cli%2Fv1.4.0&file=ibuild-windows-x64.exe
+    InstallerSha256: D78D567AE741B51AF688F928CE0AEB44CF947848AADD7A30D595D41C87C2E986
+    PortableCommandAlias: ibuild
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.locale.en-US.yaml
+++ b/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.locale.en-US.yaml
@@ -6,7 +6,6 @@ PublisherUrl: https://interactor.com
 PackageName: ibuild
 PackageUrl: https://build.interactor.com
 License: AGPL-3.0-or-later
-LicenseUrl: https://github.com/InteractorOSS/product-manager/blob/main/LICENSE
 ShortDescription: Bidirectional sync daemon for Interactor PM tasks/goals
 Description: >
   ibuild syncs your .build/ folder with Interactor's project management platform.

--- a/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.locale.en-US.yaml
+++ b/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.4.0"
+PackageLocale: en-US
+Publisher: InteractorOSS
+PublisherUrl: https://interactor.com
+PackageName: ibuild
+PackageUrl: https://build.interactor.com
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/InteractorOSS/product-manager/blob/main/LICENSE
+ShortDescription: Bidirectional sync daemon for Interactor PM tasks/goals
+Description: >
+  ibuild syncs your .build/ folder with Interactor's project management platform.
+  Works in any project regardless of programming language. Reads config from
+  .build/config.json and your personal token from .build/.sync.
+Tags:
+  - tasks
+  - goals
+  - productivity
+  - developer-tools
+  - project-management
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.yaml
+++ b/manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.yaml
@@ -1,0 +1,8 @@
+# WinGet package version manifest for ibuild.
+# Submit to: https://github.com/microsoft/winget-pkgs
+# Path in that repo: manifests/i/InteractorOSS/build/1.4.0/InteractorOSS.build.yaml
+PackageIdentifier: InteractorOSS.build
+PackageVersion: "1.4.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
Adds the WinGet manifest for `InteractorOSS.build` (ibuild), a bidirectional sync daemon for Interactor PM tasks/goals, version 1.4.0.

A prior submission for this package (v1.0.0, #403165) was closed Stale after repeatedly failing Manual Validation with:

```
DeliveryOptimization error: 0x80190194 ... Download request failed. Returned status: 404
```

That happened because the upstream repo (`InteractorOSS/product-manager`) is private, and the installer URL pointed straight at an unauthenticated `github.com/.../releases/download/...` link, which 404s for anyone without repo access — exactly what winget's downloader hit.

This submission's `InstallerUrl` instead goes through an authenticated proxy (`build.interactor.com/api/v1/cli/asset`) that streams the identical release asset via a GitHub App installation token. Verified before submitting:

```
curl -L 'https://build.interactor.com/api/v1/cli/asset?tag=cli%2Fv1.4.0&file=ibuild-windows-x64.exe' | sha256sum
# d78d567ae741b51af688f928ce0aeb44cf947848aadd7a30d595d41c87c2e986
```

which matches `InstallerSha256` in this manifest (uppercased), and matches the release's own `checksums.txt`.

- Source: https://github.com/InteractorOSS/product-manager
- License: AGPL-3.0-or-later
- Installer: https://build.interactor.com/api/v1/cli/asset?tag=cli%2Fv1.4.0&file=ibuild-windows-x64.exe
- InstallerSha256: D78D567AE741B51AF688F928CE0AEB44CF947848AADD7A30D595D41C87C2E986

## Checklist
- [x] I've verified the manifest structure follows the schema (installer, defaultLocale, version manifests)
- [x] The installer URL and SHA256 have been verified against the published asset (via the authenticated proxy, not a direct GitHub release download)
- [x] This is a new package submission
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428135)