### PR TITLE
New package: SoldaLabs.AwaySitter version 1.0.1

### DIFF
--- a/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.installer.yaml
+++ b/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.AwaySitter
+PackageVersion: 1.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- awaysitter
+Installers:
+- Architecture: x64
+  InstallerUrl: https://awaysitter.com/dl/AwaySitter-1.0.1.exe
+  InstallerSha256: 527CB530BF95F18A982DCF432C2070E50493334EF831F0226D2F1EE132F1233D
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.locale.en-US.yaml
+++ b/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.AwaySitter
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Solda Labs
+PublisherUrl: https://awaysitter.com/
+PublisherSupportUrl: https://awaysitter.com/
+PrivacyUrl: https://awaysitter.com/privacy.html
+PackageName: AwaySitter
+PackageUrl: https://awaysitter.com/
+License: Proprietary
+Copyright: Copyright (c) 2026 Solda Labs
+ShortDescription: "Keeps your presence status active with small human-like mouse movements while you are away."
+Description: |-
+  A presence keeper for Windows. When you have been genuinely inactive for a set time, AwaySitter generates small human-like mouse movements along curved paths at randomized intervals, so idle-based status indicators stay active while you step away. It pauses instantly the moment you touch the mouse or keyboard and resumes on its own. Single portable executable, lives in the system tray, global hotkey toggle, 100% local with no telemetry. Note: the input is synthetic and Windows marks it as injected. Paid app (one-time purchase) with a free 3-day trial.
+Moniker: awaysitter
+Tags:
+- mouse-jiggler
+- presence
+- idle
+- away
+- status
+- tray
+- portable
+PurchaseUrl: https://awaysitter.com/buy.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.yaml
+++ b/manifests/s/SoldaLabs/AwaySitter/1.0.1/SoldaLabs.AwaySitter.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.AwaySitter
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
#### Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validated with `winget validate`; installer URL and SHA256 verified by direct download)
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema)?

---

First submission from this publisher. AwaySitter is a portable (single-exe) paid Windows utility with a free 3-day trial, published by Solda Labs. The versioned installer URL is immutable; future releases will use new versioned filenames.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428450)