### PR TITLE
New version: M-Igashi.mp3rgui version 3.5.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.5.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-09-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.5.0/mp3rgui-v3.5.0-windows-x86_64.zip
+    InstallerSha256: 704F017F9112D4F83A66CBC3B17529CCE71CEDA6AD0C01BFCA65C894E1C02E12
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.5.0/mp3rgui-v3.5.0-windows-arm64.zip
+    InstallerSha256: D4E43410A8CAAB64D51B679FAD0E655C9838B5605CD32E9E454945E62D5639B7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.5.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.5.0/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Manifest for M-Igashi.mp3rgui version 3.5.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Notes: manifests were authored and reviewed on macOS, so the `winget validate` / `winget install` steps could not be run here. Verified instead: `PackageVersion`, `ReleaseDate`, and `ReleaseNotesUrl` bumped to 3.5.0; both `InstallerUrl` values point at the published v3.5.0 release assets and each `InstallerSha256` matches the upstream `.sha256` file for its architecture; `InstallerType: zip` with `NestedInstallerType: portable` and `RelativeFilePath: mp3rgui.exe` unchanged, so existing portable installs upgrade in place; tag list and `Publisher` / `Author` / `PublisherSupportUrl` unchanged.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.5.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428372)