### PR TITLE
New package: treealarm.OnvifLib.Gui version 1.2.0

### DIFF
--- a/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.installer.yaml
+++ b/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: treealarm.OnvifLib.Gui
+PackageVersion: 1.2.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: machine
+ReleaseDate: 2026-08-13
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/treealarm/OnvifLib/releases/download/gui-1.2.0/OnvifLib.Gui-win-x64.msi
+    InstallerSha256: FCFC95B8A80F15FA5F33120B5416B98925921DB21C4434F9D1958A2D6D31CA56
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.locale.en-US.yaml
+++ b/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: treealarm.OnvifLib.Gui
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: treealarm
+PublisherUrl: https://github.com/treealarm
+PublisherSupportUrl: https://github.com/treealarm/OnvifLib/issues
+Author: treealarm
+PackageName: OnvifLib.Gui
+PackageUrl: https://github.com/treealarm/OnvifLib
+License: MIT
+LicenseUrl: https://github.com/treealarm/OnvifLib/blob/main/LICENSE
+Copyright: Copyright (c) 2025 treealarm
+ShortDescription: Cross-platform ONVIF Device Manager alternative with live H.264/HEVC video.
+Description: |-
+  Avalonia desktop app for ONVIF IP cameras (Windows and Linux builds; this package is Windows x64).
+  Discover or add cameras, live RTSP playback via bundled LGPL ffmpeg (H.264 and HEVC), PTZ,
+  imaging, events, analytics, Profile G archive search/replay, and Device I/O.
+  Built on the OnvifLib .NET library (separate NuGet package).
+Moniker: onviflib-gui
+Tags:
+  - onvif
+  - camera
+  - ip-camera
+  - odm
+  - hevc
+  - h265
+  - ffmpeg
+  - ptz
+  - avalonia
+ReleaseNotesUrl: https://github.com/treealarm/OnvifLib/releases/tag/gui-1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.yaml
+++ b/manifests/t/treealarm/OnvifLib/Gui/1.2.0/treealarm.OnvifLib.Gui.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: treealarm.OnvifLib.Gui
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
### Pull request has:

- [x] Manifests
- [ ] Binary packages that cannot be downloaded solely from proprietary sources

### Checklist

- [x] The PackageIdentifier path uses one folder per segment (`manifests/t/treealarm/OnvifLib/Gui/1.2.0/`)
- [x] Installer is the WiX MSI from GitHub Release `gui-1.2.0`
- [x] SHA256 matches the release asset digest

### Package

- **PackageIdentifier:** treealarm.OnvifLib.Gui
- **Version:** 1.2.0
- **Installer:** https://github.com/treealarm/OnvifLib/releases/download/gui-1.2.0/OnvifLib.Gui-win-x64.msi
- **Source templates:** https://github.com/treealarm/OnvifLib/tree/main/packaging/winget

Replaces #428720 (previous PR had a wrong folder path then a noisy path-fix history).

ONVIF Device Manager–style Avalonia GUI with live H.264/HEVC via bundled ffmpeg.

Made with [Cursor](https://cursor.com)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428723)