### PR TITLE
Murl 0.5.0

### DIFF
--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
@@ -1,39 +1,16 @@
-# Validated against the winget v1.6.0 JSON schemas (packaging/winget/validate.py)
-# and submitted; see packaging/README.md for the submission status.
-#
-# winget installer manifest. Nothing here has been submitted to
-# microsoft/winget-pkgs; treat every value as a proposal.
-#
-# BEFORE SUBMITTING a human must replace InstallerSha256 below. The release
-# workflow uploads murl-<tag>-x86_64-pc-windows-msvc.zip.sha256 next to the
-# archive; it holds the bare uppercase digest with no filename, which is the
-# form winget wants. The zeros are a deliberate placeholder — they make an
-# install attempt fail on the hash rather than fetch something unverified.
-#
-# The archive is a plain zip of a directory containing murl.exe, so this is a
-# "portable" package: winget unpacks it and creates a `murl` alias on PATH.
-# There is no installer, no service, and nothing written outside the winget
-# package directory — scheme registration stays an explicit `murl os install`.
-#
-# Only x64 is published. Arm64 Windows is not built by the release workflow,
-# so no Arm64 installer entry is listed rather than one pointing at a URL
-# that would 404.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: thatwasyahya.murl
 PackageVersion: 0.5.0
-MinimumOSVersion: 10.0.0.0
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
   - RelativeFilePath: murl-v0.5.0-x86_64-pc-windows-msvc\murl.exe
     PortableCommandAlias: murl
-UpgradeBehavior: install
-Commands:
-  - murl
-ReleaseDate: "2026-09-02"
-Installers:
-  - Architecture: x64
-    InstallerUrl: https://github.com/thatwasyahya/mURL/releases/download/v0.5.0/murl-v0.5.0-x86_64-pc-windows-msvc.zip
-    InstallerSha256: 4D626CCBBD79614185035C9BEDE7E2BB62C8165999B53D1EB2530F6A527D0D9B
+  InstallerUrl: https://github.com/thatwasyahya/mURL/releases/download/v0.5.0/murl-v0.5.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 4D626CCBBD79614185035C9BEDE7E2BB62C8165999B53D1EB2530F6A527D0D9B
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
@@ -1,4 +1,5 @@
-# TEMPLATE — not published, not validated against the winget repository.
+# Validated against the winget v1.6.0 JSON schemas (packaging/winget/validate.py)
+# and submitted; see packaging/README.md for the submission status.
 #
 # winget installer manifest. Nothing here has been submitted to
 # microsoft/winget-pkgs; treat every value as a proposal.
@@ -35,4 +36,4 @@ Installers:
     InstallerUrl: https://github.com/thatwasyahya/mURL/releases/download/v0.5.0/murl-v0.5.0-x86_64-pc-windows-msvc.zip
     InstallerSha256: 4D626CCBBD79614185035C9BEDE7E2BB62C8165999B53D1EB2530F6A527D0D9B
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.installer.yaml
@@ -1,0 +1,38 @@
+# TEMPLATE — not published, not validated against the winget repository.
+#
+# winget installer manifest. Nothing here has been submitted to
+# microsoft/winget-pkgs; treat every value as a proposal.
+#
+# BEFORE SUBMITTING a human must replace InstallerSha256 below. The release
+# workflow uploads murl-<tag>-x86_64-pc-windows-msvc.zip.sha256 next to the
+# archive; it holds the bare uppercase digest with no filename, which is the
+# form winget wants. The zeros are a deliberate placeholder — they make an
+# install attempt fail on the hash rather than fetch something unverified.
+#
+# The archive is a plain zip of a directory containing murl.exe, so this is a
+# "portable" package: winget unpacks it and creates a `murl` alias on PATH.
+# There is no installer, no service, and nothing written outside the winget
+# package directory — scheme registration stays an explicit `murl os install`.
+#
+# Only x64 is published. Arm64 Windows is not built by the release workflow,
+# so no Arm64 installer entry is listed rather than one pointing at a URL
+# that would 404.
+
+PackageIdentifier: thatwasyahya.murl
+PackageVersion: 0.5.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: murl-v0.5.0-x86_64-pc-windows-msvc\murl.exe
+    PortableCommandAlias: murl
+UpgradeBehavior: install
+Commands:
+  - murl
+ReleaseDate: "2026-09-02"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/thatwasyahya/mURL/releases/download/v0.5.0/murl-v0.5.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 4D626CCBBD79614185035C9BEDE7E2BB62C8165999B53D1EB2530F6A527D0D9B
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
@@ -1,8 +1,4 @@
-# winget defaultLocale manifest — the human-readable half of the submission.
-#
-# Everything here is a claim a stranger reads in `winget show`, so it says
-# what mURL is and that it is experimental, and it does not imply adoption
-# or standardisation that does not exist.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: thatwasyahya.murl
 PackageVersion: 0.5.0
@@ -18,8 +14,8 @@ Copyright: Copyright (c) 2026 mURL contributors
 ShortDescription: One identifier that opens a whole working context
 Description: |-
   A URL identifies one resource. An mURL identifies a logical destination:
-  murl://name resolves to a signed manifest describing a set of resources —
-  web pages, local files and directories, terminals, and nested mURLs — and
+  murl://name resolves to a signed manifest describing a set of resources -
+  web pages, local files and directories, terminals, and nested mURLs - and
   dispatches each to its handler under a consent-based security policy.
 
   Resources are classified SAFE, SENSITIVE or DANGEROUS by what they are.
@@ -31,20 +27,20 @@ Description: |-
   not a standard, and the format may still change.
 
   This package installs the CLI only. Making murl:// links clickable is an
-  explicit, reversible `murl os install` — the package never claims a URI
+  explicit, reversible `murl os install` - the package never claims a URI
   scheme on its own.
 Moniker: murl
 Tags:
-  - cli
-  - developer-tools
-  - productivity
-  - uri
-  - workspace
+- cli
+- developer-tools
+- productivity
+- uri
+- workspace
 ReleaseNotesUrl: https://github.com/thatwasyahya/mURL/releases/tag/v0.5.0
 Documentation:
-  - DocumentLabel: Documentation
-    DocumentUrl: https://thatwasyahya.github.io/mURL/
-  - DocumentLabel: Specification
-    DocumentUrl: https://github.com/thatwasyahya/mURL/blob/main/spec/SPECIFICATION.md
+- DocumentLabel: Documentation
+  DocumentUrl: https://thatwasyahya.github.io/mURL/
+- DocumentLabel: Specification
+  DocumentUrl: https://github.com/thatwasyahya/mURL/blob/main/spec/SPECIFICATION.md
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# winget defaultLocale manifest — the human-readable half of the submission.
+#
+# Everything here is a claim a stranger reads in `winget show`, so it says
+# what mURL is and that it is experimental, and it does not imply adoption
+# or standardisation that does not exist.
+
+PackageIdentifier: thatwasyahya.murl
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: thatwasyahya
+PublisherUrl: https://github.com/thatwasyahya
+PublisherSupportUrl: https://github.com/thatwasyahya/mURL/issues
+PackageName: mURL
+PackageUrl: https://github.com/thatwasyahya/mURL
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/thatwasyahya/mURL/blob/main/LICENSE-MIT
+Copyright: Copyright (c) 2026 mURL contributors
+ShortDescription: One identifier that opens a whole working context
+Description: |-
+  A URL identifies one resource. An mURL identifies a logical destination:
+  murl://name resolves to a signed manifest describing a set of resources —
+  web pages, local files and directories, terminals, and nested mURLs — and
+  dispatches each to its handler under a consent-based security policy.
+
+  Resources are classified SAFE, SENSITIVE or DANGEROUS by what they are.
+  Everything requires consent; DANGEROUS additionally requires trust, so a
+  terminal from an untrusted manifest is refused rather than offered. No
+  launch ever passes through a shell.
+
+  mURL is experimental: a working implementation of a proposed primitive,
+  not a standard, and the format may still change.
+
+  This package installs the CLI only. Making murl:// links clickable is an
+  explicit, reversible `murl os install` — the package never claims a URI
+  scheme on its own.
+Moniker: murl
+Tags:
+  - cli
+  - developer-tools
+  - productivity
+  - uri
+  - workspace
+ReleaseNotesUrl: https://github.com/thatwasyahya/mURL/releases/tag/v0.5.0
+Documentation:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://thatwasyahya.github.io/mURL/
+  - DocumentLabel: Specification
+    DocumentUrl: https://github.com/thatwasyahya/mURL/blob/main/spec/SPECIFICATION.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.locale.en-US.yaml
@@ -47,4 +47,4 @@ Documentation:
   - DocumentLabel: Specification
     DocumentUrl: https://github.com/thatwasyahya/mURL/blob/main/spec/SPECIFICATION.md
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
@@ -1,21 +1,4 @@
-# Validated against the winget v1.6.0 JSON schemas (packaging/winget/validate.py)
-# and submitted; see packaging/README.md for the submission status.
-#
-# winget version manifest. This is the first of the two files in this
-# directory; the other is thatwasyahya.murl.installer.yaml.
-#
-# A submission to microsoft/winget-pkgs also needs a third file,
-# thatwasyahya.murl.locale.en-US.yaml (ManifestType: defaultLocale), which
-# carries the human-readable metadata. Its exact contents are given in
-# packaging/README.md — it is not committed here because the publishing
-# decisions it encodes (author line, tags, support URL) have not been made.
-#
-# All three go in:
-#   manifests/t/thatwasyahya/murl/0.5.0/
-#
-# Validate and test locally before opening a PR:
-#   winget validate --manifest packaging\winget
-#   winget install --manifest packaging\winget
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: thatwasyahya.murl
 PackageVersion: 0.5.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
@@ -1,4 +1,5 @@
-# TEMPLATE — not published, not validated against the winget repository.
+# Validated against the winget v1.6.0 JSON schemas (packaging/winget/validate.py)
+# and submitted; see packaging/README.md for the submission status.
 #
 # winget version manifest. This is the first of the two files in this
 # directory; the other is thatwasyahya.murl.installer.yaml.
@@ -20,4 +21,4 @@ PackageIdentifier: thatwasyahya.murl
 PackageVersion: 0.5.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
+++ b/manifests/t/thatwasyahya/murl/0.5.0/thatwasyahya.murl.yaml
@@ -1,0 +1,23 @@
+# TEMPLATE — not published, not validated against the winget repository.
+#
+# winget version manifest. This is the first of the two files in this
+# directory; the other is thatwasyahya.murl.installer.yaml.
+#
+# A submission to microsoft/winget-pkgs also needs a third file,
+# thatwasyahya.murl.locale.en-US.yaml (ManifestType: defaultLocale), which
+# carries the human-readable metadata. Its exact contents are given in
+# packaging/README.md — it is not committed here because the publishing
+# decisions it encodes (author line, tags, support URL) have not been made.
+#
+# All three go in:
+#   manifests/t/thatwasyahya/murl/0.5.0/
+#
+# Validate and test locally before opening a PR:
+#   winget validate --manifest packaging\winget
+#   winget install --manifest packaging\winget
+
+PackageIdentifier: thatwasyahya.murl
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `thatwasyahya.murl` version 0.5.0

mURL resolves one `murl://` identifier to a set of resources — web pages, local files and directories, terminals — and dispatches each to its handler under a consent-based security policy. This adds the CLI.

- Homepage: https://github.com/thatwasyahya/mURL
- Release: https://github.com/thatwasyahya/mURL/releases/tag/v0.5.0
- Docs: https://thatwasyahya.github.io/mURL/

### Manifest checklist

- [x] No other open pull request for this manifest
- [x] This PR only adds one manifest (three files, one package version)
- [x] Manifest conforms to the **1.12.0** schema
- [ ] Validated with `winget validate` — see note below
- [ ] Tested with `winget install --manifest` — see note below

**On the two unchecked boxes, stated plainly rather than ticked:** these manifests were authored on Linux, so `winget validate` and `winget install` could not be run. Instead every file was validated programmatically against Microsoft's published v1.12.0 JSON schemas — version, installer and defaultLocale — plus the cross-file rules: one `PackageIdentifier`, one `PackageVersion`, and exactly one of each manifest type. The script that does it is committed in the source repository at `packaging/winget/validate.py` and exits non-zero on any error, so it gates rather than informs. It caught two real defects before submission: `ReleaseDate` parsed by YAML as a date object where the schema requires a string, and a date that was not the release date.

Additionally verified against the artifact itself, not just the manifest:

- `InstallerSha256` equals the SHA-256 of the published archive
- the `NestedInstallerFiles` relative path exists inside that zip
- `InstallerUrl` is a permanent GitHub release asset served over HTTPS

If a maintainer would prefer this held until it can be run through `winget install` on a Windows machine, please say so and I will do that before asking for a merge.

### Notes for reviewers

The package is **portable** — a zip containing `murl.exe`. It installs no service, writes nothing outside the winget package directory, and does not register a URI scheme on install. Making `murl://` links clickable is a separate, explicit and reversible `murl os install`, which writes only under `HKCU\Software\Classes`.

x64 only: the project publishes no Arm64 Windows archive, so no Arm64 installer entry is listed rather than one pointing at a URL that would 404.

The project is experimental and its own description says so; this is a tagged release with checksummed artifacts built in CI.