### PR TITLE
New version: Pithflow.Pithflow version 1.34.0

### DIFF
--- a/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.installer.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.34.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-09-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://pithflow.com/downloads/Pithflow_1.34.0_x64-setup.exe
+  InstallerSha256: 02D5265382C0979AFD95B7EE7E1ABF0CC260B927AF738B45DEDF66078C92A6DF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.locale.en-US.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.34.0
+PackageLocale: en-US
+Publisher: Pithflow
+PublisherUrl: https://pithflow.com/?utm_source=winget&utm_medium=listing
+PublisherSupportUrl: https://pithflow.com/faq/
+PrivacyUrl: https://pithflow.com/privacy/
+PackageName: Pithflow
+PackageUrl: https://pithflow.com/?utm_source=winget&utm_medium=listing
+License: Proprietary (free tier available)
+LicenseUrl: https://pithflow.com/terms/
+PurchaseUrl: https://pithflow.com/pricing/?utm_source=winget&utm_medium=listing
+ShortDescription: Windows-native AI voice dictation. Hold Ctrl+Space, speak, release - your words land as cleaned-up text in whatever Windows app you are already using.
+Description: |-
+  Pithflow is a Windows-native voice dictation app built in Rust - a ~6 MB installer, not an Electron wrapper. Hold Ctrl+Space, speak, release: your words come back as cleaned-up text, placed straight into whatever app has focus.
+
+  Meeting notes (Pro): record a meeting in the room or a video call on Zoom, Teams or Meet, and when you stop you get a summary, the key points ranked by how often each came up, the decisions and the action items - exportable to Word, PDF or plain text.
+
+  Privacy-first by design: your session is DPAPI-encrypted on your machine and audio is never stored. Transcription runs in the cloud, so an internet connection is required.
+
+  Because audio is captured on your local machine and nothing is installed inside the remote session, Pithflow works where most dictation tools fail - including RDP, Citrix, and VDI.
+
+  Native bilingual Spanish/English, including mid-sentence Spanglish code-switching. Handles 100+ other languages too.
+
+  Free tier: 2,000 words per week, no card required. Pro is $9.99/month or $99/year. Windows 10/11.
+Moniker: pithflow
+Tags:
+- dictation
+- speech-to-text
+- voice-typing
+- meeting-notes
+- accessibility
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.yaml
+++ b/manifests/p/Pithflow/Pithflow/1.34.0/Pithflow.Pithflow.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Pithflow.Pithflow
+PackageVersion: 1.34.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Bumps Pithflow.Pithflow to 1.34.0.

Installer: https://pithflow.com/downloads/Pithflow_1.34.0_x64-setup.exe (NSIS, x64, Authenticode-signed). SHA256 matches the served file byte-for-byte. `winget validate --manifest` passes locally.

Related: #428956 is this same change (identical manifests), but its commit was authored under an email that my CLA signature does not cover, so the bot flagged it Needs-CLA; it is being closed in favor of this PR. #426966 bumps the same package to 1.33.0 and is superseded by 1.34.0.

## Checklist
- [x] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/428965)