### PR TITLE
New package: AmanThanvi.noctty version 1.3.124

### DIFF
--- a/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.installer.yaml
+++ b/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.installer.yaml
@@ -1,0 +1,16 @@
+# Created for noctty 1.3.124 bootstrap
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AmanThanvi.noctty
+PackageVersion: 1.3.124
+InstallerType: inno
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-x64-setup.exe
+  InstallerSha256: 74B2CED7EEDB653C7408DCEBA7334BA31469FC2749057477B7CC1A1785299D9C
+- Architecture: arm64
+  InstallerUrl: https://github.com/amanthanvi/noctty/releases/download/v1.3.124/noctty-1.3.124-windows-arm64-setup.exe
+  InstallerSha256: 341CB01D0E8108E4433BA780480F26BC75779459B05662046F111246F1DFAF9A
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-02

--- a/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.locale.en-US.yaml
+++ b/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created for noctty 1.3.124 bootstrap
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AmanThanvi.noctty
+PackageVersion: 1.3.124
+PackageLocale: en-US
+Publisher: Aman Thanvi
+PublisherUrl: https://github.com/amanthanvi
+PublisherSupportUrl: https://github.com/amanthanvi/noctty/discussions
+PackageName: noctty
+PackageUrl: https://github.com/amanthanvi/noctty
+License: MIT
+ShortDescription: A native Windows terminal powered by Ghostty's terminal core.
+ReleaseNotesUrl: https://github.com/amanthanvi/noctty/releases/tag/v1.3.124
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.yaml
+++ b/manifests/a/AmanThanvi/noctty/1.3.124/AmanThanvi.noctty.yaml
@@ -1,0 +1,8 @@
+# Created for noctty 1.3.124 bootstrap
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AmanThanvi.noctty
+PackageVersion: 1.3.124
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the new `AmanThanvi.noctty` package at version `1.3.124` with x64 and ARM64 Inno Setup installers from the signed Noctty GitHub release.

This is the renamed successor to `AmanThanvi.winghostty`; the new identifier is intentional so future updates use the Noctty product identity.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest .sandbox/winget-noctty-1.3.124`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

> The directory contains the version, installer, and en-US default-locale files for one package manifest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428388)