### PR TITLE
New package: Share2Us.CLI version 20260904112641

### DIFF
--- a/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.installer.yaml
+++ b/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Share2Us.CLI
+PackageVersion: "20260904112641"
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+Commands:
+  - s2u
+  - share2us
+NestedInstallerFiles:
+  - RelativeFilePath: share2us.exe
+    PortableCommandAlias: s2u
+  - RelativeFilePath: share2us.exe
+    PortableCommandAlias: share2us
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/share2us/cli/releases/download/v20260904112641/share2us_windows_amd64.zip
+    InstallerSha256: BAE58587135CBAC73BDC2A60CF92A255452A7AC9FB5417BC3B8E12CC524813DF
+  - Architecture: arm64
+    InstallerUrl: https://github.com/share2us/cli/releases/download/v20260904112641/share2us_windows_arm64.zip
+    InstallerSha256: FB9DB123F598FAC7DE99230034E4E718C8FD0D9840E41E3F6163BF9165091852
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.installer.yaml
+++ b/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.installer.yaml
@@ -8,10 +8,10 @@ Commands:
   - s2u
   - share2us
 NestedInstallerFiles:
+  # One entry per file (winget rejects a duplicate RelativeFilePath). The created
+  # command shim is s2u (the primary); "share2us" stays in Commands for search.
   - RelativeFilePath: share2us.exe
     PortableCommandAlias: s2u
-  - RelativeFilePath: share2us.exe
-    PortableCommandAlias: share2us
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/share2us/cli/releases/download/v20260904112641/share2us_windows_amd64.zip

--- a/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.locale.en-US.yaml
+++ b/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherSupportUrl: https://github.com/share2us/cli/issues
 PackageName: Share2Us CLI
 PackageUrl: https://share2.us
 License: MIT
-LicenseUrl: https://github.com/share2us/cli/blob/main/LICENSE
+LicenseUrl: https://github.com/share2us/cli/blob/main/LICENSE.md
 ShortDescription: Share files and folders by link, to your devices, or directly over the local network.
 Description: |-
   The Share2Us command line (s2u): share files and folders by link, send them to

--- a/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.locale.en-US.yaml
+++ b/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Share2Us.CLI
+PackageVersion: "20260904112641"
+PackageLocale: en-US
+Publisher: Share2Us
+PublisherUrl: https://share2.us
+PublisherSupportUrl: https://github.com/share2us/cli/issues
+PackageName: Share2Us CLI
+PackageUrl: https://share2.us
+License: MIT
+LicenseUrl: https://github.com/share2us/cli/blob/main/LICENSE
+ShortDescription: Share files and folders by link, to your devices, or directly over the local network.
+Description: |-
+  The Share2Us command line (s2u): share files and folders by link, send them to
+  your other devices or contacts end-to-end encrypted, or transfer directly over
+  the local network. Installs the s2u and share2us commands.
+Tags:
+  - file-sharing
+  - cli
+  - p2p
+  - encryption
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.yaml
+++ b/manifests/s/Share2Us/CLI/20260904112641/Share2Us.CLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Share2Us.CLI
+PackageVersion: "20260904112641"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package

- **PackageIdentifier:** Share2Us.CLI
- **Version:** 20260904112641
- Portable install (zip, nested `share2us.exe`) exposing the `s2u` and `share2us` commands, x64 + arm64.
- Installer URLs are the project's GitHub release assets; SHA256 from the release `.sha256` sidecars.

Checklist:
- [x] Manifest schema 1.6.0, three files (version, installer, defaultLocale)
- [x] Installer URLs are publicly downloadable
- [x] Have verified the SHA256 matches the published asset
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429374)