### PR TITLE
Update version: OpenJS.Electron.43 version 43.5.1

### DIFF
--- a/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.installer.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.5.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.5.1/electron-v43.5.1-win32-ia32.zip
+  InstallerSha256: 6FF262FC881D90324428C473A663A1F00B20FAB03B6F65DA2B4A7DCF84D88ADD
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.5.1/electron-v43.5.1-win32-x64.zip
+  InstallerSha256: DF797253B8729575A719B1246AACE4FD273AEB9C651D4794D1D196E86352A31D
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.5.1/electron-v43.5.1-win32-arm64.zip
+  InstallerSha256: 3FDE9D70BBEAF5F8D27A4152FF842A632850F01A325009E3DCE6049937031A15
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.5.1
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: |-
+  # Release Notes for v43.5.1
+
+  ## Fixes
+
+  • Fixed `chrome.tabs.query()` returning tab `url` and `title` to extensions without the `tabs` permission or host access, aligning with `tabs.get`. [#53356](https://github.com/electron/electron/pull/53356) <sup>(Also in [42](https://github.com/electron/electron/pull/53355), [44](https://github.com/electron/electron/pull/53354), [45](https://github.com/electron/electron/pull/53353))</sup>
+  • Fixed a renderer crash when an array with a throwing property getter is passed across `contextBridge`, and several main/utility-process crashes when option objects passed to Electron APIs contain throwing accessors or Proxy traps. [#53330](https://github.com/electron/electron/pull/53330) <sup>(Also in [42](https://github.com/electron/electron/pull/53329), [44](https://github.com/electron/electron/pull/53331))</sup>
+  • Fixed an intermittent crash at startup on Linux caused by a race between Pango and the main thread initializing fontconfig. [#53339](https://github.com/electron/electron/pull/53339) <sup>(Also in [44](https://github.com/electron/electron/pull/53340), [45](https://github.com/electron/electron/pull/53338))</sup>
+  • Fixed an issue where an exception thrown by a property getter on an object passed through `contextBridge` was swallowed instead of being thrown back to the caller. [#53334](https://github.com/electron/electron/pull/53334) <sup>(Also in [44](https://github.com/electron/electron/pull/53335), [45](https://github.com/electron/electron/pull/53297))</sup>
+  • Fixed main process crashes when navigating to `http://accessibility/` or `http://devtools/`, when an extension background page used `navigator.mediaDevices`, and when calling `SerialPort.forget()` for a disconnected device. [#53332](https://github.com/electron/electron/pull/53332) <sup>(Also in [44](https://github.com/electron/electron/pull/53333), [45](https://github.com/electron/electron/pull/53325))</sup>
+  • Fixed the PDF viewer failing to save an edited PDF with `NotAllowedError：Third party iframes are not allowed to show a file picker`. [#53327](https://github.com/electron/electron/pull/53327) <sup>(Also in [44](https://github.com/electron/electron/pull/53328), [45](https://github.com/electron/electron/pull/53326))</sup>
+  • Fixed xdg-desktop-portal misidentifying Electron apps whose `desktopName` contains dashes, which broke `globalShortcut` and other portal-based APIs on Linux. [#52722](https://github.com/electron/electron/pull/52722)
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v43.5.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.5.1/OpenJS.Electron.43.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.43 to version 43.5.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428202)