### PR TITLE
New package: t4t5.caldir version 0.13.0

### DIFF
--- a/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.installer.yaml
+++ b/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: t4t5.caldir
+PackageVersion: 0.13.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: caldir.exe
+    PortableCommandAlias: caldir
+  - RelativeFilePath: caldir-provider-google.exe
+    PortableCommandAlias: caldir-provider-google
+  - RelativeFilePath: caldir-provider-icloud.exe
+    PortableCommandAlias: caldir-provider-icloud
+  - RelativeFilePath: caldir-provider-caldav.exe
+    PortableCommandAlias: caldir-provider-caldav
+  - RelativeFilePath: caldir-provider-outlook.exe
+    PortableCommandAlias: caldir-provider-outlook
+  - RelativeFilePath: caldir-provider-webcal.exe
+    PortableCommandAlias: caldir-provider-webcal
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/t4t5/caldir/releases/download/v0.13.0/caldir-x86_64-pc-windows-msvc.zip
+    InstallerSha256: EF05AD4F6D77734DB40A5F259D19E687D8DAB9707E435F0FA91BEAD2B128CC57
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.locale.en-US.yaml
+++ b/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: t4t5.caldir
+PackageVersion: 0.13.0
+PackageLocale: en-US
+Publisher: t4t5
+PublisherUrl: https://github.com/t4t5
+PublisherSupportUrl: https://github.com/t4t5/caldir/issues
+PackageName: caldir
+PackageUrl: https://caldir.org
+License: MIT
+LicenseUrl: https://github.com/t4t5/caldir/blob/main/LICENSE
+ShortDescription: Store your calendar as a directory of ICS files and sync it with Google Calendar, iCloud, Outlook, CalDAV and webcal feeds.
+Moniker: caldir
+Tags:
+  - calendar
+  - caldav
+  - cli
+  - ics
+  - sync
+ReleaseNotesUrl: https://github.com/t4t5/caldir/releases/tag/v0.13.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.yaml
+++ b/manifests/t/t4t5/caldir/0.13.0/t4t5.caldir.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: t4t5.caldir
+PackageVersion: 0.13.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **t4t5.caldir** version **0.13.0**.

caldir (https://caldir.org, MIT) is a CLI that stores your calendar as a directory of plain `.ics` files and syncs it with Outlook, Google Calendar, iCloud, CalDAV servers and webcal feeds.

The installer is a portable zip containing six binaries: the `caldir` CLI plus five `caldir-provider-*` plugins. The CLI discovers providers by scanning `PATH` for `caldir-provider-*.exe`, so each binary is listed in `NestedInstallerFiles` with its own `PortableCommandAlias`.

Validated with `winget validate` and test-installed with `winget install --manifest` on Windows 11 (winget 1.12); all six aliases were created and `caldir` commands worked.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429456)