### PR TITLE
Update KaiKramer.KeyStoreExplorer version 5.7.0

### DIFF
--- a/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.installer.yaml
+++ b/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.installer.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KaiKramer.KeyStoreExplorer
+PackageVersion: 5.7.0
+InstallerType: inno
+FileExtensions:
+- bks
+- jceks
+- jks
+- keystore
+- ks
+- p12
+- pfx
+- uber
+ProductCode: '{A771FBEB-F7E1-4443-9181-AFD57F7BFF45}_is1'
+ReleaseDate: 2026-08-23
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/kaikramer/keystore-explorer/releases/download/v5.7.0/kse-570-setup.exe
+  InstallerSha256: 9D337FB85B3FA9DE4F75DF959DBAECD42330D58993FED6A4861CE091D67A3D56
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/kaikramer/keystore-explorer/releases/download/v5.7.0/kse-570-setup.exe
+  InstallerSha256: 9D337FB85B3FA9DE4F75DF959DBAECD42330D58993FED6A4861CE091D67A3D56
+  InstallerSwitches:
+    Custom: /ALLUSERS
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.locale.en-US.yaml
+++ b/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KaiKramer.KeyStoreExplorer
+PackageVersion: 5.7.0
+PackageLocale: en-US
+Publisher: Kai Kramer
+PublisherUrl: https://keystore-explorer.org/
+PublisherSupportUrl: https://github.com/kaikramer/keystore-explorer/issues
+Author: Wayne Grant, Kai Kramer
+PackageName: KeyStore Explorer
+PackageUrl: https://keystore-explorer.org/downloads.html
+License: GPL-3.0
+LicenseUrl: https://github.com/kaikramer/keystore-explorer/blob/master/LICENSE
+Copyright: Copyright 2004-2013 Wayne Grant, 2013-2026 Kai Kramer
+ShortDescription: An open source GUI replacement for the Java command-line utilities keytool and jarsigner
+Description: KeyStore Explorer is an open source GUI replacement for the Java command-line utilities keytool and jarsigner. KeyStore Explorer presents their functionality, and more, via an intuitive graphical user interface.
+Moniker: kse
+Tags:
+- cacerts
+- cert
+- certificate
+- jarsigner
+- key
+- keystore
+- keytool
+ReleaseNotesUrl: https://github.com/kaikramer/keystore-explorer/releases/tag/v5.7.0
+Documentations:
+- DocumentLabel: User Manual
+  DocumentUrl: https://keystore-explorer.org/doc/5.5/overview.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.yaml
+++ b/manifests/k/KaiKramer/KeyStoreExplorer/5.7.0/KaiKramer.KeyStoreExplorer.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KaiKramer.KeyStoreExplorer
+PackageVersion: 5.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates KaiKramer.KeyStoreExplorer to version **5.7.0**.

- Manifest content matches the existing open PR #423015 (installer URL, hash, ProductCode, switches all independently re-verified)
- Fixes the one issue blocking that PR: `LicenseUrl` pointed at `https://keystore-explorer.org/license.html`, which now returns HTTP 404 (confirmed — the vendor's site no longer has a standalone license page). Updated it to the project's actual GPL-3.0 license file on GitHub: `https://github.com/kaikramer/keystore-explorer/blob/master/LICENSE`
- `InstallerSha256` independently verified by downloading the installer directly and hashing
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428854)