### PR TITLE
New package: BigHatGroup.FileCommand version 0.1.0

### DIFF
--- a/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.installer.yaml
+++ b/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.installer.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+#
+# Winget installer manifest template for FileCommand.
+# See winget/README.md for how to fill in 0.1.0, https://github.com/kkaminsk/FileCommand/releases/download/v0.1.0, and
+# 57B15F9CED7BBD2B48776F91321DCC21ADAF18B2ABC74110D191E3EC58DBE7AA at release time, and installer/README.md for scope semantics.
+#
+# Two installer entries share the same FileCommandSetup.exe (the Burn
+# bundle embeds both scopes; see Bundle.wxs) and are distinguished only by
+# Scope + InstallerSwitches.Custom, which forwards winget's --scope choice
+# to the bundle's InstallScope variable (design.md decision D4).
+
+PackageIdentifier: BigHatGroup.FileCommand
+PackageVersion: "0.1.0"
+InstallerType: burn
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: "https://github.com/kkaminsk/FileCommand/releases/download/v0.1.0/FileCommandSetup.exe"
+    InstallerSha256: "57B15F9CED7BBD2B48776F91321DCC21ADAF18B2ABC74110D191E3EC58DBE7AA"
+    InstallerSwitches:
+      Silent: "/quiet"
+      SilentWithProgress: "/passive"
+  - Architecture: x64
+    Scope: machine
+    InstallerUrl: "https://github.com/kkaminsk/FileCommand/releases/download/v0.1.0/FileCommandSetup.exe"
+    InstallerSha256: "57B15F9CED7BBD2B48776F91321DCC21ADAF18B2ABC74110D191E3EC58DBE7AA"
+    InstallerSwitches:
+      Silent: "/quiet InstallScope=perMachine"
+      SilentWithProgress: "/passive InstallScope=perMachine"
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.locale.en-US.yaml
+++ b/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: BigHatGroup.FileCommand
+PackageVersion: "0.1.0"
+PackageLocale: en-US
+Publisher: BigHatGroup
+PackageName: FileCommand
+License: MIT OR Apache-2.0
+ShortDescription: >-
+  A keyboard-driven, dual-panel file manager for the terminal, recreating
+  the Norton Commander 5.5 workflow with modern extras.
+Moniker: filecommand
+Tags:
+  - file-manager
+  - terminal
+  - tui
+  - console
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.yaml
+++ b/manifests/b/BigHatGroup/FileCommand/0.1.0/BigHatGroup.FileCommand.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+#
+# Winget version manifest template for FileCommand.
+#
+# This is a TEMPLATE checked into the repo so the bundle and the manifest
+# stay next to each other and in sync (design.md, risk: "winget manifest
+# can drift from bundle reality"). It is not submitted anywhere by this
+# repo; see winget/README.md for the release-time fill-in and submission
+# steps. Submitting to winget-pkgs is out of scope for this change.
+
+PackageIdentifier: BigHatGroup.FileCommand
+PackageVersion: "0.1.0" # e.g. 0.1.0 -- from Cargo.toml [workspace.package].version
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description

Adds a new package: **BigHatGroup.FileCommand**, version 0.1.0.

FileCommand is a keyboard-driven, dual-panel file manager for the terminal, written in Rust, recreating the Norton Commander 5.5 workflow with modern extras (mouse support incl. drag-and-drop, visual themes, built-in viewer/editor).

- Homepage / source: https://github.com/kkaminsk/FileCommand
- Release: https://github.com/kkaminsk/FileCommand/releases/tag/v0.1.0
- Installer: `FileCommandSetup.exe` (WiX Burn bootstrapper, `InstallerType: burn`), signed with Big Hat Group Inc.'s Azure Trusted Signing certificate, supporting both per-user and per-machine scope (`--scope user`/`--scope machine`).

## Checklist

- [x] I've checked that there are no similar PR's for the same manifests
- [x] I've checked that the ProductCode(s) for this package version, and only this package version, are used in the previous section
- [x] This PR only modifies one (1) manifest
- [x] I have not included any external URLs, images, or scripts that are not directly related to this PR and the changed manifest
- [x] My installers/binaries are digitally signed by the vendor, or are hosted in a repository that meets the [source requirements](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#software-requirements)

Validated locally with `winget validate --manifest .` before submission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429006)