### PR TITLE
New version: Unity.CLI version 1.0.0.20008

### DIFF
--- a/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.installer.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20008
+InstallerLocale: en-US
+InstallerType: msix
+MinimumOSVersion: 10.0.17763.0
+PackageFamilyName: UnityTechnologies.UnityCLI_2vrhnee42bhxm
+Commands:
+- unity
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.8/unity-windows-x64.msix
+  InstallerSha256: 638F44E04E4F43CBC01C64941E6A7EDB06CB65619159D0B7ED80B2BA65E0A195
+  SignatureSha256: 2867760E4763A6E907535A60DC8DDF9451404C487E80DF61922516F822A092FA
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.8/unity-windows-arm64.msix
+  InstallerSha256: 999BA827BB21EB5C579F9A0EC61E34622B0018D1635A1A6E27993F7C4E89CE43
+  SignatureSha256: 4738E7A00CAE75B599BDEAFDCD72253E21F69A58EA0495BF8BA3525EF072CFA5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.locale.en-US.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20008
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity CLI
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Command-line interface for installing Unity Editors and creating, opening, and building Unity projects.
+Description: The Unity CLI (invoked as "unity") manages Unity Editor installations and modules, creates and opens projects, runs builds and Editor commands, and manages licenses and cloud sign-in from the terminal. This build reports its version as 1.0.0-beta.8; MSIX package versions encode the prerelease channel in the fourth (revision) field.
+Moniker: unity-cli
+Tags:
+- cli
+- command-line
+- unity
+- unity3d
+ReleaseNotes: |-
+  Highlights of 1.0.0-beta.8 (full notes at the release notes URL):
+  - unity close closes the Unity editor that has a project open, and is available in a released build for the first time. Neither the default nor --force saves your work.
+  - The command that updates the CLI itself is now unity self-update; unity upgrade keeps working as an alias.
+  - Repository creation now works on Bitbucket through bkt and on Azure DevOps through az, alongside the existing gh, glab, and tea integrations.
+  - On Windows, unity install no longer reports a successful install as failed when you are not an administrator, and installing modules into a protected folder now works.
+  - Interrupting a download with Ctrl+C no longer leaves the taskbar showing progress forever, orphans the elevated installer, or leaves the install lock behind.
+  - Commands no longer stall after their work is done on a signed-in, opted-in profile, where reading the OS keyring could block for tens of seconds.
+  - unity vcs uvcs review reads and answers Unity Version Control code review comments from the terminal.
+ReleaseNotesUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.8/CHANGELOG.md
+Documentations:
+- DocumentLabel: Unity CLI Manual
+  DocumentUrl: https://docs.unity.com/unity-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20008/Unity.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20008
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been automatically created?
No — manual submission.

### Does this pull request the manifest for a new package?
No, this is a new version of an existing package (`Unity.CLI`).

---

Adds **Unity.CLI 1.0.0.20008**, the MSIX for Unity CLI `1.0.0-beta.8`, released 2026-09-02.

`PackageVersion` is the 4-part MSIX identity version, not the app-displayed semver. For `InstallerType: msix` the validation pipeline reads the identity version out of the package and requires them to match. I verified it directly from both packages rather than only from our encoder:

```
AppxManifest.xml  x64:   Version="1.0.0.20008"  ProcessorArchitecture="x64"
AppxManifest.xml  arm64: Version="1.0.0.20008"  ProcessorArchitecture="arm64"
```

Both architectures ship in this PR, as in previous `Unity.CLI` submissions.

### Verification

- `InstallerSha256` computed locally from the downloaded packages and cross-checked against the published `SHA256SUMS` for the release; both architectures match on both sources.
- `SignatureSha256` is the SHA256 of `AppxSignature.p7x` extracted from each `.msix`.
- Installer URLs are the immutable versioned CDN paths, and `ReleaseNotesUrl` returns HTTP 200.
- Manifests parse as YAML and carry a consistent `PackageVersion` across all three files.

### Notes

- `PackageFamilyName` is unchanged (`UnityTechnologies.UnityCLI_2vrhnee42bhxm`), so winget correlates upgrades with the installed package as before.
- The previous version in the catalog is `1.0.0.20006`. There is deliberately no `1.0.0.20007`: `1.0.0-beta.7` was published and withdrawn the same day and was never submitted here.
- MSIX writes no ARP uninstall key, so a `DisplayVersion` attributed to this package in a validation log belongs to another app on the validation VM.

### Manifest

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428400)