### PR TITLE
New package: RuntimeNotesLabs.Sideband version 0.1.1

### DIFF
--- a/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.installer.yaml
+++ b/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RuntimeNotesLabs.Sideband
+PackageVersion: 0.1.1
+InstallerType: portable
+Commands:
+- sideband
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/runtimenoteslabs/sideband-public/releases/download/v0.1.1/sideband.exe
+  InstallerSha256: D1FA02CA87DD20D76DBB57BE7CAE6BD6AD357D0DF35F3BB11FCCE609156BDF0C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.locale.en-US.yaml
+++ b/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RuntimeNotesLabs.Sideband
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: RuntimeNotes Labs
+PublisherUrl: https://runtimenotes.com
+PublisherSupportUrl: https://github.com/runtimenoteslabs/sideband-public/issues
+Author: RuntimeNotes Labs
+PackageName: sideband
+PackageUrl: https://sideband.runtimenotes.com
+License: MIT
+LicenseUrl: https://github.com/runtimenoteslabs/sideband-public/blob/main/LICENSE
+Copyright: Copyright (c) 2026 RuntimeNotes Labs
+ShortDescription: Vendor-neutral monitor control for Windows over DDC/CI, with window arrangement.
+Description: |-
+  sideband reads and writes monitor settings over DDC/CI, the control channel compliant
+  displays have carried since 1998. Brightness, contrast, volume, input source and colour
+  presets are set from the command line or from the notification area. There is no support
+  list, so any brand answers or reports why it cannot. A laptop's built-in panel has no
+  DDC/CI channel and is driven through the display driver instead.
+
+  It also arranges open windows into zone layouts, with an undo that puts every window back
+  where it was.
+
+  One executable of about 347 KB. No installer, no service, no driver, no elevation, no
+  network access and no telemetry.
+Moniker: sideband
+Tags:
+- brightness
+- ddc-ci
+- display
+- edid
+- kvm
+- mccs
+- monitor
+- monitor-control
+- vesa
+- window-management
+ReleaseNotesUrl: https://github.com/runtimenoteslabs/sideband-public/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.yaml
+++ b/manifests/r/RuntimeNotesLabs/Sideband/0.1.1/RuntimeNotesLabs.Sideband.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RuntimeNotesLabs.Sideband
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package. sideband is a monitor control tool for Windows. It reads and writes display
settings over DDC/CI, so brightness, contrast, volume, input source and colour presets work on
any compliant monitor without a vendor utility. It also arranges open windows into zone
layouts.

One portable executable of 347 KB, x64 only. No installer, no service, no driver and no
elevation.

- Package: `RuntimeNotesLabs.Sideband`
- Version: 0.1.1
- Homepage: https://sideband.runtimenotes.com
- Release: https://github.com/runtimenoteslabs/sideband-public/releases/tag/v0.1.1

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428302)