### PR TITLE
New version: Tomclanc.GestureSignV2 version 18.2.4

### DIFF
--- a/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.installer.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.installer.yaml
@@ -1,0 +1,23 @@
+# Created for GestureSign V2 18.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.4
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{8DC9E7FF-D06B-4CAC-9BFC-A687E402859C}'
+AppsAndFeaturesEntries:
+- DisplayName: GestureSign V2
+  Publisher: TransposonY / WinUI rebuild
+  ProductCode: '{8DC9E7FF-D06B-4CAC-9BFC-A687E402859C}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Tomclanc/GestureSignv2/releases/download/v18.2.4/GestureSign-V2-18.2.4-x64.msi
+  InstallerSha256: 40129423D88E414F6F683268A3AC80DC8EAD521763090B273054B82C1BC7A8A8
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-04

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.locale.en-US.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created for GestureSign V2 18.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.4
+PackageLocale: en-US
+Publisher: Tomclanc
+PublisherUrl: https://github.com/Tomclanc
+PublisherSupportUrl: https://github.com/Tomclanc/GestureSignv2/issues
+Author: Tomclanc
+PackageName: GestureSign V2
+PackageUrl: https://github.com/Tomclanc/GestureSignv2
+License: GPL-2.0
+LicenseUrl: https://github.com/Tomclanc/GestureSignv2/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Tomclanc
+ShortDescription: A Windows 11 focused rebuild of GestureSign for touchpad, touchscreen, and mouse gestures.
+Description: GestureSign V2 is a Windows 11 focused rebuild of the classic open-source GestureSign project. It supports touchpad gestures, touchscreen gestures, mouse gestures, per-app device selection, gesture trails, ignore rules, tray controls, Smart Close, Smart New Tab, and optional Kando radial menu quick actions.
+Moniker: gesturesignv2
+Tags:
+- gesture
+- gestures
+- mouse
+- touchscreen
+- touchpad
+- windows-11
+ReleaseNotes: |-
+  - Fixed Microsoft Store startup bringing the Kando window to the foreground unexpectedly.
+  - Kept Kando background startup centralized in the daemon to avoid startup races.
+  - Updated MSI and x64 portable packages.
+ReleaseNotesUrl: https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.2.4
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/Tomclanc/GestureSignv2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.yaml
+++ b/manifests/t/Tomclanc/GestureSignV2/18.2.4/Tomclanc.GestureSignV2.yaml
@@ -1,0 +1,7 @@
+# Created for GestureSign V2 18.2.4
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Tomclanc.GestureSignV2
+PackageVersion: 18.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the GestureSign V2 18.2.4 x64 MSI installer manifest. The MSI is published at https://github.com/Tomclanc/GestureSignv2/releases/tag/v18.2.4.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429086)