### PR TITLE
Update PuTTY.PuTTY version 0.85.0.0

### DIFF
--- a/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.installer.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.installer.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PuTTY.PuTTY
+PackageVersion: 0.85.0.0
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    InstallLocation: INSTALLDIR="<INSTALLPATH>"
+  UpgradeBehavior: uninstallPrevious
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/w64/putty-64bit-0.85-installer.msi
+  InstallerSha256: 2213EBACF962B709411D654A40087508A694756BC4E41C5A1C24AD86596B2511
+  ProductCode: '{3B0346D3-155D-43E5-9561-B9BE51CF2EB6}'
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85 (64-bit)
+    ProductCode: '{3B0346D3-155D-43E5-9561-B9BE51CF2EB6}'
+    UpgradeCode: '{C9EAA861-2B72-4FAF-9FEE-EEB1AD5FD15E}'
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: PUTTY.EXE
+    PortableCommandAlias: putty
+  - RelativeFilePath: PUTTYGEN.EXE
+    PortableCommandAlias: puttygen
+  - RelativeFilePath: PLINK.EXE
+    PortableCommandAlias: plink
+  - RelativeFilePath: PSFTP.EXE
+    PortableCommandAlias: psftp
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/w64/putty.zip
+  InstallerSha256: E0B36E5381ECC78DD06A291BAB25FB9D95BC991D0D864CF2741A5BDE82816668
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85 (64-bit, portable)
+- Architecture: x86
+  InstallerType: wix
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    InstallLocation: INSTALLDIR="<INSTALLPATH>"
+  UpgradeBehavior: uninstallPrevious
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/w32/putty-0.85-installer.msi
+  InstallerSha256: CBC48AF94F6462FA3C1859F4185A1FFDA360C3C760DEF9AD5B1E0EC1430B2E09
+  ProductCode: '{057E0E80-E4D6-4541-9E00-5FE18954C4D5}'
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85
+    ProductCode: '{057E0E80-E4D6-4541-9E00-5FE18954C4D5}'
+    UpgradeCode: '{DCE70C63-8808-4646-B16B-A677BD298385}'
+- Architecture: x86
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: PUTTY.EXE
+    PortableCommandAlias: putty
+  - RelativeFilePath: PUTTYGEN.EXE
+    PortableCommandAlias: puttygen
+  - RelativeFilePath: PLINK.EXE
+    PortableCommandAlias: plink
+  - RelativeFilePath: PSFTP.EXE
+    PortableCommandAlias: psftp
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/w32/putty.zip
+  InstallerSha256: A7A28753A4F91316A8DEB8FDC08403B68852AD04A9D2753C413E8E8B8A1A72F1
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85 (Portable x86)
+- Architecture: arm64
+  InstallerType: wix
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerSwitches:
+    InstallLocation: INSTALLDIR="<INSTALLPATH>"
+  UpgradeBehavior: uninstallPrevious
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/wa64/putty-arm64-0.85-installer.msi
+  InstallerSha256: F26059B6F6CFA7BADD59A1F133AF4338AD3EC68E8B0AEB0EC1DFD7D63E1C66D4
+  ProductCode: '{B9D99033-2B04-4C26-8751-DD51F2D9A2C1}'
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85 (64-bit Arm)
+    ProductCode: '{B9D99033-2B04-4C26-8751-DD51F2D9A2C1}'
+    UpgradeCode: '{2125AD39-A960-4377-AD41-99E50D842AE5}'
+- Architecture: arm64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: PUTTY.EXE
+    PortableCommandAlias: putty
+  - RelativeFilePath: PUTTYGEN.EXE
+    PortableCommandAlias: puttygen
+  - RelativeFilePath: PLINK.EXE
+    PortableCommandAlias: plink
+  - RelativeFilePath: PSFTP.EXE
+    PortableCommandAlias: psftp
+  InstallerUrl: https://the.earth.li/~sgtatham/putty/0.85/wa64/putty.zip
+  InstallerSha256: BD3A8E6EB9D7D14E0A7D7E9B461A1FCA70211F032C2B5FF2B16E5952867930F6
+  AppsAndFeaturesEntries:
+  - DisplayName: PuTTY release 0.85 (64-bit Arm, portable)
+FileExtensions:
+- ppk
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.locale.en-US.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.locale.en-US.yaml
@@ -29,6 +29,12 @@ Tags:
 - xterm
 - supdup
 - rlogin
+ReleaseNotes: |-
+  These features are new in 0.85 (released 2026-08-16):
+  - Security issue: fixed a remotely triggerable use-after-free in Pageant. (Might be exploitable to execute code, although this is not proved.)
+  - Security issue: fixed a remotely triggerable buffer overflow if the OpenSSH encrypt-then-MAC cipher modes are in use. (However they are only used if a server supports nothing else.)
+  - Security issue: fixed a buffer overflow in private key decryption, if the private key is constructed maliciously. (Only triggerable on purpose if you let somebody else generate your key for you.)
+  - Denial-of-service security fixes: a server can trigger a tight loop in PuTTY, and even a MITM can make it consume unlimited memory at startup.
 ReleaseNotesUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 Documentations:
 - DocumentLabel: Documentation

--- a/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.locale.en-US.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PuTTY.PuTTY
+PackageVersion: 0.85.0.0
+PackageLocale: en-US
+Publisher: Simon Tatham
+PublisherUrl: https://www.chiark.greenend.org.uk/
+PublisherSupportUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/feedback.html
+PrivacyUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/privacy.html
+Author: Simon Tatham
+PackageName: PuTTY
+PackageUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/
+License: MIT
+LicenseUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html
+Copyright: © 1997-2026 Simon Tatham. All rights reserved.
+ShortDescription: A free implementation of SSH and Telnet for Windows and Unix platforms, along with an xterm terminal emulator.
+Description: |-
+  PuTTY is a client program for the SSH, Telnet, Rlogin, and SUPDUP network protocols.
+  These protocols are all used to run a remote session on a computer, over a network. PuTTY implements the client end of that session: the end at which the session is displayed, rather than the end at which it runs.
+  In really simple terms: you run PuTTY on a Windows machine, and tell it to connect to (for example) a Unix machine. PuTTY opens a window. Then, anything you type into that window is sent straight to the Unix machine, and everything the Unix machine sends back is displayed in the window. So you can work on the Unix machine as if you were sitting at its console, while actually sitting somewhere else.
+Moniker: putty
+Tags:
+- puttygen
+- plink
+- psftp
+- ssh
+- telnet
+- tty
+- xterm
+- supdup
+- rlogin
+ReleaseNotesUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/docs.html
+- DocumentLabel: FAQ
+  DocumentUrl: https://www.chiark.greenend.org.uk/~sgtatham/putty/faq.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.yaml
+++ b/manifests/p/PuTTY/PuTTY/0.85.0.0/PuTTY.PuTTY.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PuTTY.PuTTY
+PackageVersion: 0.85.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates PuTTY.PuTTY to version **0.85.0.0**.

- Updated `PackageVersion` to `0.85.0.0` across all manifest files
- Updated `InstallerUrl`/`InstallerSha256` for all 6 installer entries (x86/x64/arm64, each with a WiX MSI + a portable zip variant)
- `ProductCode` values extracted directly from each MSI via the Windows Installer API; `UpgradeCode` values are unchanged from 0.84 (confirmed via that manifest)
- Updated `ReleaseDate` to `2026-08-14`

Two other open PRs (#418543, #418418) attempt this same version bump but both fail `02. Manifest Validation`: they set the portable zip installer entries' `InstallerUrl` to the `.msi` installer file instead of the actual `putty.zip` archive that PuTTY publishes alongside it (e.g. `https://the.earth.li/~sgtatham/putty/0.85/w64/putty.zip`). This PR uses the correct zip URLs, independently downloaded and hashed, and follows the exact structure of the last successfully merged manifest (0.84.0.0).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428851)