### PR TITLE
New package: anttiak.LoFeline version 1.0.0

### DIFF
--- a/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.installer.yaml
+++ b/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: anttiak.LoFeline
+PackageVersion: 1.0.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{8E5B2C41-7A3D-4F19-9C6E-1B2A4D8F0E37}_is1'
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/anttiak/lofeline-windows/releases/download/v1.0.0/LoFeline-1.0.0-setup.exe
+  InstallerSha256: 4C55E33B4B15150D9803DF9F8C897E7ABF9772AEDDEE2938C54066451ECF2FC9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.locale.en-US.yaml
+++ b/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: anttiak.LoFeline
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Antti Ala-Könni
+PublisherUrl: https://github.com/anttiak
+PublisherSupportUrl: https://github.com/anttiak/lofeline-windows/issues
+PackageName: LoFeline
+PackageUrl: https://github.com/anttiak/lofeline-windows
+License: MIT
+LicenseUrl: https://github.com/anttiak/lofeline-windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Antti Ala-Könni
+ShortDescription: A pixel cat that naps in the notification area and plays lofi radio.
+Description: |-
+  A pixel cat that naps in your Windows notification area. Click it for lofi beats, click again
+  for silence. Right click for the station list and a volume slider.
+Moniker: lofeline
+Tags:
+- lofi
+- music
+- radio
+- somafm
+- streaming
+- tray
+ReleaseNotesUrl: https://github.com/anttiak/lofeline-windows/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.yaml
+++ b/manifests/a/anttiak/LoFeline/1.0.0/anttiak.LoFeline.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: anttiak.LoFeline
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
A pixel cat that naps in the Windows notification area and plays lofi radio.

- Repository: https://github.com/anttiak/lofeline-windows
- Release: https://github.com/anttiak/lofeline-windows/releases/tag/v1.0.0
- Installer: Inno Setup, per-user scope, so silent switches are supplied automatically by the `inno` installer type.

### Checklist

- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.12 schema?

`winget install --manifest` completed successfully: the installer downloaded from the release URL, the hash verified, and the package installed silently without elevation. Uninstall removes the program directory, the Start Menu entry and the run-at-startup registry value the app writes for itself.

Other checks:

- The Add/Remove Programs entry reads `LoFeline` / `Antti Ala-Könni`, matching `PackageName` and `Publisher`.
- `ProductCode` was read from the registry after a real install rather than inferred from Inno's naming convention.
- `InstallerSha256` was taken from the published release asset, re-downloaded from the release URL and hashed.
