### PR TITLE
New package: ChenZibo.NewbeeOCRCLI version 0.2.3

### DIFF
--- a/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.installer.yaml
+++ b/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ChenZibo.NewbeeOCRCLI
+PackageVersion: 0.2.3
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  InstallLocation: APPLICATIONFOLDER="<INSTALLPATH>"
+UpgradeBehavior: install
+Commands:
+- nbocr
+ProductCode: '{61D634E6-CA9A-408A-82DB-CEB65274043A}'
+ReleaseDate: 2026-09-04
+AppsAndFeaturesEntries:
+- DisplayName: newbee_ocr_cli
+  Publisher: ChenZibo
+  DisplayVersion: 0.2.3
+  ProductCode: '{61D634E6-CA9A-408A-82DB-CEB65274043A}'
+  UpgradeCode: '{C95EFE3A-1A02-46B3-9A9A-D3B190F5217C}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\newbee_ocr_cli'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zibo-chen/newbee-ocr-cli/releases/download/v0.2.3/newbee_ocr_cli-x86_64-pc-windows-msvc.msi
+  InstallerSha256: 1DA0470F3CC1017DA5B15591258AC1AAB95F01C60A725C68CFB224DB9DA4B385
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.locale.en-US.yaml
+++ b/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ChenZibo.NewbeeOCRCLI
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: ChenZibo
+PublisherUrl: https://github.com/zibo-chen
+PublisherSupportUrl: https://github.com/zibo-chen/newbee-ocr-cli/issues
+Author: ChenZibo
+PackageName: newbee_ocr_cli
+PackageUrl: https://github.com/zibo-chen/newbee-ocr-cli
+License: Apache-2.0
+LicenseUrl: https://github.com/zibo-chen/newbee-ocr-cli/blob/v0.2.3/LICENSE
+ShortDescription: High-performance command-line OCR powered by PaddleOCR models
+Description: A fast OCR command-line tool with embedded multilingual PaddleOCR models, batch processing, structured output, and CPU or GPU acceleration support.
+Moniker: nbocr
+Tags:
+- cli
+- image
+- ocr
+- paddleocr
+- text-recognition
+ReleaseNotesUrl: https://github.com/zibo-chen/newbee-ocr-cli/releases/tag/v0.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.yaml
+++ b/manifests/c/ChenZibo/NewbeeOCRCLI/0.2.3/ChenZibo.NewbeeOCRCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ChenZibo.NewbeeOCRCLI
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the first WinGet manifest for Newbee OCR CLI 0.2.3 using the official version-specific WiX MSI from the project GitHub Release.

The MSI SHA256 was independently verified. ProductCode, UpgradeCode, Publisher, ProductName, and ProductVersion were extracted directly from the MSI Property table.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement
- [x] Linked to an issue (if applicable)
  - Not applicable; this is a routine new-package manifest submission.

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one package manifest set
- [ ] Validated manifest locally with winget validate
  - winget is not available on the macOS authoring host. All three files passed YAML parsing and the official 1.12 JSON schemas; repository validation is requested.
- [ ] Tested manifest locally with winget install
  - Windows installation testing is delegated to the repository validation pipeline. The MSI was produced successfully by the upstream Windows release job and its metadata was inspected independently.
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429475)