### PR TITLE
Update version: AES256Afro.VideoKidnapper version 1.8.2

### DIFF
--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.installer.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.2
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: "{8C8E1A2F-5D4B-4E6A-9F32-7C1A5B2D6E84}_is1"
+ReleaseDate: 2026-09-03
+AppsAndFeaturesEntries:
+- ProductCode: "{8C8E1A2F-5D4B-4E6A-9F32-7C1A5B2D6E84}_is1"
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/AES256Afro/VideoKidnapper/releases/download/v1.8.2/VideoKidnapper-Setup-1.8.2.exe
+  InstallerSha256: 51E88BAB6E6F60D83062BA2C54185EC5ECE501CA875A7F7AB2B6065EDB1C4BDD
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/AES256Afro/VideoKidnapper/releases/download/v1.8.2/VideoKidnapper-Setup-1.8.2.exe
+  InstallerSha256: 51E88BAB6E6F60D83062BA2C54185EC5ECE501CA875A7F7AB2B6065EDB1C4BDD
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  InstallationMetadata:
+    DefaultInstallLocation: "%ProgramFiles%\\VideoKidnapper"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.locale.en-US.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.2
+PackageLocale: en-US
+Publisher: AES256Afro
+PublisherUrl: https://github.com/AES256Afro
+PublisherSupportUrl: https://github.com/AES256Afro/VideoKidnapper/issues
+Author: AES256Afro
+PackageName: VideoKidnapper
+PackageUrl: https://github.com/AES256Afro/VideoKidnapper
+License: Apache-2.0
+LicenseUrl: https://github.com/AES256Afro/VideoKidnapper/blob/HEAD/LICENSE
+ShortDescription: Open-source desktop app to trim, caption, GIF, and download videos from multiple platforms using yt-dlp and FFmpeg.
+Description: VideoKidnapper is a free, open-source desktop app for grabbing and editing video. Paste a link to download clips from multiple platforms via yt-dlp, then trim to a range, add captions, and export as a video or an animated GIF — all locally with the full FFmpeg toolchain, so nothing is blocked or watermarked. Runs on Windows, macOS, and Linux and is released under the Apache-2.0 license.
+Tags:
+- customtkinter
+- desktop-app
+- ffmpeg
+- gif
+- python
+- screen-recorder
+- tkinter
+- video
+- video-editor
+- yt-dlp
+ReleaseNotes: "Published to PyPI：https://pypi.org/project/videokidnapper/1.8.2/\n\n**macOS:** `*-macos-arm64.dmg` (Apple Silicon) · `*-macos-x86_64.dmg` (Intel). Signed and notarized by Apple — drag to Applications and double-click, no security prompt. FFmpeg is bundled.\n\n---\n\n> **First release that opens on a Mac with no security prompt.** The `.dmg` is now Developer-ID signed and notarized by Apple. v1.8.1 needed a trip through *Open Anyway*; v1.8.0 would not open at all.\n\n### Added\n\n• **Themes.** Five to choose from under the ◐ button in the header：**Cream retro tech** (warm beige and burnt orange, the look of late-70s computing hardware), **Fallout** (Pip-Boy phosphor green), **Retro** (80s synthwave violet and hot pink), plus the existing Dark and Light. Every palette is checked for readable contrast before it can ship. Switching still takes a restart.\n\n• **Exports are named after the video.** A folder of clips used to be a wall of `VidKid_trim_20260902_143022.mp4` where only the timestamp told them apart. Exports now take the source video's title — the real title for a download, the filename for a local file. **Export Options → File names** switches between *Video title*, *Video title + date*, *Video title + date & time*, and the old *VidKid + timestamp*, with a live example of what the next file will be called.\n\n  Titles are cleaned up on the way：path separators, control characters and Windows-illegal characters are removed, over-long titles are cut at a word boundary, and names that would collide with a Windows device (`CON`, `NUL`, `COM1`) are defused. Accents, CJK and emoji are kept. A second export of the same clip gets `_1`, `_2` rather than overwriting.\n\n• **Animated stickers.** Overlay an animated GIF, APNG, or WebP onto a video *or* onto a GIF export — reaction stickers, animated logos, looping accents. The sticker loops for as long as it is on screen, with the same position, scale, opacity, and timing controls still images already had. The overlay row labels animated files with their frame count, since a file path alone doesn't say whether something moves.\n\n### Changed\n\n• **macOS builds are signed and notarized.** Every release DMG is now signed with a Developer ID certificate, submitted to Apple's notary service, and has the notarization ticket stapled in — so it launches with a normal double-click, offline, with no *\"Apple could not verify\"* prompt. The release build fails if Gatekeeper reports anything other than `accepted`, so an unnotarized DMG can no longer ship by accident. Setting this up on a fresh machine is one command：`scripts/setup-macos-signing.sh`.\n• **Cream retro tech is the default theme** for new installs. An existing install keeps whatever it already has stored, so nobody's choice is overridden — pick Cream from the ◐ menu to switch.\n\n### Fixed\n\n• **Adding a GIF overlay used to kill the export.** The file picker has always offered `.gif` and `.webp`, but every overlay was handed to FFmpeg as a still image (`-loop 1`, an option that only exists for the image2 demuxer). Picking an animated sticker made FFmpeg exit with `Option loop not found.` before writing a single frame, so the export just failed. Animated sources now get the right loop handling, and animated WebP — which FFmpeg cannot decode — is converted first instead of rendering frozen.\n• **GIF export with an overlay could hang forever.** Overlay inputs loop indefinitely, and the palette pass every GIF export runs has to read the whole stream before it can start, so it waited on an input that never ended and left a zero-byte file behind. The overlay is now bounded by the length of the video."
+ReleaseNotesUrl: https://github.com/AES256Afro/VideoKidnapper/releases/tag/v1.8.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.2/AES256Afro.VideoKidnapper.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update AES256Afro.VideoKidnapper to version 1.8.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429148)