### PR TITLE
New package: platwa.KanjiWidget version 1.4.1

### DIFF
--- a/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.installer.yaml
+++ b/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: platwa.KanjiWidget
+PackageVersion: 1.4.1
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/platwa/KanjiWidget/releases/download/v1.4.1/KanjiWidget-1.4.1-x64.msi
+    InstallerSha256: 30C527B47709759D06F4E6E4011715CBDA58ACB490E5F20020E2CCBEE95215BF
+    ProductCode: '{CD06576A-6F73-4D59-A139-AA8CF9AE3C02}'
+    AppsAndFeaturesEntries:
+      - DisplayName: KanjiWidget
+        Publisher: KanjiWidget
+        DisplayVersion: 1.4.1
+        ProductCode: '{CD06576A-6F73-4D59-A139-AA8CF9AE3C02}'
+        UpgradeCode: '{50836B62-135B-5028-BEAE-F25129624AEB}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.locale.en-US.yaml
+++ b/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: platwa.KanjiWidget
+PackageVersion: 1.4.1
+PackageLocale: en-US
+Publisher: KanjiWidget
+PublisherUrl: https://github.com/platwa
+PublisherSupportUrl: https://github.com/platwa/KanjiWidget/issues
+Author: Vladimir Stepanov
+PackageName: KanjiWidget
+PackageUrl: https://platwa.github.io/KanjiWidget/
+License: Apache-2.0
+LicenseUrl: https://github.com/platwa/KanjiWidget/blob/main/LICENSE
+Copyright: Copyright © 2026 Vladimir Stepanov
+ShortDescription: A free offline Windows widget for learning Japanese kanji in the background.
+Description: KanjiWidget keeps kanji and example sentences visible on the Windows desktop, with furigana, English and Russian interfaces, FSRS spaced repetition, Anki .apkg import, custom decks, and active recall. It works offline without ads, accounts, or subscriptions.
+Moniker: kanjiwidget
+Tags:
+  - anki
+  - desktop-widget
+  - fsrs
+  - japanese
+  - kanji
+  - language-learning
+  - spaced-repetition
+ReleaseNotes: Fixed the brief flicker when revealing or concealing details in Active recall mode. The main kanji, Japanese example, and example furigana now remain visually stationary while hidden details fade in or out.
+ReleaseNotesUrl: https://github.com/platwa/KanjiWidget/releases/tag/v1.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.locale.ru-RU.yaml
+++ b/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.locale.ru-RU.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: platwa.KanjiWidget
+PackageVersion: 1.4.1
+PackageLocale: ru-RU
+Publisher: KanjiWidget
+PublisherUrl: https://github.com/platwa
+PublisherSupportUrl: https://github.com/platwa/KanjiWidget/issues
+Author: Vladimir Stepanov
+PackageName: KanjiWidget
+PackageUrl: https://platwa.github.io/KanjiWidget/
+License: Apache-2.0
+LicenseUrl: https://github.com/platwa/KanjiWidget/blob/main/LICENSE
+Copyright: Copyright © 2026 Владимир Степанов
+ShortDescription: Бесплатный офлайн-виджет Windows для фонового изучения японских кандзи.
+Description: KanjiWidget постоянно показывает кандзи и примеры на рабочем столе Windows. В приложении есть фуригана, русский и английский интерфейсы, интервальные повторения FSRS, импорт колод Anki .apkg, собственные колоды и режим активного вспоминания. Работает без интернета, рекламы, аккаунтов и подписок.
+ReleaseNotes: Убрано краткое мерцание при показе и скрытии ответа в режиме «Активное вспоминание». Основной кандзи, японский пример и фуригана примера теперь остаются неподвижными, пока скрытые сведения плавно появляются или исчезают.
+ReleaseNotesUrl: https://github.com/platwa/KanjiWidget/releases/tag/v1.4.1
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.yaml
+++ b/manifests/p/platwa/KanjiWidget/1.4.1/platwa.KanjiWidget.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: platwa.KanjiWidget
+PackageVersion: 1.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for KanjiWidget 1.4.1, a free and open-source offline Windows widget for learning Japanese kanji.

Official version-specific MSI: https://github.com/platwa/KanjiWidget/releases/tag/v1.4.1

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for a routine new-package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for this package
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The MSI metadata (package name, publisher, version, ProductCode, and UpgradeCode) was read directly from the release artifact. The local install test is intentionally left unchecked; the package is already installed on the maintainer's machine and reinstalling it could disturb the running desktop widget.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428387)