### PR TITLE
New package: SoldaLabs.StayUp version 1.0.1

### DIFF
--- a/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.installer.yaml
+++ b/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.StayUp
+PackageVersion: 1.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- stayup
+Installers:
+- Architecture: x64
+  InstallerUrl: https://getstayup.com/dl/StayUp-1.0.1.exe
+  InstallerSha256: 11771D535FA9FBE4B9F5F7AF96ADC9C44B62948E4D151707E62A9FDC7616D31E
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.locale.en-US.yaml
+++ b/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.StayUp
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Solda Labs
+PublisherUrl: https://getstayup.com/
+PublisherSupportUrl: https://getstayup.com/
+PrivacyUrl: https://getstayup.com/privacy.html
+PackageName: StayUp
+PackageUrl: https://getstayup.com/
+License: Proprietary
+Copyright: Copyright (c) 2026 Solda Labs
+ShortDescription: "Keep-awake utility: keep your PC awake forever, for a duration, until a time, per app, or on a schedule."
+Description: |-
+  A keep-awake utility for Windows. Keeps the PC (and optionally the screen) awake indefinitely, for a set duration, until a clock time, while chosen apps are running, or on a daily schedule, with an optional stay-active mouse nudge. Global hotkey, system-tray icon, single portable executable, 100% local with no telemetry. Paid app (one-time purchase) with a free 3-day trial.
+Moniker: stayup
+Tags:
+- keep-awake
+- caffeine
+- insomnia
+- sleep
+- power
+- tray
+- portable
+PurchaseUrl: https://getstayup.com/buy.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.yaml
+++ b/manifests/s/SoldaLabs/StayUp/1.0.1/SoldaLabs.StayUp.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.StayUp
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
#### Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validated with `winget validate`; installer URL and SHA256 verified by direct download)
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema)?

---

StayUp is a portable (single-exe) paid Windows utility with a free 3-day trial, published by Solda Labs. Same publisher as SoldaLabs.AwaySitter (#428450, validation passed). The versioned installer URL is immutable; future releases will use new versioned filenames.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428666)