### PR TITLE
New package: Medalijal.Cade version 0.1.1

### DIFF
--- a/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.installer.yaml
+++ b/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Medalijal.Cade
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: cade.exe
+    PortableCommandAlias: cade
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Medalijal/cade/releases/download/v0.1.1/cade_0.1.1_windows_amd64.zip
+    InstallerSha256: EEF309B22CE3D5EE15FFDB7119CE1A99C84531A216FBD177DE85548AB5EC0A02
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Medalijal/cade/releases/download/v0.1.1/cade_0.1.1_windows_arm64.zip
+    InstallerSha256: 8915562C885FFE8E5E62B7CF28261C8B4A2C8B8C514DE8DDA0CA2F05C91226F3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.locale.en-US.yaml
+++ b/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Medalijal.Cade
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Medalijal
+PublisherUrl: https://github.com/Medalijal
+PublisherSupportUrl: https://github.com/Medalijal/cade/issues
+PackageName: Cade
+PackageUrl: https://github.com/Medalijal/cade
+License: MIT
+LicenseUrl: https://github.com/Medalijal/cade/blob/v0.1.1/LICENSE
+ShortDescription: Local, provider-agnostic orchestrator for AI coding workflows.
+Moniker: cade
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.yaml
+++ b/manifests/m/Medalijal/Cade/0.1.1/Medalijal.Cade.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Medalijal.Cade
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the Cade 0.1.1 portable ZIP package for x64 and ARM64 Windows. Both installer URLs are immutable GitHub Release assets with SHA-256 checksums.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428455)