### PR TITLE
Update Python.Launcher version 3.14.7

### DIFF
--- a/manifests/p/Python/Launcher/3.14.7/Python.Launcher.installer.yaml
+++ b/manifests/p/Python/Launcher/3.14.7/Python.Launcher.installer.yaml
@@ -1,0 +1,35 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Python.Launcher
+PackageVersion: 3.14.7
+InstallerType: wix
+UpgradeBehavior: install
+Commands:
+- py
+- python
+- pythonw
+- pyw
+FileExtensions:
+- py
+- pyc
+- pyd
+- pyo
+- pyw
+- pyz
+- pyzw
+ProductCode: '{E81C7963-7B6A-4296-9368-C4CA4D78470A}'
+ReleaseDate: 2026-08-05
+AppsAndFeaturesEntries:
+- DisplayVersion: 3.14.7150.0
+  DisplayName: Python Launcher
+  ProductCode: '{E81C7963-7B6A-4296-9368-C4CA4D78470A}'
+  UpgradeCode: '{1B68A0EC-4DD3-5134-840E-73854B0863F1}'
+InstallationMetadata:
+  DefaultInstallLocation: .
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.python.org/ftp/python/3.14.7/win32/launcher.msi
+  InstallerSha256: E0FE589EB1C7D4E474C7D2AC2D9D2655F6FBA28079C93FD6F6819E423CEFD96A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Python/Launcher/3.14.7/Python.Launcher.locale.en-US.yaml
+++ b/manifests/p/Python/Launcher/3.14.7/Python.Launcher.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Python.Launcher
+PackageVersion: 3.14.7
+PackageLocale: en-US
+Publisher: Python Software Foundation
+PublisherUrl: https://www.python.org/
+PublisherSupportUrl: https://www.python.org/about/help/
+PrivacyUrl: https://www.python.org/privacy/
+Author: Python Software Foundation
+PackageName: Python Launcher
+PackageUrl: https://www.python.org/
+License: PSF-2.0
+LicenseUrl: https://docs.python.org/3/license.html
+Copyright: Copyright (c) 2001-2023 Python Software Foundation. All Rights Reserved.
+CopyrightUrl: https://www.python.org/about/legal/
+ShortDescription: The Python launcher for Windows is a utility which aids in locating and executing of different Python versions.
+Description: |-
+  The Python launcher for Windows is a utility which aids in locating and executing of different Python versions.
+  It allows scripts (or the command-line) to indicate a preference for a specific Python version, and will locate and execute that version.
+
+  Unlike the PATH variable, the launcher will correctly select the most appropriate version of Python.
+  It will prefer per-user installations over system-wide ones, and orders by language version rather than using the most recently installed version.
+
+  The launcher was originally specified in PEP 397.
+Moniker: python-launcher
+Tags:
+- language
+- programming
+- programming-language
+- python
+- python3
+- script
+Documentations:
+- DocumentLabel: Python Launcher for Windows
+  DocumentUrl: https://docs.python.org/3/using/windows.html#launcher
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Python/Launcher/3.14.7/Python.Launcher.yaml
+++ b/manifests/p/Python/Launcher/3.14.7/Python.Launcher.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Python.Launcher
+PackageVersion: 3.14.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates the Python.Launcher package to version **3.14.7**.

- Updated `PackageVersion` to `3.14.7`
- Updated `InstallerUrl` to `https://www.python.org/ftp/python/3.14.7/win32/launcher.msi`
- Updated `InstallerSha256` (verified by downloading the installer directly and hashing)
- Updated `ProductCode` to `{E81C7963-7B6A-4296-9368-C4CA4D78470A}` — extracted directly from the MSI via the Windows Installer API, since ProductCode changes with every release; `UpgradeCode` (`{1B68A0EC-4DD3-5134-840E-73854B0863F1}`) is unchanged and consistent with all prior versions
- Updated `ReleaseDate` to `2026-08-05`
- Updated `AppsAndFeaturesEntries.DisplayVersion` to `3.14.7150.0`

The previous manifest version (3.13.5) had not been updated since 2025-06-11, despite Python 3.14 (the current actively-developed branch) having been out for nearly a year.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428808)