### PR TITLE
New version: Nidzoki.win-alias version 1.0.1

### DIFF
--- a/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.installer.yaml
+++ b/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.installer.yaml
@@ -1,11 +1,13 @@
-# Created using wingetcreate 1.12.8.0
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Nidzoki.win-alias
 PackageVersion: 1.0.1
 InstallerType: portable
-Commands:
-- alias
+InstallModes:
+- silent
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-09-03
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/Nidzoki/win-alias/releases/download/v1.0.1/win-alias.exe

--- a/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.installer.yaml
+++ b/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nidzoki.win-alias
+PackageVersion: 1.0.1
+InstallerType: portable
+Commands:
+- alias
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Nidzoki/win-alias/releases/download/v1.0.1/win-alias.exe
+  InstallerSha256: 69C3E0E9A2027D4B4A97E61367C9A09B2B48B12F9244DBE13E6437CE5C3936AE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.locale.en-US.yaml
+++ b/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.locale.en-US.yaml
@@ -1,12 +1,24 @@
-# Created using wingetcreate 1.12.8.0
+# Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Nidzoki.win-alias
 PackageVersion: 1.0.1
 PackageLocale: en-US
 Publisher: Nidzoki
+PublisherUrl: https://github.com/Nidzoki
+PublisherSupportUrl: https://github.com/Nidzoki/win-alias/issues
+Author: Nikola Vidović
 PackageName: win-alias
-License: MIT License
-ShortDescription: Alias manager for Windows CMD
+PackageUrl: https://github.com/Nidzoki/win-alias
+License: MIT
+LicenseUrl: https://github.com/Nidzoki/win-alias/blob/master/LICENSE
+Copyright: Copyright (c) 2026 win-alias contributors
+CopyrightUrl: https://github.com/Nidzoki/win-alias/blob/master/LICENSE
+ShortDescription: Fast and lightweight alias manager for Windows CMD.
+Description: >
+  Fast and lightweight alias manager for Windows CMD, bringing Linux-like alias
+  functionality with Registry-backed persistence.
+ReleaseNotes: 'Full Changelog: https://github.com/Nidzoki/win-alias/commits/v1.0.1'
+ReleaseNotesUrl: https://github.com/Nidzoki/win-alias/releases/tag/v1.0.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.locale.en-US.yaml
+++ b/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nidzoki.win-alias
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Nidzoki
+PackageName: win-alias
+License: MIT License
+ShortDescription: Alias manager for Windows CMD
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.yaml
+++ b/manifests/n/Nidzoki/win-alias/1.0.1/Nidzoki.win-alias.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.8.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nidzoki.win-alias
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description of the change`n`nNew version of Nidzoki.win-alias with same-session CMD alias support.`n`n## Validation performed`n`n- `winget validate` passed.`n- Installer SHA256 verified against GitHub release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429024)