### PR TITLE
New package: Issinoho.Loadbearer version 1.2.1

### DIFF
--- a/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.installer.yaml
+++ b/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+# loadbearer ships as a portable exe inside a versioned .zip release asset, so
+# winget extracts the archive and registers `loadbearer.exe` as a portable
+# command on PATH (alias `loadbearer`). RelativeFilePath must match the folder
+# name inside the zip exactly — the release workflow packages under
+# `loadbearer-<version>-<target>/`.
+
+PackageIdentifier: Issinoho.Loadbearer
+PackageVersion: 1.2.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: loadbearer-1.2.1-x86_64-pc-windows-msvc\loadbearer.exe
+    PortableCommandAlias: loadbearer
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: "2026-09-04"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/issinoho/loadbearer/releases/download/v1.2.1/loadbearer-1.2.1-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 83B44F45F462654E0ABC77FB996A904371FC242ECDB19586CF1F803E74C40FB1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.locale.en-US.yaml
+++ b/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Issinoho.Loadbearer
+PackageVersion: 1.2.1
+PackageLocale: en-US
+Publisher: Iain Smith
+PublisherUrl: https://github.com/issinoho
+PublisherSupportUrl: https://github.com/issinoho/loadbearer/issues
+Author: Iain Smith
+PackageName: loadbearer
+PackageUrl: https://github.com/issinoho/loadbearer
+License: MIT
+LicenseUrl: https://github.com/issinoho/loadbearer/blob/main/LICENSE
+Copyright: Copyright (c) Iain Smith
+CopyrightUrl: https://github.com/issinoho/loadbearer/blob/main/LICENSE
+ShortDescription: CLI system-assessment tool that benchmarks CPU, memory, disk, network and GPU and grades the machine on an S-F scale.
+Description: |-
+  loadbearer benchmarks a machine's CPU, memory, disk and network stack - and its
+  GPU where there is one - scores every measurement against a shared reference
+  baseline, and grades each component and the whole machine on an S-to-F scale.
+  compare mode reads two result files and reports which machine wins, by how much,
+  and why. A sustained-load test shows how much speed a machine keeps once it
+  throttles. Single self-contained binary, no runtime, no network calls.
+Moniker: loadbearer
+Tags:
+  - benchmark
+  - cli
+  - cpu
+  - disk
+  - gpu
+  - hardware
+  - memory
+  - performance
+  - system-information
+ReleaseNotesUrl: https://github.com/issinoho/loadbearer/releases/tag/v1.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.yaml
+++ b/manifests/i/Issinoho/Loadbearer/1.2.1/Issinoho.Loadbearer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Issinoho.Loadbearer
+PackageVersion: 1.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `Issinoho.Loadbearer` version `1.2.1`

A CLI system-assessment / benchmark tool (Rust): benchmarks CPU, memory, disk,
network and GPU, scores each metric against an embedded baseline, and grades the
machine on an S–F scale. Portable single executable, shipped in a versioned
`.zip` GitHub release asset.

- Upstream: https://github.com/issinoho/loadbearer
- Release: https://github.com/issinoho/loadbearer/releases/tag/v1.2.1
- License: MIT

#### Manifest

- [x] Validates against the winget v1.6.0 schemas (installer / defaultLocale / version).
- [x] `InstallerSha256` matches the release `SHA256SUMS`.
- [x] Nested portable install: `NestedInstallerType: portable`, `RelativeFilePath`
      checked against the archive (`loadbearer-1.2.1-x86_64-pc-windows-msvc\loadbearer.exe`),
      `PortableCommandAlias: loadbearer`.
- [ ] Not run through `winget install --manifest` locally (no Windows host in the
      submitter's setup) — relying on the automated sandbox validation.

#### Notes

- x64 only; there is no arm64 Windows build.
- The executable is currently unsigned. A portable-zip install only extracts the
  archive, so it should pass sandbox validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429367)