### PR TITLE
Update package: Karuzip.Karuzip version 2.2.0

### DIFF
--- a/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.installer.yaml
+++ b/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Karuzip.Karuzip
+PackageVersion: 2.2.0
+InstallerLocale: ja-JP
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - karuzip-cli
+ReleaseDate: 2026-09-03
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/AAAAAnson/karuzip/releases/download/v2.2.0/Karuzip_2.2.0_x64-setup.exe
+    InstallerSha256: "945849B7025136BCEF19CE5F4FCF300B123001312B3DAD489728D69B3BDB3316"
+    ProductCode: Karuzip
+    AppsAndFeaturesEntries:
+      - DisplayName: Karuzip
+        Publisher: Karuzip
+        ProductCode: Karuzip
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.locale.en-US.yaml
+++ b/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+PackageIdentifier: Karuzip.Karuzip
+PackageVersion: 2.2.0
+PackageLocale: en-US
+Publisher: Karuzip
+PublisherUrl: https://karuzip.com
+PublisherSupportUrl: https://karuzip.com/operator.html
+PrivacyUrl: https://karuzip.com/privacy.html
+Author: Karuzip
+PackageName: Karuzip
+PackageUrl: https://karuzip.com
+License: Proprietary
+LicenseUrl: https://github.com/AAAAAnson/karuzip/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Karuzip
+ShortDescription: A free, ad-free Windows archive utility supporting 320 file extensions, with a full English or Japanese interface.
+Description: |-
+  Karuzip is a free archive utility for Windows. It has no ads, bundled software, account requirement, or usage tracking.
+
+  Version 2.2.0 adds Automation: watch a folder and Karuzip checks and extracts the archives that land there, with three templates (check and extract, batch health check, verified delivery compression). It runs only while Karuzip is open. This version also adds a pre-extraction check (encryption, entry count, extracted size), a searchable processing history, and a manual diagnostic export. Extracting from the right-click menu no longer blocks unrelated work in the main window.
+
+  - Extracts 320 file extensions (230 verified by automated tests or samples, 12 verified on real Windows systems)
+  - Lets users switch filename encodings among UTF-8, CP932, GBK, and Big5 before extraction
+  - Puts Extract here, Extract to folder, and View contents plus three compress actions in the Explorer right-click menu, hiding the compress actions when everything you selected is an archive
+  - Compresses immediately to "name.zip" or "name.7z", adding a numeric suffix when necessary
+  - Creates ZIP, 7z, TAR, GZIP, BZIP2, XZ, and WIM archives
+  - Extracts RAR archives but does not create them
+  - Creates and extracts password-protected ZIP and 7z archives without saving passwords
+  - Supports split archives such as .zip.001, .7z.001, and .part1.rar
+  - Lists, searches, tests, and selectively extracts large archives with file-count progress
+  - Cleans up only newly created partial output after cancellation or failure
+
+  Processing stays on the device. Karuzip bundles unmodified 7-Zip 25.01 and unar 1.8.1 binaries as archive engines.
+Tags:
+  - 7z
+  - archive
+  - archiver
+  - compression
+  - extract
+  - file-archiver
+  - japanese
+  - rar
+  - unzip
+  - zip
+ReleaseNotesUrl: https://karuzip.com/koushin-rireki.html
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.locale.ja-JP.yaml
+++ b/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.locale.ja-JP.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Karuzip.Karuzip
+PackageVersion: 2.2.0
+PackageLocale: ja-JP
+Publisher: Karuzip
+PublisherUrl: https://karuzip.com
+PublisherSupportUrl: https://karuzip.com/operator.html
+PrivacyUrl: https://karuzip.com/privacy.html
+Author: Karuzip
+PackageName: Karuzip
+PackageUrl: https://karuzip.com
+License: Proprietary
+LicenseUrl: https://github.com/AAAAAnson/karuzip/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Karuzip
+ShortDescription: 文字化けした ZIP も、右クリックですぐ解凍。320 拡張子に対応する、広告なし・無料の解凍／圧縮ソフトです。
+Description: |-
+  Karuzip（かるジップ）は、日本語環境で迷わず使える無料の解凍・圧縮ソフトです。広告、バンドルソフト、アカウント登録、利用状況の収集はありません。
+
+  - 解凍は 320 拡張子に対応（うち動作検証済み 230、実機検証済み 12）
+  - 文字化けした ZIP は、解凍前に UTF-8 / CP932 / GBK / Big5 へ切り替えてファイル名を確認
+  - 右クリックメニューに「ここに解凍」「フォルダーに解凍」「中身を見る」と圧縮 3 項目（書庫だけを選んだときは圧縮項目を出しません）
+  - 「名前.zip」「名前.7z」への即時圧縮と、同名時の連番保存
+  - ZIP / 7z / TAR / GZIP / BZIP2 / XZ / WIM の作成に対応
+  - RAR は解凍のみ対応（作成はできません）
+  - パスワード付き ZIP / 7z の作成と解凍。入力したパスワードは保存しません
+  - 分割書庫（.zip.001 / .7z.001 / .part1.rar など）に対応
+  - 数万件の書庫でも一覧・検索・選択解凍と「N / M 件」の進捗表示
+  - キャンセルや失敗時は、新しく作った途中出力だけを後始末
+  - 表示言語は日本語と英語を設定から切り替え可能（右クリックメニューとファイル種別名もアプリの設定に追従）
+
+  処理は端末内で完結します。解凍・圧縮エンジンとして 7-Zip 25.01 と unar 1.8.1 を改変せず同梱しています。
+Moniker: karuzip
+Tags:
+  - 7z
+  - archive
+  - archiver
+  - compression
+  - extract
+  - file-archiver
+  - japanese
+  - rar
+  - unzip
+  - zip
+  - 圧縮
+  - 解凍
+ReleaseNotesUrl: https://karuzip.com/koushin-rireki.html
+Documentations:
+  - DocumentLabel: 使い方ガイド
+    DocumentUrl: https://karuzip.com/tsukaikata.html
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.yaml
+++ b/manifests/k/Karuzip/Karuzip/2.2.0/Karuzip.Karuzip.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Karuzip.Karuzip
+PackageVersion: 2.2.0
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds manifests for Karuzip.Karuzip 2.2.0.

- Installer: version-pinned GitHub Release URL, SHA-256 verified against the release asset digest.
- No `DisplayVersion` in `AppsAndFeaturesEntries` (equals PackageVersion).

Automated validation was run locally against the 1.6.0 schema.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428701)