### PR TITLE
New package: Issinoho.tvdinner version 1.42.1

### DIFF
--- a/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.installer.yaml
+++ b/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Issinoho.tvdinner
+PackageVersion: 1.42.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: '2026-09-04'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/issinoho/tvdinner/releases/download/v1.42.1/tvdinner-setup-1.42.1.exe
+  InstallerSha256: 46A3392EAB61F404A7EB5FA225E17C5B47CF7C04ADAF4A84A4F097AB20595C00
+  ProductCode: '{7B591A96-E431-4BB4-B509-3EAFD9CFA81F}_is1'
+  AppsAndFeaturesEntries:
+  - DisplayName: tvdinner
+    Publisher: Iain Smith
+    DisplayVersion: 1.42.1
+    ProductCode: '{7B591A96-E431-4BB4-B509-3EAFD9CFA81F}_is1'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.locale.en-US.yaml
+++ b/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Issinoho.tvdinner
+PackageVersion: 1.42.1
+PackageLocale: en-US
+Publisher: Iain Smith
+PublisherUrl: https://github.com/issinoho
+PublisherSupportUrl: https://github.com/issinoho/tvdinner/issues
+PackageName: tvdinner
+PackageUrl: https://github.com/issinoho/tvdinner
+License: MIT
+LicenseUrl: https://github.com/issinoho/tvdinner/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Iain Smith
+CopyrightUrl: https://github.com/issinoho/tvdinner/blob/master/LICENSE
+ShortDescription: A command-line IPTV player with a TiviMate-style on-screen programme guide.
+Description: |-
+  A command-line IPTV and media player built on mpv, with a TiviMate-style on-screen
+  program guide, timezone-aware EPG from XMLTV, per-channel clock-correction shifts,
+  recording and scheduled recording, and on-demand browsing for Plex, local files and
+  YouTube. Plays M3U/M3U8 playlists, Xtream Codes panels, Stalker portals, HDHomeRun
+  tuners, and tvtimes accounts. The installer bundles its own mpv, so nothing else is
+  needed.
+Moniker: tvdinner
+Tags:
+- epg
+- hdhomerun
+- iptv
+- m3u
+- media-player
+- mpv
+- playlist
+- tv
+- xmltv
+- xtream
+ReleaseNotesUrl: https://github.com/issinoho/tvdinner/releases/tag/v1.42.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/issinoho/tvdinner/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.yaml
+++ b/manifests/i/Issinoho/tvdinner/1.42.1/Issinoho.tvdinner.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Issinoho.tvdinner
+PackageVersion: 1.42.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `Issinoho.tvdinner` version 1.42.1

A command-line IPTV and media player built on mpv, with a TiviMate-style on-screen programme guide, timezone-aware EPG from XMLTV, recording and scheduled recording. Open source (MIT).

- Repository: https://github.com/issinoho/tvdinner
- Release: https://github.com/issinoho/tvdinner/releases/tag/v1.42.1

#### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — no Windows machine available. Validated against the official 1.12.0 JSON schemas instead (see below).
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — same reason.
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

#### Notes for reviewers

- **Validated against the 1.12.0 JSON schemas** for all three manifest types. The `InstallerUrl` returns 200 and the `InstallerSha256` was computed from that published asset.
- **The installer is not code signed.** The project has a [code signing policy](https://github.com/issinoho/tvdinner/blob/master/CODE_SIGNING_POLICY.md) and CI wiring for SignPath Foundation signing, but the application hasn't completed, so releases currently ship unsigned. Flagging it rather than have validation surface it.
- **It is a PyInstaller bundle**, which antivirus heuristics sometimes flag. If `Validation-Defender-Error` fires, I'm happy to help chase a false-positive report.
- `ProductCode` is the Inno Setup `AppId` with the `_is1` suffix, taken from [`windows/tvdinner.iss`](https://github.com/issinoho/tvdinner/blob/master/windows/tvdinner.iss). The `AppId` is fixed and won't change between versions.
- Installs machine-scope to Program Files (`DefaultDirName={autopf}`), x64 only.
