### PR TITLE
New version: Stickies.Stickies version 0.1.1

### DIFF
--- a/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.installer.yaml
+++ b/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Stickies.Stickies
+PackageVersion: 0.1.1
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://pub-eb47da305a0f4746aa32176769847b5b.r2.dev/v0.1.1/Stickies_0.1.0_x64-setup.exe
+    InstallerSha256: A50C7A01A61F544F64D590A0B2BE00901EADF3CC0A0F0AA0245E2DCA81CC1F06
+    InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.locale.en-US.yaml
+++ b/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Stickies.Stickies
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Stickies
+PublisherUrl: https://stickies.lol
+PublisherSupportUrl: https://stickies.lol/#faq
+PrivacyUrl: https://stickies.lol/#privacy
+PackageName: Stickies
+PackageUrl: https://stickies.lol
+License: Proprietary
+LicenseUrl: https://stickies.lol
+Copyright: Copyright (c) 2026 Stickies.lol
+ShortDescription: A lightweight, edge-docked sticky notes app for Windows 11.
+Description: Stickies is a lightweight desktop sticky notes deck docked to the right edge of Windows 11. Notes fan out on hover, save with hardware-backed DPAPI encryption, and feature searchable history with markdown export.
+Moniker: stickies
+Tags:
+  - notes
+  - stickies
+  - productivity
+  - edge-docked
+  - desktop
+  - tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.yaml
+++ b/manifests/s/Stickies/Stickies/0.1.1/Stickies.Stickies.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Stickies.Stickies
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
Release update for Stickies version 0.1.1.

- **Publisher**: Stickies (https://stickies.lol)
- **Description**: A lightweight, edge-docked sticky notes app for Windows 11.
- **Installer**: https://pub-eb47da305a0f4746aa32176769847b5b.r2.dev/v0.1.1/Stickies_0.1.1_x64-setup.exe

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked for duplicate pull requests
- [x] Validated manifest locally with `winget validate`
- [x] Manifest conforms to schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428241)