### PR TITLE
Update: ynjmxn.Gengchou to 2.5.2

### DIFF
--- a/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.installer.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.2
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gengchou.exe
+  PortableCommandAlias: gengchou
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ynjmxn/gengchou/releases/download/v2.5.2/gengchou-windows-x64.zip
+  InstallerSha256: 4CA6283275DAD9B68710567C33D62EEE9B367FD45B857685889581525970B398
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-03

--- a/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.locale.en-US.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.2
+PackageLocale: en-US
+Publisher: ynjmxn
+PublisherUrl: https://github.com/ynjmxn
+PublisherSupportUrl: https://github.com/ynjmxn/gengchou/issues
+PrivacyUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.2/README.md#data--privacy
+Author: ynjmxn, lvfeinan and contributors
+PackageName: Gengchou
+PackageUrl: https://github.com/ynjmxn/gengchou
+License: MIT
+LicenseUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.2/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 Jianxin Yin
+CopyrightUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.2/LICENSE
+ShortDescription: A Windows taskbar and tray AI quota monitor for Claude, Codex, Antigravity, and Grok.
+Description: Gengchou is a lightweight native Windows taskbar widget and system-tray app for viewing the quota windows reported by Claude, Codex, Google Antigravity, and Grok without opening a provider dashboard. On first start it asks once for permission, then detects which providers are signed in on this machine and shows only those. Nothing is read before permission is granted, and access can be revoked per provider at any time. It has no analytics, telemetry, or separate backend service, and it does not store provider tokens.
+Moniker: gengchou
+Tags:
+- antigravity
+- claude-code
+- codex
+- grok
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: Fixes a group of failures that gave no sign they had happened. A panic on a background thread left the usage frozen for as long as the app stayed open. A settings file that could not be read or parsed was replaced by defaults within seconds; the original is now kept as settings.json.corrupt and reported once. Claude and Codex recorded an empty quota response as a successful refresh and erased the numbers, and now keep the last good values instead. A second signed-in Windows account could not start Gengchou at all, because the single-instance guard was machine-wide while settings are per user; it is now scoped to the data directory it protects. An Explorer restart could stop monitoring for good in the degraded startup path. A credential probe that wrote more than the pipe buffer holds was reported as a provider that never answered. The updater is also hardened, confirming that its target is this installation before replacing or starting it, checking the download's version and not only its hash, and validating its working directory before downloading into it.
+ReleaseNotesUrl: https://github.com/ynjmxn/gengchou/releases/tag/v2.5.2
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "gengchou", then answer the one-time permission prompt that covers every provider. Access can be revoked for a single provider later under "Provider access"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.2/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.locale.zh-CN.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.locale.zh-CN.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.2
+PackageLocale: zh-CN
+Publisher: ynjmxn
+PackageName: 更筹 Gengchou
+License: MIT
+ShortDescription: 面向 Windows 的 Claude、Codex、Antigravity 和 Grok 配额监视器，提供任务栏组件、浮窗和托盘图标。
+Description: 更筹是轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台 即可查看 Claude、Codex、Google Antigravity 和 Grok 实际报告的配额窗口。 首次启动只请求一次授权，随后探测本机有哪些服务商已登录，并只显示探测到的。 未获授权前不读取任何凭据，且可随时按服务商单独撤销。 应用不包含分析、遥测或独立后端服务，也不会保存服务商令牌。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“gengchou”，并回答那一次覆盖全部服务商的授权提示；之后可在“服务商访问权限”菜单中按服务商单独撤销。如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.2/ynjmxn.Gengchou.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request type

- [x] Package update (`ynjmxn.Gengchou` 2.5.1 -> 2.5.2)

### What is this PR for

Updates `ynjmxn.Gengchou` to 2.5.2, published at https://github.com/ynjmxn/gengchou/releases/tag/v2.5.2

Changes against the 2.5.1 manifests: `PackageVersion`, the installer URL, `InstallerSha256`, `ReleaseDate`, `ReleaseNotes`, `ReleaseNotesUrl`, and the four tag-pinned URLs in the en-US locale (privacy, license, copyright, README). Nothing else differs.

`InstallerSha256` was computed from the asset re-downloaded from the public release page, not from a local build:

```
4CA6283275DAD9B68710567C33D62EEE9B367FD45B857685889581525970B398  gengchou-windows-x64.zip
```

That matches the release's own `SHA256SUMS`, and the asset carries a GitHub build-provenance attestation that verifies against `ynjmxn/gengchou`.

### Checklist

- [x] Manifest version matches the release tag and the `ProductVersion` of the executable inside the archive (`2.5.2`).
- [x] Installer URL resolves and the archive layout is unchanged (`gengchou.exe` at the root, portable alias `gengchou`).
- [x] All tag-pinned documentation URLs resolve at `v2.5.2`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428603)