### PR TITLE
Update version: OpenJS.Electron.43 version 43.6.0

### DIFF
--- a/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.installer.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.6.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.6.0/electron-v43.6.0-win32-ia32.zip
+  InstallerSha256: D2CE6996992B18DC2E3A4B3A24FC663E0010B9BD23EC3CA02221D3E7BF288711
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.6.0/electron-v43.6.0-win32-x64.zip
+  InstallerSha256: 4140545D6ED47B59C35900F266DEA6C02F4A5496069ECE7F6E7BC825E0D959C2
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v43.6.0/electron-v43.6.0-win32-arm64.zip
+  InstallerSha256: 7B8749FEE290EAA5319918142686DD147F2ADEB9E680AF092BAC02E2B2BC8A1D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.6.0
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: "# Release Notes for v43.6.0\n\n## Features\n\n• Added a `badge` property to `MenuItem` on macOS 14+ for showing a count or custom text badge next to a menu item's label. [#53045](https://github.com/electron/electron/pull/53045) <sup>(Also in [44](https://github.com/electron/electron/pull/53046))</sup>\n• Added webContents.caretBrowsingEnabled for toggling caret browsing in a WebContents. [#53034](https://github.com/electron/electron/pull/53034) <sup>(Also in [44](https://github.com/electron/electron/pull/53035))</sup>\n## Fixes\n\n• Fixed VoiceOver Braille displays showing the wrong line in multi-line text fields on macOS：`AXLineForIndex` and `AXRangeForLine` now return the line containing the caret. [#53428](https://github.com/electron/electron/pull/53428) \n• Fixed a pending read on a `net.request` chunked upload stream inside a protocol handler never settling when the request failed or was aborted. [#53374](https://github.com/electron/electron/pull/53374) <sup>(Also in [44](https://github.com/electron/electron/pull/53373), [45](https://github.com/electron/electron/pull/53368))</sup>\n• Fixed a potential crash when using `menu.popup` with a frame from an offscreen rendered window. [#53432](https://github.com/electron/electron/pull/53432) <sup>(Also in [44](https://github.com/electron/electron/pull/53362))</sup>\n• Fixed an intermittent crash (access violation) on Windows when an ASAR integrity violation is detected, so the process now exits with code 1 as intended. [#53456](https://github.com/electron/electron/pull/53456) <sup>(Also in [44](https://github.com/electron/electron/pull/53455), [45](https://github.com/electron/electron/pull/53438))</sup>\n• Fixed application crash after a large number of IPC messages from renderers. [#53420](https://github.com/electron/electron/pull/53420) <sup>(Also in [42](https://github.com/electron/electron/pull/53419), [44](https://github.com/electron/electron/pull/53417), [45](https://github.com/electron/electron/pull/53418))</sup>\n• Fixed native addons deriving from `node::ObjectWrap` aborting during garbage collection on Node.js 24.19.0 and later. [#53393](https://github.com/electron/electron/pull/53393) <sup>(Also in [42](https://github.com/electron/electron/pull/53394), [44](https://github.com/electron/electron/pull/53392), [45](https://github.com/electron/electron/pull/53391))</sup>\n## Other Changes\n\n• Backported fixes from upstream ANGLE, Chromium, Skia and V8. [#53485](https://github.com/electron/electron/pull/53485) \n• Backported fixes from upstream Chromium, Dawn and V8. [#53396](https://github.com/electron/electron/pull/53396) \n• Updated Node.js to v24.20.0. [#53249](https://github.com/electron/electron/pull/53249)"
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v43.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.yaml
+++ b/manifests/o/OpenJS/Electron/43/43.6.0/OpenJS.Electron.43.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.43
+PackageVersion: 43.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.43 to version 43.6.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429188)