### PR TITLE
New package: manuja-me.VulnRadar version 0.7.0

### DIFF
--- a/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.installer.yaml
+++ b/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: manuja-me.VulnRadar
+PackageVersion: 0.7.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/manuja-me/vuln-radar/releases/download/v0.7.0/VulnRadar_0.7.0_x64-setup.exe
+  InstallerSha256: B439F1F5453AC912E80354261801509A3B3A1603E96BA16DED96433C8B2184A1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.locale.en-US.yaml
+++ b/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: manuja-me.VulnRadar
+PackageVersion: 0.7.0
+PackageLocale: en-US
+Publisher: manuja-me
+PublisherUrl: https://github.com/manuja-me
+PublisherSupportUrl: https://github.com/manuja-me/vuln-radar/issues
+Author: manuja-me
+PackageName: VulnRadar
+PackageUrl: https://github.com/manuja-me/vuln-radar
+License: MIT
+LicenseUrl: https://github.com/manuja-me/vuln-radar/blob/main/LICENSE
+Copyright: Copyright (c) 2024-2026 manuja-me
+ShortDescription: Web Vulnerability & Security Scanner desktop application
+Description: VulnRadar is a native desktop cybersecurity workstation for web vulnerability scanning, security posture auditing, and DevSecOps compliance.
+Moniker: vulnradar
+Tags:
+- security
+- vulnerability-scanner
+- cybersecurity
+- devsecops
+- scanner
+- tauri
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.yaml
+++ b/manifests/m/manuja-me/VulnRadar/0.7.0/manuja-me.VulnRadar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: manuja-me.VulnRadar
+PackageVersion: 0.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description
Adds the initial package manifest for **VulnRadar** (`manuja-me.VulnRadar`) version **0.7.0**.

VulnRadar is an open-source native desktop cybersecurity workstation built with Tauri, designed for web vulnerability scanning, DevSecOps audits, and security posture evaluation.

- **Package Identifier**: `manuja-me.VulnRadar`
- **Package Version**: `0.7.0`
- **Publisher**: `manuja-me`
- **CLI Moniker**: `vulnradar`
- **License**: MIT
- **Release Assets**: https://github.com/manuja-me/vuln-radar/releases/tag/v0.7.0

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the schema

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429182)