### PR TITLE
New package: ZITAN.RELYR version 0.1.389

### DIFF
--- a/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.installer.yaml
+++ b/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ZITAN.RELYR
+PackageVersion: 0.1.389
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+FileExtensions:
+- relyr
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/zitan-source/RELYR/releases/download/v0.1.389/RELYR-Setup-0.1.389.exe
+  InstallerSha256: 41B7E2C6DEF0D796FCA9BA77772E8099A4C73538CD8761E6FE74845A21FDDB7F
+  ProductCode: '{68EDBC8F-BBC3-4AF7-97E5-7C32CC1A4065}_is1'
+  ElevationRequirement: elevatesSelf
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-04

--- a/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.locale.en-US.yaml
+++ b/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ZITAN.RELYR
+PackageVersion: 0.1.389
+PackageLocale: en-US
+Publisher: ZITAN
+PublisherUrl: https://github.com/zitan-source
+PublisherSupportUrl: https://github.com/zitan-source/RELYR/issues
+PrivacyUrl: https://zitan-source.github.io/RELYR/privacy.html
+Author: ZITAN
+PackageName: RELYR
+PackageUrl: https://zitan-source.github.io/RELYR/
+License: MIT
+LicenseUrl: https://github.com/zitan-source/RELYR/blob/main/LICENSE
+ShortDescription: Turn an ordinary Windows keyboard and mouse into programmable layers, macros, gestures, and an on-screen Deck.
+Description: |-
+  RELYR is a free and open-source input customization utility for Windows 10 and 11.
+  It lets you assign actions to keyboard and mouse layers, build macros and mouse gestures, and create configurable on-screen Deck panels without dedicated hardware or code.
+Moniker: relyr
+Tags:
+- automation
+- hotkey
+- keyboard
+- macro
+- mouse
+- productivity
+- remapping
+- shortcut
+Agreements:
+- AgreementLabel: RELYR Terms of Use
+  AgreementUrl: https://zitan-source.github.io/RELYR/terms.html
+- AgreementLabel: RELYR Privacy Information
+  AgreementUrl: https://zitan-source.github.io/RELYR/privacy.html
+ReleaseNotesUrl: https://github.com/zitan-source/RELYR/releases/tag/v0.1.389
+InstallationNotes: The current public beta is not code-signed, so Windows SmartScreen may show an unknown-publisher warning. Download and updates originate from the official RELYR GitHub Release.
+Documentations:
+- DocumentLabel: Getting Started
+  DocumentUrl: https://github.com/zitan-source/RELYR/blob/main/docs/getting-started.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.locale.ja-JP.yaml
+++ b/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.locale.ja-JP.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ZITAN.RELYR
+PackageVersion: 0.1.389
+PackageLocale: ja-JP
+Publisher: ZITAN
+PublisherUrl: https://github.com/zitan-source
+PublisherSupportUrl: https://github.com/zitan-source/RELYR/issues
+PrivacyUrl: https://zitan-source.github.io/RELYR/privacy.html
+Author: ZITAN
+PackageName: RELYR
+PackageUrl: https://zitan-source.github.io/RELYR/
+License: MIT
+LicenseUrl: https://github.com/zitan-source/RELYR/blob/main/LICENSE
+ShortDescription: 普段のWindowsキーボードとマウスを、レイヤー、マクロ、ジェスチャー、画面上のDeckとして活用できます。
+Description: |-
+  RELYRはWindows 10/11向けの無料オープンソース入力カスタマイズツールです。
+  専用ハードウェアやコードを必要とせず、キーボードとマウスのレイヤーへのAction割り当て、マクロ、マウスジェスチャー、画面上のDeckパネルを設定できます。
+Tags:
+- キーボード
+- ショートカット
+- マウス
+- マクロ
+- 自動化
+Agreements:
+- AgreementLabel: RELYR利用条件
+  AgreementUrl: https://zitan-source.github.io/RELYR/terms.html
+- AgreementLabel: RELYRプライバシー情報
+  AgreementUrl: https://zitan-source.github.io/RELYR/privacy.html
+ReleaseNotesUrl: https://github.com/zitan-source/RELYR/releases/tag/v0.1.389
+InstallationNotes: 現在の公開ベータ版はコード署名前のため、Windows SmartScreenが不明な発行元として警告する場合があります。ダウンロードと更新はRELYR公式GitHub Releaseから行われます。
+Documentations:
+- DocumentLabel: 使い始める
+  DocumentUrl: https://github.com/zitan-source/RELYR/blob/main/docs/getting-started.ja.md
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.yaml
+++ b/manifests/z/ZITAN/RELYR/0.1.389/ZITAN.RELYR.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ZITAN.RELYR
+PackageVersion: 0.1.389
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package submission for RELYR 0.1.389.\n\n- Official versioned installer from the RELYR GitHub Release\n- Windows x64 machine-scope Inno Setup installer\n- English default locale and Japanese locale\n- Package agreement links for Terms of Use and privacy information\n- Local validation passed with winget validate
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429317)