### PR TITLE
New version: RedEyeNetworks.HopMatrix version 1.15.1

### DIFF
--- a/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.installer.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.15.1
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- HopMatrix
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.15.1/HopMatrix-win-x64-setup.exe
+  InstallerSha256: 9E1644244D28A307D2EF61ED8DCA1E103E290EC20625B366505A61B41A8D8049
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.15.1/HopMatrix-win-x64-machine-setup.exe
+  InstallerSha256: 17CF5B2E0632E6D1E2AC5F92D87499256B060E059A1C63A12DBF15EBF28E37DB
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.15.1/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: F19A305BF8BFC4F81B904BB2B516F6BBC410064A7CB7BD1FA97A9FC5C1EA2205
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.15.1/HopMatrix-win-arm64-machine-setup.exe
+  InstallerSha256: 9825EF3E581FCC026727743202AF76EC19A27A3DD303EF1AC58BC726487C0A96
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.15.1
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: HopMatrix
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2025-2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Visual multi-path traceroute, network monitoring, and analysis platform
+Description: |-
+  HopMatrix is a portable, single-executable, cross-platform network analysis platform
+  with eight operational modes: Trace, Monitor, iPerf, OUI/MAC Lookup, SNMP, Multicast,
+  L2 Inspector, and Quick Tools. Features continuous multi-path traceroute with real-time
+  topology visualization, 256-endpoint fleet monitoring, iperf3-compatible bandwidth
+  testing, SNMP v1/v2c/v3 discovery, and multicast/CDP/LLDP analysis.
+Moniker: hopmatrix
+Tags:
+- traceroute
+- network
+- monitoring
+- bandwidth
+- iperf
+- snmp
+- multicast
+- network-analysis
+- pathping
+- topology
+- cdp
+- lldp
+- nmap
+- oui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.15.1/RedEyeNetworks.HopMatrix.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.15.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
HopMatrix v1.15.1 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is now done in HopMatrix's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

The manifests are composed and SHA256-pinned by the release pipeline from the same artifacts published to the download host; the pipeline runs on Linux and does not run `winget validate`, so validation is deferred to this repository's own checks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428230)