### PR TITLE
New version: SosomLab.NexaDir version 0.19.0

### DIFF
--- a/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.installer.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.19.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+Installers:
+# Per-user install (installer default: PrivilegesRequired=lowest, no elevation).
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/SosomLab/nexa-dir2/releases/download/0.19.0/NexaDir-Setup-0.19.0.exe
+  InstallerSha256: 2A70AB18D871903F63E1714C31B06F34D82ECB3F02C543EAA2E73003644A1764
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+# Machine-wide install (the installer allows the /ALLUSERS command-line override).
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/SosomLab/nexa-dir2/releases/download/0.19.0/NexaDir-Setup-0.19.0.exe
+  InstallerSha256: 2A70AB18D871903F63E1714C31B06F34D82ECB3F02C543EAA2E73003644A1764
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  ElevationRequirement: elevatesSelf
+AppsAndFeaturesEntries:
+- DisplayName: Nexa Dir
+  Publisher: SosomLab
+  ProductCode: '{7E4B1C9D-3A52-4F8E-9B70-6C2D815FA3E1}_is1'
+  InstallerType: inno
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.locale.en-US.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.19.0
+PackageLocale: en-US
+Publisher: SosomLab
+PublisherUrl: https://sosomlab.com
+PublisherSupportUrl: https://github.com/SosomLab/nexa-dir2/issues
+Author: Sangyong Bae
+PackageName: Nexa Dir
+PackageUrl: https://sosomlab.com/apps/nexa-dir/
+License: PolyForm Noncommercial License 1.0.0
+LicenseUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+Copyright: Copyright (c) 2026 SosomLab
+CopyrightUrl: https://github.com/SosomLab/nexa-dir2/blob/main/LICENSE.md
+ShortDescription: Lightweight, keyboard-first file explorer for Windows in a single native exe.
+Description: |-
+  Nexa Dir is a lightweight file explorer for Windows, built as a single native
+  executable in pure Rust on the Win32 API — no managed runtime, no UI framework,
+  and no external DLLs beyond the OS inbox set.
+
+  Highlights:
+  - Single portable exe under 10 MB, with an idle memory footprint under 30 MB.
+  - Dense, dark, keyboard-first UI designed for fast navigation over the mouse.
+  - Virtualized tree and list views that stay smooth over 100k+ entries.
+  - Bulk rename with reusable presets and live preview.
+  - Cloud storage in the same window: link an existing OneDrive, Google Drive or
+    Dropbox sync folder, or connect an account directly over OAuth to browse,
+    upload and download without syncing anything to disk.
+  - Trilingual UI (English, Korean, and Japanese).
+
+  Settings and session data live next to the executable under data\, falling back
+  to %LOCALAPPDATA%\NexaDir\data when the install directory is not writable.
+  Uninstalling keeps your data so a reinstall restores your settings.
+
+  Nexa Dir is free for personal and other noncommercial use under the PolyForm
+  Noncommercial License 1.0.0. Commercial use requires a separate paid license.
+Moniker: nexa-dir
+Tags:
+- explorer
+- file-manager
+- files
+- native
+- portable
+- rust
+- win32
+ReleaseNotesUrl: https://github.com/SosomLab/nexa-dir2/releases/tag/0.19.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/SosomLab/nexa-dir2/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.yaml
+++ b/manifests/s/SosomLab/NexaDir/0.19.0/SosomLab.NexaDir.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SosomLab.NexaDir
+PackageVersion: 0.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with winget validate --manifest <path>?
- [ ] Have you tested your manifest locally with winget install --manifest <path>?
- [x] Does your manifest conform to the 1.12 schema?

Release: https://github.com/SosomLab/nexa-dir2/releases/tag/0.19.0

Version update: preferences window scrolling rework (overlay scrollbar), font fallback chain
applied to all UI text, overlay scrollbars on the file list. Same manifest shape as 0.16–0.18.1;
installer SHA-256 taken from the published release asset and cross-checked against SHA256SUMS.txt.
`winget validate --manifest` passed locally.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429155)