### PR TITLE
Update CPUID.CPU-Z version 3.01

### DIFF
--- a/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.installer.yaml
+++ b/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.installer.yaml
@@ -1,0 +1,34 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CPUID.CPU-Z
+PackageVersion: '3.01'
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+ProductCode: CPUID CPU-Z_is1
+ReleaseDate: 2026-08-20
+AppsAndFeaturesEntries:
+- ProductCode: CPUID CPU-Z_is1
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\CPUID\CPU-Z'
+Installers:
+- InstallerLocale: en-US
+  Architecture: x86
+  InstallerUrl: https://download.cpuid.com/cpu-z/cpu-z_3.01-en.exe
+  InstallerSha256: 74AB9B1C24FB223D0A5C23E2E444B6CBBA7D0C6882CC4BF389E3F88BFCA37490
+- InstallerLocale: en-US
+  Architecture: x64
+  InstallerUrl: https://download.cpuid.com/cpu-z/cpu-z_3.01-en.exe
+  InstallerSha256: 74AB9B1C24FB223D0A5C23E2E444B6CBBA7D0C6882CC4BF389E3F88BFCA37490
+- InstallerLocale: zh-CN
+  Architecture: x86
+  InstallerUrl: https://download.cpuid.com/cpu-z/cpu-z_3.01-cn.exe
+  InstallerSha256: 2BD8E75A9C4AE99400C1C06262A5BD6127B81DE7B57D4E459F0C382BDC3BC189
+- InstallerLocale: zh-CN
+  Architecture: x64
+  InstallerUrl: https://download.cpuid.com/cpu-z/cpu-z_3.01-cn.exe
+  InstallerSha256: 2BD8E75A9C4AE99400C1C06262A5BD6127B81DE7B57D4E459F0C382BDC3BC189
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.locale.en-US.yaml
+++ b/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.locale.en-US.yaml
@@ -1,0 +1,44 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CPUID.CPU-Z
+PackageVersion: '3.01'
+PackageLocale: en-US
+Publisher: CPUID, Inc.
+PublisherUrl: https://www.cpuid.com/
+PublisherSupportUrl: https://www.cpuid.com/contact.html
+PrivacyUrl: https://www.cpuid.com/privacy-policy.html
+Author: CPUID, Inc.
+PackageName: CPUID CPU-Z
+PackageUrl: https://www.cpuid.com/softwares/cpu-z.html
+License: Freeware
+LicenseUrl: https://www.cpuid.com/terms-of-service.html
+Copyright: CPUID © 2001-2026 - All website content subjected to copyright
+CopyrightUrl: https://www.cpuid.com/terms-of-service.html
+ShortDescription: System information software
+Description: |-
+  CPU-Z is a freeware that gathers information on some of the main devices of your system
+  - Processor name and number, codename, process, package, cache levels.
+  - Mainboard and chipset.
+  - Memory type, size, timings, and module specifications (SPD).
+  - Real time measurement of each cores internal frequency, memory frequency.
+Moniker: cpu-z
+Tags:
+- amd
+- cpu
+- cpuz
+- hardware
+- intel
+- memory
+- motherboard
+- processor
+- system
+- system-information
+ReleaseNotes: |-
+  - CPU-Z Validator V3.
+ReleaseNotesUrl: https://www.cpuid.com/softwares/cpu-z.html#version-history
+Documentations:
+- DocumentLabel: FAQ
+  DocumentUrl: https://www.cpuid.com/softwares/cpu-z.html#faq
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.yaml
+++ b/manifests/c/CPUID/CPU-Z/3.01/CPUID.CPU-Z.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CPUID.CPU-Z
+PackageVersion: '3.01'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

This PR updates CPUID.CPU-Z to version **3.01** ("CPU-Z Validator V3", released 2026-08-20).

- No open or closed PR exists yet for this version — the automation that normally submits CPU-Z updates same-day (see #419141 for 2.21) hasn't picked this one up
- Updated `InstallerUrl`/`InstallerSha256` for both en-US and zh-CN installers, independently downloaded and hashed
- `ProductCode` (`CPUID CPU-Z_is1`, an Inno Setup AppId) confirmed unchanged from 2.21
- Updated `ReleaseDate` to `2026-08-20` and `ReleaseNotes` to the 3.01 changelog entry
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428871)