### PR TITLE
New package: AbrarZShahriar.OmaWrite version 0.5.0.1

### DIFF
--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.installer.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: AbrarZShahriar.OmaWrite
 PackageVersion: 0.5.0.1
@@ -11,6 +11,9 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AbrarZShahriar/omawrite-windows/releases/download/v0.5.0-windows.1/OmaWrite-Windows-v0.5.0-windows.1-x64-Setup.exe
   InstallerSha256: 58104A062B554DFE2BD6332B34340E05E2348143FCEA24BE6BD97ECF07B8DAB5
+  ProductCode: '{AE6883F4-1FC1-44FE-BE70-362A97A57B86}_is1'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{AE6883F4-1FC1-44FE-BE70-362A97A57B86}_is1'
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0
 ReleaseDate: 2026-08-28

--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.installer.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: AbrarZShahriar.OmaWrite
+PackageVersion: 0.5.0.1
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+FileExtensions:
+- md
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AbrarZShahriar/omawrite-windows/releases/download/v0.5.0-windows.1/OmaWrite-Windows-v0.5.0-windows.1-x64-Setup.exe
+  InstallerSha256: 58104A062B554DFE2BD6332B34340E05E2348143FCEA24BE6BD97ECF07B8DAB5
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-08-28

--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.locale.en-US.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: AbrarZShahriar.OmaWrite
 PackageVersion: 0.5.0.1
@@ -25,4 +25,4 @@ ReleaseNotes: First native Windows release with portable and per-user installer 
 ReleaseNotesUrl: https://github.com/AbrarZShahriar/omawrite-windows/releases/tag/v0.5.0-windows.1
 InstallationNotes: To make OmaWrite your default Markdown editor, open Windows Settings > Apps > Default apps > OmaWrite for Windows and assign .md.
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.locale.en-US.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: AbrarZShahriar.OmaWrite
+PackageVersion: 0.5.0.1
+PackageLocale: en-US
+Publisher: OmaWrite contributors
+PublisherUrl: https://github.com/AbrarZShahriar
+PublisherSupportUrl: https://github.com/AbrarZShahriar/omawrite-windows/issues
+PrivacyUrl: https://github.com/AbrarZShahriar/omawrite-windows/blob/master/PRIVACY.md
+Author: OmaWrite contributors
+PackageName: OmaWrite for Windows
+PackageUrl: https://github.com/AbrarZShahriar/omawrite-windows
+License: MIT License
+LicenseUrl: https://github.com/AbrarZShahriar/omawrite-windows/blob/master/LICENSE
+Copyright: Copyright (c) OmaWrite contributors
+ShortDescription: A focused native Markdown writing app for Windows.
+Description: OmaWrite is a focused native Markdown editor for Windows with local files, crash recovery, file-change detection, system theme support, search and replace, and keyboard-first formatting.
+Moniker: omawrite
+Tags:
+- editor
+- markdown
+- qt
+- writing
+ReleaseNotes: First native Windows release with portable and per-user installer packages, Markdown file association, system theme support, crash recovery, and automated build verification.
+ReleaseNotesUrl: https://github.com/AbrarZShahriar/omawrite-windows/releases/tag/v0.5.0-windows.1
+InstallationNotes: To make OmaWrite your default Markdown editor, open Windows Settings > Apps > Default apps > OmaWrite for Windows and assign .md.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: AbrarZShahriar.OmaWrite
+PackageVersion: 0.5.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.yaml
+++ b/manifests/a/AbrarZShahriar/OmaWrite/0.5.0.1/AbrarZShahriar.OmaWrite.yaml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: AbrarZShahriar.OmaWrite
 PackageVersion: 0.5.0.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the first WinGet manifest for OmaWrite for Windows 0.5.0.1.

OmaWrite is a focused native Qt Markdown editor. This per-user Inno Setup
package is built from the public repository workflow and published with a
SHA-256 checksum.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## Manifest checklist

- [x] Checked that there are no other open pull requests for this package
- [x] This pull request modifies one package manifest
- [x] Validated locally with `winget validate --manifest <path>`
- [x] Tested with `winget install --manifest <path>` (local-manifest installation requires an administrator-enabled setting on this machine)
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428205)