### PR TITLE
Update Mozilla.Firefox.DeveloperEdition version 156.0 (156.0b2)

### DIFF
--- a/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.installer.yaml
+++ b/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.installer.yaml
@@ -1,0 +1,40 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.DeveloperEdition
+PackageVersion: "156.0"
+InstallerType: nullsoft
+Scope: machine
+InstallerSwitches:
+  Silent: /S /PreventRebootRequired=true
+  SilentWithProgress: /S /PreventRebootRequired=true
+  InstallLocation: /InstallDirectoryPath="<INSTALLPATH>"
+UpgradeBehavior: install
+Protocols:
+- http
+- https
+- mailto
+FileExtensions:
+- avif
+- htm
+- html
+- pdf
+- shtml
+- svg
+- webp
+- xht
+- xhtml
+ProductCode: Firefox Developer Edition
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/devedition/releases/156.0b2/win32/en-US/Firefox%20Setup%20156.0b2.exe
+  InstallerSha256: 66D6910EB8E80B1A6B28C894710D9789AF3F9D9B9EA96F972742AE2A4D3FF613
+- Architecture: x64
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/devedition/releases/156.0b2/win64/en-US/Firefox%20Setup%20156.0b2.exe
+  InstallerSha256: 16474C74B4C8456F283E2BBDC53CE1689582A816AE100555C459D6AEBBECCE8D
+- Architecture: arm64
+  InstallerUrl: https://download-installer.cdn.mozilla.net/pub/devedition/releases/156.0b2/win64-aarch64/en-US/Firefox%20Setup%20156.0b2.exe
+  InstallerSha256: 8A54F365080466FE0E3072588FF1B047C2350EA8B937D195B500B184C2655C2E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.locale.en-US.yaml
+++ b/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.DeveloperEdition
+PackageVersion: "156.0"
+PackageLocale: en-US
+Publisher: Mozilla
+PublisherUrl: https://www.mozilla.org/
+PublisherSupportUrl: https://support.mozilla.org/
+PrivacyUrl: https://www.mozilla.org/privacy/firefox/
+Author: Mozilla Foundation
+PackageName: Firefox Developer Edition (en-US)
+PackageUrl: https://www.mozilla.org/firefox/developer/
+License: MPL-2.0
+LicenseUrl: https://www.mozilla.org/MPL/2.0
+CopyrightUrl: https://www.mozilla.org/foundation/trademarks/policy
+ShortDescription: Firefox Browser Developer Edition
+Description: Get the latest features, fast performance, and the development tools you need to build for the open web using Firefox Browser Developer Edition.
+Moniker: firefox-dev
+Tags:
+- browser
+- cross-platform
+- foss
+- gecko
+- quantum
+- spidermonkey
+- web
+- web-browser
+ReleaseNotes: |-
+  Version 156.0beta, first offered to Beta channel users on August 31, 2026
+  Firefox Beta gets updated 3 times a week and as a consequence, the release notes for the Beta channel are updated continuously to reflect features that have reached sufficient maturity to benefit from community feedback and bug reports.
+  Warning: Features listed here may or may not make a final release of Firefox.
+  In addition to these release notes, you can follow ongoing development via the Firefox Trains website or our @FirefoxBeta Bluesky account.
+
+  New
+  - macOS users can now configure Firefox to launch automatically at startup via Settings.
+  - Improved memory and CPU usage when Firefox displays large JPEG images scaled down to fit a page.
+  - Localized Wikipedia and occasional sponsored suggestions in the address bar now available in France, Germany, and Italy (can be disabled in Firefox Suggest settings).
+  - Firefox for Android media notifications now include previous/next buttons and timeline seeking controls.
+  - Firefox for Android sharing now uses native Android share sheet on Android 14+, with options like Send tab to device and Scan QR code.
+
+  Fixed
+  - Windows ARM64 devices: WebRTC video calls may now use hardware H264 decoding.
+  - Fixed dragging an inline image to a new position in a rich-text editor replacing it with a long line of text instead of moving it.
+  - All devices: WebRTC video calls may now use hardware AV1 decoding.
+  - Fixed high-sample-rate FLAC audio in MP4 failing to play on sites such as Bilibili.
+  - Fixed find bar becoming permanently unavailable after reversing panes in Split View.
+  - Windows: fixed Firefox blocking auto-hiding taskbars.
+  - Firefox for Android: fixed crashes when selecting files from certain Android file providers.
+  - Fixed subtitles not appearing in Picture-in-Picture after being enabled post-launch.
+  - Firefox for Android: fixed date picker allowing dates before minimum when maximum was specified.
+
+  Changed
+  - Firefox's built-in PDF viewer now starts up to 45% faster.
+
+  Enterprise
+  - FirefoxHome policy now includes Widgets option for controlling new tab productivity widgets.
+  - SitePolicies policy now supports DisableServiceWorkers for blocking service worker registration.
+  - Windows installer now resolves /INI= paths relative to installer location.
+  - Fixed DontCheckDefaultBrowser and DefaultBrowserSettingEnabled policies being ignored on new profiles.
+
+  Web Platform
+  - text-box-trim now uses font metrics of ::first-line pseudo-elements when applicable.
+ReleaseNotesUrl: https://www.firefox.com/en-US/firefox/156.0beta/releasenotes/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.yaml
+++ b/manifests/m/Mozilla/Firefox/DeveloperEdition/156.0/Mozilla.Firefox.DeveloperEdition.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Mozilla.Firefox.DeveloperEdition
+PackageVersion: "156.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates the Mozilla.Firefox.DeveloperEdition package to version **156.0** (build 156.0b2).

- Updated `PackageVersion` to `156.0` across all manifest files
- Updated `InstallerUrl` for all three architectures (x86/x64/arm64), en-US locale
- Updated `InstallerSha256` with hashes independently verified by downloading each installer from Mozilla's official CDN and hashing
- Updated `ReleaseDate` to `2026-09-02` (per ftp.mozilla.org file timestamp)
- Updated `ReleaseNotes`/`ReleaseNotesUrl` to the 156.0 beta cycle notes

The previous manifest version (151.0) had not been updated since 2026-05-13, despite Firefox Developer Edition having progressed through several beta cycles since then.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428807)