### PR TITLE
Update: rullerzhou-afk.clawd-on-desk to 1.0.0

### DIFF
--- a/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.installer.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.installer.yaml
@@ -1,0 +1,42 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: rullerzhou-afk.clawd-on-desk
+PackageVersion: 1.0.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallerSwitches:
+  Upgrade: --updated
+UpgradeBehavior: install
+ProductCode: 3e932233-a8b2-5530-b285-e0ceb08488f2
+ReleaseDate: 2026-09-04
+AppsAndFeaturesEntries:
+- DisplayName: Clawd on Desk 1.0.0
+  ProductCode: 3e932233-a8b2-5530-b285-e0ceb08488f2
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v1.0.0/Clawd-on-Desk-Setup-1.0.0-x64.exe
+  InstallerSha256: 9A7AD8B6F08C849A6483F93EF0023A2FAC43A21D164406C99AD972207241A507
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v1.0.0/Clawd-on-Desk-Setup-1.0.0-x64.exe
+  InstallerSha256: 9A7AD8B6F08C849A6483F93EF0023A2FAC43A21D164406C99AD972207241A507
+  InstallerSwitches:
+    Custom: /allusers
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v1.0.0/Clawd-on-Desk-Setup-1.0.0-arm64.exe
+  InstallerSha256: 7C600D2B78AAAD3BF8CEEA29D293ADEA6F91159175AE1F27C6B7E9AA90DAF930
+  InstallerSwitches:
+    Custom: /currentuser
+- Architecture: arm64
+  Scope: machine
+  InstallerUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v1.0.0/Clawd-on-Desk-Setup-1.0.0-arm64.exe
+  InstallerSha256: 7C600D2B78AAAD3BF8CEEA29D293ADEA6F91159175AE1F27C6B7E9AA90DAF930
+  InstallerSwitches:
+    Custom: /allusers
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.locale.en-US.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.locale.en-US.yaml
@@ -1,0 +1,134 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: rullerzhou-afk.clawd-on-desk
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: rullerzhou-afk
+PublisherUrl: https://github.com/rullerzhou-afk
+PublisherSupportUrl: https://github.com/rullerzhou-afk/clawd-on-desk/issues
+PackageName: Clawd on Desk
+PackageUrl: https://github.com/rullerzhou-afk/clawd-on-desk
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/rullerzhou-afk/clawd-on-desk/blob/v1.0.0/LICENSE
+Copyright: Copyright (c) 2026 rullerzhou-afk
+ShortDescription: A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents — so you don't have to.
+Description: |-
+  Clawd on Desk is an open-source desktop pet that shows the activity of AI coding agents, including Claude Code, Codex, Cursor, and others. It reacts to working, permission requests, and task completion with animations and supports multiple concurrent sessions.
+
+  It includes Clawd, Calico, and Cloudling themes, custom themes, a sessions dashboard, optional permission bubbles, and a local activity recap.
+Tags:
+  - claude-code
+  - codebuddy
+  - codex
+  - copilot-cli
+  - cursor
+  - desktop-pet
+  - gemini-cli
+  - kiro
+  - opencode
+ReleaseNotes: |-
+  v1.0.0
+  Clawd v1.0.0 adds local activity Footprints, expandable permission cards and an
+  overflow queue, signed macOS in-app updates, and Windows fullscreen auto-hide.
+  It also improves Codex session recovery, Claude background completion, agent
+  installation detection, and Settings navigation.
+  Local Activity Footprints
+  - Private activity history (#963) — Settings → Footprints shows Today,
+    This week, This month, and This year. It counts accepted agent signals and
+    distinguishes recorded quiet periods from periods Clawd could not observe.
+    Unsupported metrics remain a dash, never an invented zero.
+  - Local storage only — recording is on by default, with 14 local days of
+    minimized event tickets and 400 local days of daily totals and coverage.
+    Footprints does not store prompts, responses, commands, paths, project names,
+    or raw session/turn/tool identifiers, and adds no network, export, or sharing.
+  - Recording controls — turn off Record footprints to pause, or Clear
+    footprint data to remove the managed history. Delayed completion counts cannot
+    cross a clear or off/on boundary. Normal completion feedback still works.
+    When preference recovery pauses recording, the page explains that state.
+  - Clock changes — historical local hours stay visible after timezone changes,
+    including coverage without activity; daylight-saving gaps and folds retain
+    their distinct meaning.
+  Permission Cards And Desktop
+  - Expandable details and overflow queue (#937, #944, #949, #950, #953) —
+    inspect longer requests, plans, and questions while preserving input drafts.
+    Answerable questions open in detail when space allows. The queue navigates
+    requests without making decisions. Global Allow/Deny shortcuts refuse an
+    overflow target that is clipped or obscured by the session HUD, including
+    queue loading and failure fallback.
+  - Independent bubble placement (#918, #934) — permission and update bubbles
+    can follow Clawd automatically or on a preferred side, or stay at one of four
+    primary-display corners, while avoiding other floating surfaces.
+  - Windows fullscreen auto-hide (#973) — optionally hides Clawd and floating
+    surfaces during fullscreen use, including newly arriving local permission
+    cards. Leaving fullscreen restores only requests still pending. Remote
+    approval and configured auto-close keep their existing behavior.
+  - Desktop reliability (#928, #955, #957) — improves permission cleanup,
+    macOS theme-specific Dock/menu-bar icons, and animation/geometry settlement.
+  - Settings polish (#923, #925, #926, #929, #930, #931, #932) — improves
+    language picking, collapsible sections, focus rings, idle visual selection,
+    and permission automation controls.
+  Agents And Sessions
+  - TraeCode / Trae CN (#886) — experimental state-only hooks, including
+    Windows Sandbox command handling. Enable hooks in Trae CN's own Settings;
+    approvals remain in Trae. Migration preserves unrelated nested hook entries.
+  - DeepSeek Harness (#938, #962) — supports exact rc.2 and rc.6 version
+    contracts, safer lifecycle cleanup, and POSIX GUI-launch discovery. Real
+    API-backed session approval was verified with rc.6 source runs on macOS and
+    Windows x64; rc.2 Windows packaged evidence covers install/web boot and direct
+    bridge-client round trips. These are separate validation levels. See the
+    DSH guide for the experimental scope.
+  - Codex (#954, #959, #960) — restores scoped-session focus, adds an opt-in
+    cold-start switch, and separates active-turn timeout from idle cleanup.
+    Upgrades retain a longer effective legacy timeout when the Codex-specific
+    preference is absent. Delayed question/output records cannot revive a closed
+    turn or extend another turn's lifetime.
+  - Windows Codex hook reliability (#986, #987) — avoids Windows Defender
+    false positives caused by the retired PowerShell launcher, while retaining
+    managed-hook validation and migration. Thanks to @eugenewang5425.
+  - Claude completion and installation detection (#958, #961) — improves
+    background subagent completion and avoids mistaking leftover directories for
+    installed agents.
+  Upgrade Notes
+  - macOS: install v1.0.0 manually once. v0.16.0 and older packaged apps
+    cannot install this update themselves. Download the DMG containing the signed and notarized app, quit Clawd,
+    and replace the application while keeping its data. Starting with this bridge
+    version, later signed releases can use in-app download and Restart Now, or
+    Later followed by quit/reopen (#922). Linux packages still update manually.
+  - Footprints starts recording by default after upgrade. Use Settings → Footprints
+    to turn it off or clear its history. See the Footprints guide
+    for retention, metric coverage, and recovery behavior.
+  - If bubble following was previously disabled, fixed placement now uses the
+    selected corner of the primary display rather than the display containing Clawd.
+  - Launch once after upgrading so installed and enabled integrations reconcile
+    their packaged hooks/plugins. Disabled integrations are not reinstalled.
+  Contributors
+  Thanks to first-time contributors @eugenewang5425 (DeepSeek Harness rc.2, #938),
+  @draintovmasyan783-creator (Codex scoped focus, #954), and @Yueh-H (macOS Control
+  modifier, #946), and returning contributors @anthonyonazure, @KaiC5504,
+  @YOIMIYA66, and @xiaoshidefeng. Existing contributor credit and original
+  authorship are retained.
+  Known Limitations
+  - DeepSeek Harness stale approval bubbles (#988): a cancelled or disposed
+    DSH approval may leave its Clawd bubble visible until timeout. The proposed
+    lifecycle fix in #989 is not included in this build.
+  - Some macOS interaction checks remain unverified, including cross-Space focus,
+    IME/approval shortcuts, Dock-edge combinations, fresh-profile onboarding, and
+    sleep/wake. Linux and WSL real-device acceptance is not claimed.
+  Validation Status
+  Local source validation on September 3, 2026 completed with 9,295 passed,
+  0 failed, and 42 skipped tests. The release contract and asset audit passed;
+  the existing tracked-tree size warning remains. An isolated macOS Electron
+  check confirmed that clipped permission buttons cannot be decided by hotkey.
+  Release packages are built from commit 5ca26b5cfdf1c516b8dde649eb35c333841a5f65.
+  Windows real-device acceptance was completed by the maintainer. macOS testing
+  covered Developer ID signing and notarization of the app, a manual upgrade from
+  v0.16.0 with settings retained, and both signed update installation paths.
+  The release reuses the original artifacts from successful multi-platform
+  Build & Release run 33832532197.
+  Downloaded artifact digests and updater metadata were verified before upload.
+  App signature and notarization checks passed; the DMG container itself is not
+  separately signed. The validation gaps above remain unverified, not passed.
+ReleaseNotesUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.locale.zh-CN.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.locale.zh-CN.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: rullerzhou-afk.clawd-on-desk
+PackageVersion: 1.0.0
+PackageLocale: zh-CN
+ShortDescription: 一款像素桌宠，替你监视 Claude Code、Codex、Cursor 及其他 AI 编程助手。
+Description: |-
+  Clawd on Desk 是一款开源桌宠，通过动画显示 Claude Code、Codex、Cursor 等 AI 编程助手的工作、权限请求和任务完成状态，支持同时跟踪多个会话。
+
+  内置 Clawd、Calico、Cloudling 三套主题，支持自定义主题、会话面板、可选权限气泡和本地活动小结。
+Tags:
+  - claude-code
+  - codebuddy
+  - codex
+  - copilot-cli
+  - cursor
+  - gemini-cli
+  - kiro
+  - opencode
+  - 桌宠
+ManifestType: locale
+ManifestVersion: 1.12.0
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/rullerzhou-afk/clawd-on-desk/blob/v1.0.0/LICENSE
+ReleaseNotesUrl: https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v1.0.0

--- a/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.yaml
+++ b/manifests/r/rullerzhou-afk/clawd-on-desk/1.0.0/rullerzhou-afk.clawd-on-desk.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: rullerzhou-afk.clawd-on-desk
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Update `rullerzhou-afk.clawd-on-desk` to **1.0.0** from the published [v1.0.0 release](https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v1.0.0).

Preserves all four existing installer combinations: x64 and arm64, each with user and machine scope. Installer URLs and SHA256 values match the published release files. Retains the NSIS ProductCode, `/currentuser` and `/allusers` switches, and `--updated` upgrade switch.

Based on the [successful prepare run 33855364140](https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/33855364140), artifact `winget-generated-manifest` (9929949802). The generated locale files were normalized to `AGPL-3.0-only`, version-pinned license/release links, and current concise descriptions.

## ✅ Checklist
- [ ] Signed the Contributor License Agreement (Microsoft CLA bot to verify the existing contributor account)
- Linked issue: not applicable; this is a new version submission.

## 📦 Manifest Checklist
- [x] Checked that there are no other open pull requests for the same package version
- [x] This PR only modifies one package version (`1.0.0`)
- [ ] Validated locally with `winget validate --manifest <path>`
- [ ] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 JSON schemas

Validation performed on macOS: parsed all four YAML files against Microsoft's 1.12.0 JSON schemas; checked the exact architecture/scope matrix, URLs, switches, ProductCode, locale metadata, and actual installer SHA256 values against the release. Native WinGet validate/install commands have not been run on this host; upstream Windows validation remains required.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429437)