### PR TITLE
New package: RobworksSoftware.WindowInvert version 0.1.0

### DIFF
--- a/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.installer.yaml
+++ b/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobworksSoftware.WindowInvert
+PackageVersion: 0.1.0
+InstallerType: inno
+Scope: user
+MinimumOSVersion: 10.0.22000.0
+UpgradeBehavior: install
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/robworks-code/window-invert/releases/download/v0.1.0/WindowInvert-Setup-0.1.0.exe
+  InstallerSha256: F06D1914D703BBD1833275A612326BE241107A118897F9B36059996D60974FBD
+  ProductCode: '{156ACB7C-F4C6-4E99-81A3-3C0C520923D2}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: Window Invert
+    Publisher: Robworks Software
+    DisplayVersion: 0.1.0
+    ProductCode: '{156ACB7C-F4C6-4E99-81A3-3C0C520923D2}_is1'
+    InstallerType: inno
+  InstallationMetadata:
+    DefaultInstallLocation: '%LOCALAPPDATA%\Programs\Window Invert'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.locale.en-US.yaml
+++ b/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobworksSoftware.WindowInvert
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Robworks Software
+PublisherUrl: https://github.com/robworks-code
+PublisherSupportUrl: https://github.com/robworks-code/window-invert/issues
+Author: Ryan Robson
+PackageName: Window Invert
+PackageUrl: https://github.com/robworks-code/window-invert
+License: MIT
+LicenseUrl: https://github.com/robworks-code/window-invert/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Ryan Robson
+CopyrightUrl: https://github.com/robworks-code/window-invert/blob/HEAD/LICENSE
+ShortDescription: Inverts the colors of individual chosen windows, leaving the rest of the screen alone.
+Description: |-
+  Window Invert applies a live color inversion to a single chosen window on Windows 11 and leaves the rest of the screen alone. It is for applications that have no dark mode and are used all day, where flipping the whole display fixes one window by breaking every other one.
+  The inverted window keeps behaving like a normal window: move it, resize it, minimize and restore it, type in it. Only the pixels change. Any number of windows can be inverted at once, independently.
+  It lives in the notification area. Pick windows from the tray menu, by clicking one, or with the toggle button that sits beside each window's caption buttons. Elevated windows cannot be inverted; that is an operating system restriction.
+Moniker: window-invert
+Tags:
+- accessibility
+- color
+- contrast
+- dark-mode
+- invert
+- low-vision
+- magnifier
+- tray
+ReleaseNotesUrl: https://github.com/robworks-code/window-invert/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.yaml
+++ b/manifests/r/RobworksSoftware/WindowInvert/0.1.0/RobworksSoftware.WindowInvert.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobworksSoftware.WindowInvert
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: RobworksSoftware.WindowInvert version 0.1.0

Window Invert applies a live color inversion to individual chosen windows on Windows 11 and leaves the rest of the screen alone. Per-user Inno Setup installer from the GitHub release at https://github.com/robworks-code/window-invert/releases/tag/v0.1.0.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428545)