### PR TITLE
New package: SoldaLabs.CueValet version 1.0.1

### DIFF
--- a/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.installer.yaml
+++ b/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.CueValet
+PackageVersion: 1.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+- cuevalet
+Installers:
+- Architecture: x64
+  InstallerUrl: https://cuevalet.com/dl/CueValet-1.0.1.exe
+  InstallerSha256: DED457C727A5CB2D33734B3B4263FB28F0F59F8C3585F9C20C3D2A7E957CA53C
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.locale.en-US.yaml
+++ b/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.CueValet
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Solda Labs
+PublisherUrl: https://cuevalet.com/
+PublisherSupportUrl: https://cuevalet.com/
+PrivacyUrl: https://cuevalet.com/privacy.html
+PackageName: CueValet
+PackageUrl: https://cuevalet.com/
+License: Proprietary
+Copyright: Copyright (c) 2026 Solda Labs
+ShortDescription: "Visual trigger tool: when a pixel changes, a window appears or a timer fires, it clicks, types or launches."
+Description: |-
+  A visual trigger tool for Windows. Build rules with no code: when a screen pixel changes or matches a colour, a window appears, a timer fires, at a time of day, or on a hotkey, CueValet clicks, presses keys, types text, launches an app or file, or shows a notification. One master hotkey arms and disarms every rule; it lives in the system tray. Single portable executable, 100% local with no telemetry. Paid app (one-time purchase) with a free 3-day trial.
+Moniker: cuevalet
+Tags:
+- automation
+- trigger
+- auto-clicker
+- pixel
+- no-code
+- portable
+PurchaseUrl: https://cuevalet.com/buy.html
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.yaml
+++ b/manifests/s/SoldaLabs/CueValet/1.0.1/SoldaLabs.CueValet.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: SoldaLabs.CueValet
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
#### Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validated with `winget validate`; installer URL and SHA256 verified by direct download)
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema)?

---

CueValet is a portable (single-exe) paid Windows utility with a free 3-day trial, published by Solda Labs. Same publisher as SoldaLabs.AwaySitter (#428450, validation passed). The versioned installer URL is immutable; future releases will use new versioned filenames.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428668)