### PR TITLE
New package: thebubbsy.Marksmith version 3.1.1

### DIFF
--- a/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.installer.yaml
+++ b/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: thebubbsy.Marksmith
+PackageVersion: 3.1.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/thebubbsy/marksmith/releases/download/v3.1.0/Marksmith-Setup-x64.exe
+  InstallerSha256: 6acd063aca5dd512c22fb0b601668d3beca48f172c37d34ab11052f7eb9e0d2e
+- Architecture: arm64
+  InstallerUrl: https://github.com/thebubbsy/marksmith/releases/download/v3.1.0/Marksmith-Setup-arm64.exe
+  InstallerSha256: 31b79a6003becdb8cdfcd825538a7b29491d746d09d7457a8331f4a88758937b
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.locale.en-US.yaml
+++ b/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: thebubbsy.Marksmith
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: thebubbsy
+PublisherUrl: https://github.com/thebubbsy
+PublisherSupportUrl: https://github.com/thebubbsy/marksmith/issues
+PackageName: Marksmith
+PackageUrl: https://github.com/thebubbsy/marksmith
+License: MIT
+LicenseUrl: https://github.com/thebubbsy/marksmith/blob/main/LICENSE
+Copyright: Copyright (c) thebubbsy
+ShortDescription: Turn AI chats into polished PDF and DOCX documents.
+Description: Marksmith is a native WinUI 3 desktop app that turns Markdown — especially replies from ChatGPT, Gemini, and Claude — into professional PDF or DOCX documents. It detects the AI source, cleans up the formatting quirks each assistant leaves behind (LaTeX delimiters, citation pips, pseudo-headings), and renders the result with proper math, syntax highlighting, Mermaid diagrams, and your choice of theme. It also works as a plain live Markdown editor, watches folders and the clipboard for hands-free conversion, and exposes a local REST API plus a companion browser extension.
+Moniker: marksmith
+Tags:
+- markdown
+- pdf
+- docx
+- converter
+- editor
+- ai
+- chatgpt
+- documents
+- winui
+ReleaseNotes: See the GitHub release for the full changelog.
+ReleaseNotesUrl: https://github.com/thebubbsy/marksmith/releases/tag/v3.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.yaml
+++ b/manifests/t/thebubbsy/Marksmith/3.1.0/thebubbsy.Marksmith.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: thebubbsy.Marksmith
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
New package submission for Marksmith version 3.1.1 (native WinUI 3 desktop Markdown editor and document converter).

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with winget validate --manifest <path> ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Manifest conforms to the schema