### PR TITLE
Update version: OpenTelemetry.Weaver version 0.26.1

### DIFF
--- a/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.installer.yaml
+++ b/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenTelemetry.Weaver
+PackageVersion: 0.26.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: weaver.exe
+  PortableCommandAlias: weaver
+ReleaseDate: 2026-09-03
+AppsAndFeaturesEntries:
+- DisplayName: Weaver (Portable)
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-pc-windows-msvc.zip
+  InstallerSha256: BE49D09FE34311D34A55C879D7A5050FC082FF25CD1D18DA799DDD2EC2E21764
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.locale.en-US.yaml
+++ b/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.locale.en-US.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenTelemetry.Weaver
+PackageVersion: 0.26.1
+PackageLocale: en-US
+Publisher: OpenTelemetry
+PublisherUrl: https://github.com/open-telemetry
+PublisherSupportUrl: https://github.com/open-telemetry/weaver/issues
+PackageName: Weaver
+PackageUrl: https://github.com/open-telemetry/weaver
+License: Apache-2.0
+LicenseUrl: https://github.com/open-telemetry/weaver/blob/HEAD/LICENSE
+ShortDescription: OTel Weaver lets you easily develop, validate, document, and deploy semantic conventions
+Tags:
+- codegen
+- documentation
+- observability
+- opentelemetry
+- policy
+- semconv
+ReleaseNotes: |-
+  ## Release Notes
+
+  • Fix `weaver-installer.sh` failing to detect Unix platforms due to missing bash shell in release workflow. ([#1744](https://github.com/open-telemetry/weaver/issues/1744))
+
+  ## Install weaver 0.26.1
+
+  ### Install prebuilt binaries via shell script
+
+  ```sh
+  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-installer.sh | sh
+  ```
+
+  ### Install prebuilt binaries via powershell script
+
+  ```sh
+  powershell -ExecutionPolicy Bypass -c "irm https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-installer.ps1 | iex"
+  ```
+
+  ## Download weaver 0.26.1
+
+  |  File  | Platform | Checksum |
+  |--------|----------|----------|
+  | [weaver-aarch64-apple-darwin.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-apple-darwin.tar.xz.sha256) |
+  | [weaver-x86_64-apple-darwin.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-apple-darwin.tar.xz.sha256) |
+  | [weaver-x86_64-pc-windows-msvc.zip](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-pc-windows-msvc.zip.sha256) |
+  | [weaver-x86_64-pc-windows-msvc.msi](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-pc-windows-msvc.msi) | x64 Windows | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-pc-windows-msvc.msi.sha256) |
+  | [weaver-aarch64-unknown-linux-gnu.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-unknown-linux-gnu.tar.xz.sha256) |
+  | [weaver-x86_64-unknown-linux-gnu.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-unknown-linux-gnu.tar.xz.sha256) |
+  | [weaver-aarch64-unknown-linux-musl.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-aarch64-unknown-linux-musl.tar.xz.sha256) |
+  | [weaver-x86_64-unknown-linux-musl.tar.xz](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/open-telemetry/weaver/releases/download/v0.26.1/weaver-x86_64-unknown-linux-musl.tar.xz.sha256) |
+
+  ## Verifying GitHub Artifact Attestations
+
+  The artifacts in this release have attestations generated with GitHub Artifact Attestations. These can be verified by using the [GitHub CLI](https://cli.github.com/manual/gh_attestation_verify):
+  ```sh
+  gh attestation verify <file-path of downloaded artifact> --repo open-telemetry/weaver
+  ```
+
+  You can also download the attestation from [GitHub](https://github.com/open-telemetry/weaver/attestations) and verify against that directly:
+  ```sh
+  gh attestation verify <file-path of downloaded artifact> --bundle <file-path of downloaded attestation>
+  ```
+ReleaseNotesUrl: https://github.com/open-telemetry/weaver/releases/tag/v0.26.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/open-telemetry/weaver/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.yaml
+++ b/manifests/o/OpenTelemetry/Weaver/0.26.1/OpenTelemetry.Weaver.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenTelemetry.Weaver
+PackageVersion: 0.26.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenTelemetry.Weaver to version 0.26.1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429459)