### PR TITLE
New version: gemron.Termexo version 0.7.0

### DIFF
--- a/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.installer.yaml
+++ b/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: gemron.Termexo
+PackageVersion: 0.7.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-09-03
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Termexo'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gemron/Termexo/releases/download/v0.7.0/Termexo_0.7.0_x64-setup.exe
+  InstallerSha256: 23B6FDEB884726EA29377D512496D7EAAACAF9E2195CF2D003D4FC2E0672169A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.locale.en-US.yaml
+++ b/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: gemron.Termexo
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: gemron
+PublisherUrl: https://github.com/gemron
+PublisherSupportUrl: https://github.com/gemron/Termexo/issues
+PackageName: Termexo
+PackageUrl: https://www.termexo.com
+License: MIT
+LicenseUrl: https://github.com/gemron/Termexo/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Termexo contributors
+ShortDescription: A local-first Windows workspace for Claude Code, Codex and OpenCode terminals.
+Description: |-
+  Termexo runs Claude Code, Codex CLI and OpenCode in real PTY terminals inside one Windows
+  workspace, and owns the layer above them: workspaces, grid layout, agent state, native session
+  recovery, a task board, model provider profiles, and login accounts. Each terminal names the
+  account it is signed in as and can be switched to another one. Workspace state is kept in local
+  SQLite and API keys in Windows Credential Manager; the agents' own session files stay read-only.
+  Requires the WebView2 runtime, which Windows 11 includes and most Windows 10 installs already
+  have through Edge.
+Tags:
+- agent
+- ai
+- claude
+- codex
+- developer-tools
+- llm
+- terminal
+ReleaseNotesUrl: https://github.com/gemron/Termexo/releases/tag/v0.7.0
+Documentations:
+- DocumentLabel: Changelog
+  DocumentUrl: https://github.com/gemron/Termexo/blob/main/CHANGELOG.md
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.yaml
+++ b/manifests/g/gemron/Termexo/0.7.0/gemron.Termexo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: gemron.Termexo
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
﻿### New version: gemron.Termexo version 0.7.0

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

Termexo is a Windows-only, local-first workspace for AI coding agents. It runs Claude Code,
Codex CLI and OpenCode in real PTY terminals and manages their workspaces, layout, state,
session recovery, model provider profiles and login accounts.

- Repository: https://github.com/gemron/Termexo
- Release: https://github.com/gemron/Termexo/releases/tag/v0.7.0
- Licence: MIT
- Installer: NSIS (`nullsoft`), per-user scope, x64
- Runtime requirement: WebView2, noted in the package description

`winget validate` passes locally against the 1.10.0 schema.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428916)