### PR TITLE
New package: RicardoFrantz.pdf-next version 0.9.0

### DIFF
--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: RicardoFrantz.pdf-next
 PackageVersion: 0.9.0
 InstallerType: nullsoft
@@ -14,4 +14,4 @@ Installers:
     InstallerUrl: https://github.com/ricardofrantz/pdf-next/releases/download/v0.9.0/pdf-next_0.9.0_x64-setup.exe
     InstallerSha256: EEBA84A7D450A7949830F5BEFEDAE419A4697BC1F5A7CE6DA87137625FBCD9FB
 ManifestType: installer
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
@@ -13,5 +13,10 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/ricardofrantz/pdf-next/releases/download/v0.9.0/pdf-next_0.9.0_x64-setup.exe
     InstallerSha256: EEBA84A7D450A7949830F5BEFEDAE419A4697BC1F5A7CE6DA87137625FBCD9FB
+    AppsAndFeaturesEntries:
+      - DisplayName: pdf-next
+        DisplayVersion: 0.9.0
+        Publisher: frantz
+        ProductCode: pdf-next
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: RicardoFrantz.pdf-next
+PackageVersion: 0.9.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-02
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ricardofrantz/pdf-next/releases/download/v0.9.0/pdf-next_0.9.0_x64-setup.exe
+    InstallerSha256: EEBA84A7D450A7949830F5BEFEDAE419A4697BC1F5A7CE6DA87137625FBCD9FB
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.locale.en-US.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: RicardoFrantz.pdf-next
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Ricardo Frantz
+PublisherUrl: https://github.com/ricardofrantz
+PublisherSupportUrl: https://github.com/ricardofrantz/pdf-next/issues
+Author: Ricardo Frantz
+PackageName: pdf-next
+PackageUrl: https://github.com/ricardofrantz/pdf-next
+License: MIT
+LicenseUrl: https://github.com/ricardofrantz/pdf-next/blob/main/LICENSE
+ShortDescription: Tiny PDF, image and markdown viewer with one-second live reload
+Description: |-
+  pdf-next opens PDFs, images and markdown, follows your system dark mode,
+  searches text, typesets TeX equations in markdown, and reloads within a
+  second of the file changing on disk — built for the LaTeX, Typst and
+  markdown compile loop. A command line opens a file at a page or at a
+  figure, so an editor or an agent can point you at the right place.
+Tags:
+  - pdf
+  - markdown
+  - latex
+  - typst
+  - viewer
+  - live-reload
+ReleaseNotesUrl: https://github.com/ricardofrantz/pdf-next/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.locale.en-US.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: RicardoFrantz.pdf-next
 PackageVersion: 0.9.0
 PackageLocale: en-US
@@ -26,4 +26,4 @@ Tags:
   - live-reload
 ReleaseNotesUrl: https://github.com/ricardofrantz/pdf-next/releases/tag/v0.9.0
 ManifestType: defaultLocale
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: RicardoFrantz.pdf-next
 PackageVersion: 0.9.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.9.0
+ManifestVersion: 1.12.0

--- a/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.yaml
+++ b/manifests/r/RicardoFrantz/pdf-next/0.9.0/RicardoFrantz.pdf-next.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: RicardoFrantz.pdf-next
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Validation done locally

- [x] `winget validate --manifest <path>` — succeeded
- [x] Installer verified by hand: `pdf-next_0.9.0_x64-setup.exe /S` exits 0 and
  registers `HKCU\...\Uninstall\pdf-next` (DisplayName `pdf-next`, version
  `0.9.0`, publisher `frantz`), which is what `AppsAndFeaturesEntries` records.
  `winget install --manifest` itself needs `LocalManifestFiles` enabled by an
  administrator, which I could not do on this machine.

### Manifest

- **Package**: `RicardoFrantz.pdf-next` 0.9.0 (new package)
- **Installer**: NSIS, x64, user scope, silent install supported
- **Source**: https://github.com/ricardofrantz/pdf-next/releases/tag/v0.9.0

pdf-next is a small MIT-licensed PDF, image and markdown viewer that reloads
the document within a second of the file changing on disk — built for the
LaTeX and Typst compile loop. It is built and published by GitHub Actions
from the public repository above.

### Changes since the first push

- Manifest schema 1.9.0 -> 1.12.0, as the automated review suggested.
- Added `AppsAndFeaturesEntries`. The installer writes `frantz` as the
  publisher (it comes from the bundle identifier) while this manifest says
  `Ricardo Frantz`, so without the entry `winget upgrade` had nothing to
  correlate on. The application has been corrected upstream; the entry here
  describes the 0.9.0 installer as it actually is.

### Note

The installer is not code signed yet, so Microsoft Defender SmartScreen may
warn on first run. A signing certificate is being arranged, and the manifest
will be updated when signed builds ship.

https://claude.ai/code/session_019yqEUNbvwwgHbkNYMoaBAk