### PR TITLE
New package: Monoglyph.MidiSlayer version 0.7.3

### DIFF
--- a/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.installer.yaml
+++ b/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: Monoglyph.MidiSlayer
+PackageVersion: 0.7.3
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.midislayer.com/v0.7.3/MidiSlayer_0.7.3_x64_en-US.msi
+  InstallerSha256: 0EF29FA8E4B77EF6D548CEEA6555809AF41BEF49DC3367E48B45D09ECE699BB5
+  ProductCode: '{87190684-414A-444A-B095-6F6BDA492224}'
+  AppsAndFeaturesEntries:
+  - DisplayName: MidiSlayer
+    Publisher: co
+    DisplayVersion: 0.7.3
+    ProductCode: '{87190684-414A-444A-B095-6F6BDA492224}'
+    UpgradeCode: '{0762ED9D-0BC1-56E8-8B76-54AC80FA1945}'
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.locale.en-US.yaml
+++ b/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: Monoglyph.MidiSlayer
+PackageVersion: 0.7.3
+PackageLocale: en-US
+Publisher: Monoglyph Ltd
+PublisherUrl: https://monoglyph.co.uk
+PublisherSupportUrl: https://midislayer.com/contact
+PrivacyUrl: https://midislayer.com/privacy
+Author: Monoglyph Ltd
+PackageName: MidiSlayer
+PackageUrl: https://midislayer.com
+License: Proprietary
+LicenseUrl: https://midislayer.com/terms
+Copyright: Copyright 2026 Monoglyph Ltd
+ShortDescription: Sight-reading and music-theory practice for MIDI keyboards. Buy once, keep it.
+Description: |-
+  MidiSlayer is a desktop trainer for people who practise on a MIDI keyboard and want to read real notation. Plug in the keyboard, pick a mode, play what is on the staff, and every note is marked right or wrong the moment it arrives.
+  Nine training modes (note flashcards, graded reading keyed to exam grades from Initial to Grade 8, intervals, chords, arpeggios, scale patterns, key signatures, a circle-of-fifths compass and chord progressions), a practice library of 69 public-domain scores plus your own MusicXML, three arcade games with a daily challenge, and a seven-lesson reading course.
+  The free tier is unlimited in time. MidiSlayer Pro is a one-time purchase, no subscription, activated on two machines. Practice data stays on the PC; the app works offline after activation.
+Moniker: midislayer
+Tags:
+- midi
+- music
+- music-theory
+- notation
+- piano
+- sheet-music
+- sight-reading
+ReleaseNotesUrl: https://midislayer.com/download
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.yaml
+++ b/manifests/m/Monoglyph/MidiSlayer/0.7.3/Monoglyph.MidiSlayer.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: Monoglyph.MidiSlayer
+PackageVersion: 0.7.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
New package: MidiSlayer 0.7.3 by Monoglyph Ltd. Desktop sight-reading and music-theory trainer for MIDI keyboards (freemium, one-time purchase for Pro). Publisher's own release location, signed MSI (Azure Trusted Signing, CN=Monoglyph Ltd), versioned URL, no redirect.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? (authored on macOS; validated field by field against the 1.9.0 schema, relying on the pipeline for `winget validate`)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (the MSI installs silently with `msiexec /quiet`; not run through winget locally, see above)
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note for moderators: the AppsAndFeaturesEntries Publisher is "co" because that is what this MSI currently registers (Tauri derives it from the bundle identifier); the developer has set the publisher name for the next release, after which the entry will read Monoglyph Ltd.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429349)