### PR TITLE
New version: RedEyeNetworks.LogivoreForVeeam version 1.48.0

### DIFF
--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.48.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- logivoreforveeam
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.48.0/logivore-for-veeam-win-x64-setup.exe
+  InstallerSha256: 6C80D7AE7760B09F5D7521C2BB83C6795E567D3B8C8792791F5C0DBDCBFC30C4
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/logivore-for-veeam/releases/1.48.0/logivore-for-veeam-win-x64-machine-setup.exe
+  InstallerSha256: 468D6C6040503FE9CAB566B4C0518B2C8BDB61AAAE3CCA63E2667B3593A10B64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.48.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: Logivore for Veeam
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Logivore plus Advanced Veeam Mode — collects, normalizes, and analyzes Veeam Backup and Replication logs end-to-end
+Description: |-
+  Logivore for Veeam is the Veeam-centric SKU of Logivore. Includes
+  everything in Logivore (cross-platform log analysis, LILA AI
+  assistant, memory-tier-adaptive parsing, local-first trust-gated
+  LLM boundary) plus Microsoft.PowerShell.SDK and a built-in
+  Advanced Veeam Mode that drives the Veeam VBR PowerShell cmdlets
+  to collect job/repository/proxy diagnostics on demand. Targeted
+  at Veeam backup administrators who need to triage failed jobs
+  against backup server, repository, and proxy logs in one
+  timeline.
+Moniker: logivore-for-veeam
+Tags:
+- veeam
+- vbr
+- backup
+- log-analysis
+- log-viewer
+- syslog
+- evtx
+- powershell
+- ai
+- llm
+- claude
+- gemini
+- timeline
+- correlation
+- desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.yaml
+++ b/manifests/r/RedEyeNetworks/LogivoreForVeeam/1.48.0/RedEyeNetworks.LogivoreForVeeam.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.LogivoreForVeeam
+PackageVersion: 1.48.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Logivore for Veeam v1.48.0 — the Veeam-centric SKU of Logivore, separated from the base package per the v0.11.0 SKU split. Ships as a distinct WinGet package (`RedEyeNetworks.LogivoreForVeeam`) with its own settings folder, credential namespace, install directory, and Argus appcast endpoint so it can coexist with the base `RedEyeNetworks.Logivore` package on the same machine.

Two installer entries (user-scope + machine-scope), both x64, each an Inno Setup EXE wrapped around a self-contained .NET 9 publish that includes Microsoft.PowerShell.SDK for the Advanced Veeam Mode runspace. The base `RedEyeNetworks.Logivore` package keeps its 4-entry x64 + arm64 shape; this SKU narrowed to x64 because Veeam Backup & Replication is a Windows product whose consoles are x64, so an arm64 build carrying the PowerShell SDK had no VBR host to reach. There is no arm64 entry by design: these installers declare `ArchitecturesAllowed=x64` (Inno Setup's `x64os`), so they run on x64 Windows only.

The split was driven by Cortex XDR / CrowdStrike behavioral signatures on the embedded PowerShell SDK + self-extract + auto-launch combo — see the v0.11.0 release notes for the full rationale.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428289)