### PR TITLE
New package: EmilEklund.Minne version 0.5.0

### DIFF
--- a/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.installer.yaml
+++ b/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.installer.yaml
@@ -1,0 +1,21 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: EmilEklund.Minne
+PackageVersion: 0.5.0
+InstallerLocale: en-US
+InstallerType: wix
+# Per-user: installs to %LOCALAPPDATA%\Programs\Minne without a UAC prompt.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/emil-eklund/minne/releases/download/v0.5.0/Minne-0.5.0-x64.msi
+    InstallerSha256: 32FEF5D1DFFFEFE030EF45C94D586C4173CCDB071488520816BCAC89F9BD283F
+    ProductCode: '{ABA0B8F5-C3D5-481E-97CD-81D424CA1C6F}'
+ManifestType: installer
+ManifestVersion: 1.12.0
+

--- a/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.locale.en-US.yaml
+++ b/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.locale.en-US.yaml
@@ -1,0 +1,34 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: EmilEklund.Minne
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Emil Eklund
+Author: Emil Eklund
+PublisherUrl: https://github.com/emil-eklund
+PublisherSupportUrl: https://github.com/emil-eklund/minne/issues
+PackageName: Minne
+PackageUrl: https://github.com/emil-eklund/minne
+License: MIT
+LicenseUrl: https://github.com/emil-eklund/minne/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Emil Eklund
+ShortDescription: Local hybrid search for your Microsoft 365 mailbox
+Description: |-
+  Minne indexes a Microsoft 365 mailbox locally and searches it with keyword (SQLite FTS5) and
+  semantic (embedding) retrieval at the same time, fusing the two with reciprocal rank fusion and
+  an optional cross-encoder rerank — so "kickoff schedule" finds an email that said "kick-off
+  agenda". Nothing leaves the machine except the Graph calls that fetch your own mail and a
+  one-time embedding-model download.
+Moniker: minne
+Tags:
+  - email
+  - search
+  - outlook
+  - microsoft-365
+  - semantic-search
+  - embeddings
+  - offline
+  - privacy
+ReleaseNotesUrl: https://github.com/emil-eklund/minne/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+

--- a/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.yaml
+++ b/manifests/e/EmilEklund/Minne/0.5.0/EmilEklund.Minne.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: EmilEklund.Minne
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+


### PR DESCRIPTION
## 📖 Description

New package: **Minne** `0.5.0` (`EmilEklund.Minne`) — a local hybrid (keyword + embedding) search tool for a Microsoft 365 mailbox. MIT licensed, open source, published by an individual: https://github.com/emil-eklund/minne

Notes for reviewers:

- The installer is a **per-user MSI** (WiX v6, installs to `%LOCALAPPDATA%\Programs\Minne`, no UAC prompt), hence `Scope: user`.
- `ProductCode` is pinned in the manifest and matches the shipped MSI.
- The binaries are **not code signed** — there is no certificate behind this project yet. Every release asset also ships a `.sha256` alongside it, and `InstallerSha256` here was verified against the published release asset.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
  <!-- Will be signed as an individual as soon as the CLA bot posts the link. -->
- [ ] Linked to an issue (if applicable)
  <!-- Not applicable. -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428334)