### PR TITLE
Add JDEProjects.SimpleSFTPClient version 1.8.0

### DIFF
--- a/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.installer.yaml
+++ b/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: JDEProjects.SimpleSFTPClient
+PackageVersion: 1.8.0
+InstallerLocale: en-US
+InstallerType: inno
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JDE-Projects/Simple-SFTP-Client/releases/download/v1.8.0/SimpleSFTPClient-v1.8.0-setup.exe
+  InstallerSha256: B55BAC7E532D379CA73D1811E83A4A048F289EDC14D61DA806B930A7838FC842
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.locale.en-US.yaml
+++ b/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: JDEProjects.SimpleSFTPClient
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: JDE-Projects
+PublisherUrl: https://jde-projects.com
+PublisherSupportUrl: https://github.com/JDE-Projects/Simple-SFTP-Client/issues
+Author: JDE-Projects
+PackageName: Simple SFTP Client
+PackageUrl: https://github.com/JDE-Projects/Simple-SFTP-Client
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/JDE-Projects/Simple-SFTP-Client/blob/main/LICENSE
+Copyright: Copyright (c) 2026 JDE-Projects
+ShortDescription: A clean, dual-pane SFTP client with a background transfer queue, saved sessions, and folder compare/sync/watch. Secure connections only.
+Description: |-
+  Simple SFTP Client is a Windows desktop SFTP client with a dual-pane browser
+  (local and remote side by side), a background transfer queue with progress and
+  retry, saved connections, key authentication with a built-in key generator,
+  folder compare and sync with a preview, and a local-folder upload watcher. It
+  connects only with modern, secure algorithms and makes no network calls beyond
+  an optional update check against GitHub.
+Moniker: simple-sftp-client
+Tags:
+- sftp
+- ssh
+- file-transfer
+- transfer
+- client
+ReleaseNotesUrl: https://github.com/JDE-Projects/Simple-SFTP-Client/releases/tag/v1.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.yaml
+++ b/manifests/j/JDEProjects/SimpleSFTPClient/1.8.0/JDEProjects.SimpleSFTPClient.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: JDEProjects.SimpleSFTPClient
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: Simple SFTP Client 1.8.0 by JDE-Projects.

Manifests generated for the published Inno Setup installer and validated locally with `winget validate` (Manifest validation succeeded). Installer SHA256 matches the release's published `.sha256`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428338)