### PR TITLE
New package: rukpat.DecryptPDFs version 2.0.3

### DIFF
--- a/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.installer.yaml
+++ b/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: rukpat.DecryptPDFs
+PackageVersion: 2.0.3
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/rukpat/DecryptPDFs/releases/download/v2.0.3/DecryptPDFs-Setup-2.0.3.exe
+    InstallerSha256: A0DD98633CC1CDEF9C8C6A5C3B03780F33B858D82A47B96D577DED84882EDBA3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.locale.en-US.yaml
+++ b/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: rukpat.DecryptPDFs
+PackageVersion: 2.0.3
+PackageLocale: en-US
+Publisher: Rukesh Patel
+PublisherUrl: https://github.com/rukpat
+PublisherSupportUrl: https://github.com/rukpat/DecryptPDFs/issues
+PackageName: Decrypt PDFs
+PackageUrl: https://github.com/rukpat/DecryptPDFs
+License: MIT
+LicenseUrl: https://github.com/rukpat/DecryptPDFs/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Rukesh Patel
+ShortDescription: Bulk-remove PDF passwords from Windows Explorer - learns and auto-tries your passwords.
+Description: |-
+  A Windows utility for finding and removing password protection from PDF files in bulk. Right-click a
+  folder or a batch of PDFs in Explorer and it scans them, tells you which are password-protected, and
+  strips that protection - either with a password you type in, or automatically using passwords it has
+  already learned.
+
+  Includes a Password Manager that stores learned passwords encrypted at rest with Windows DPAPI, gated
+  behind your Windows login (password, PIN, or Windows Hello) and masked by default.
+Moniker: decryptpdfs
+Tags:
+  - pdf
+  - pdf-password
+  - password-remover
+  - password-manager
+  - pdf-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.yaml
+++ b/manifests/r/rukpat/DecryptPDFs/2.0.3/rukpat.DecryptPDFs.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: rukpat.DecryptPDFs
+PackageVersion: 2.0.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds **Decrypt PDFs** - a Windows utility for finding and removing password protection from PDF files in bulk, with a built-in password manager that learns your passwords and auto-tries them on future scans.

- Repo: https://github.com/rukpat/DecryptPDFs
- Release: https://github.com/rukpat/DecryptPDFs/releases/tag/v2.0.3
- License: MIT
- Installer: Inno Setup, per-user install (no admin rights required)

## Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.schema.json)?

Note: `winget validate` passed clean locally. A full `winget install --manifest` run was not completed in this environment - the `InstallerSha256` has been verified against the actual published release asset (downloaded fresh and hashed, not just the local build). The installer itself has been manually run and verified separately (install + right-click/Send-to integration + uninstall all confirmed working).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428934)