### PR TITLE
New package: MartinPospisil.Gleanvolt version 1.0.1

### DIFF
--- a/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.installer.yaml
+++ b/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MartinPospisil.Gleanvolt
+PackageVersion: 1.0.1
+# The release ships a zip, not an installer: a self-contained build that needs no .NET and writes
+# nothing outside its own directory. WinGet installs it as a portable, which is what it is.
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: '2026-09-03'
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  # The zip contains exactly one top-level directory, named for the runtime identifier. That is
+  # deliberate in release.yml, and this path depends on it.
+  - RelativeFilePath: win-x64\Gleanvolt.Worker.exe
+    PortableCommandAlias: gleanvolt
+  InstallerUrl: https://github.com/mpospisil/gleanvolt/releases/download/v1.0.1/gleanvolt-1.0.1-win-x64.zip
+  InstallerSha256: 803EEE3EFC76978198B4984198B119ED788588CADC8B4000979D905118491B4E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.locale.en-US.yaml
+++ b/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MartinPospisil.Gleanvolt
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Martin Pospisil
+PublisherUrl: https://github.com/mpospisil
+PublisherSupportUrl: https://github.com/mpospisil/gleanvolt/issues
+PackageName: Gleanvolt
+PackageUrl: https://github.com/mpospisil/gleanvolt
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/mpospisil/gleanvolt/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Martin Pospisil
+CopyrightUrl: https://github.com/mpospisil/gleanvolt/blob/main/LICENSE
+ShortDescription: Locally hosted controller for a SolaX hybrid inverter and EV charger, over Modbus TCP.
+Description: >-
+  A standalone background service for managing and monitoring a SolaX X3-HYB-G4 PRO hybrid inverter
+  and a SolaX X1/X3-HAC EV charger. It operates entirely within the local network over Modbus TCP,
+  with no cloud dependency, so polling is immediate and the data stays on the premises.
+
+  It reads PV generation, battery state of charge and grid power flow, and uses them to drive EV
+  charging and home-battery use from household surplus: charging the car on live solar, holding the
+  battery back when the forecast says it will be needed, and targeting a departure time. A web UI is
+  built in, and it can publish itself to Home Assistant over MQTT.
+
+  This build is free for any noncommercial purpose under the PolyForm Noncommercial License 1.0.0.
+  Commercial use requires a separate licence -- see the LICENSE file.
+Moniker: gleanvolt
+Tags:
+- battery
+- ev-charger
+- home-assistant
+- inverter
+- modbus
+- solar
+- solax
+ReleaseNotesUrl: https://github.com/mpospisil/gleanvolt/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.yaml
+++ b/manifests/m/MartinPospisil/Gleanvolt/1.0.1/MartinPospisil.Gleanvolt.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MartinPospisil.Gleanvolt
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **MartinPospisil.Gleanvolt** version **1.0.1**.

Gleanvolt is a locally hosted background service for a SolaX X3-HYB-G4 PRO hybrid inverter and a
SolaX X1/X3-HAC EV charger. It talks to them over Modbus TCP on the local network with no cloud
dependency, and uses PV generation, battery state of charge and grid flow to drive EV charging from
household surplus.

I am the author and publisher of this software. The installer URL points at the official GitHub
release in the project's own repository:
https://github.com/mpospisil/gleanvolt/releases/tag/v1.0.1

**Packaging notes**

- `InstallerType: zip` with `NestedInstallerType: portable`. The release ships a self-contained
  build that requires no .NET runtime, writes nothing outside its own directory, and has no
  uninstaller.
- `RelativeFilePath: win-x64\Gleanvolt.Worker.exe` — the archive contains a single top-level
  directory named for the runtime identifier.
- `PortableCommandAlias: gleanvolt`.
- Licensed under PolyForm Noncommercial 1.0.0; free for any noncommercial use. `LicenseUrl` points
  at the licence text in the repository.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428803)