### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.2.3

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.2.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.3
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{5C30BEEB-7D56-4222-A856-BBBFEE145414}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{5C30BEEB-7D56-4222-A856-BBBFEE145414}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.2.3/GestureSign-V2-18.2.3-x64.msi
+  InstallerSha256: 869EC4475CD3CADD919ADD42ADE7CB1C34462F29261D77F4D96602D7007B8CFC
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-03

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created for GestureSign V2 18.2.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.3
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Unified the capture, preview, recognition, and execution lifecycle.
+  - Added device-independent end-to-end orchestration regression coverage (9/9 groups passing).
+  - Improved x64 and ARM64 build validation, warning gates, configuration migration, Kando migration, and portable package checks.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.2.3
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.3/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# Created for GestureSign V2 18.2.3
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Update Tomclanc.GestureSignV2 to version 18.2.3.

## Changes
- Kando menu activation now uses the running instance local IPC to avoid Electron process startup latency.
- Improved GestureSign exit responsiveness and reduced cursor hitching.

## Validation
- MSI URL and SHA256 verified against the v18.2.3 GitHub Release.
- x64 build: 0 warnings, 0 errors.
- Regression tests: 9/9 passing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428799)