### PR TITLE
New package: CodeForFire.Lagebuch version 0.5.0

### DIFF
--- a/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.installer.yaml
+++ b/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CodeForFire.Lagebuch
+PackageVersion: 0.3.0
+InstallerType: msi
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/CodeForFire/lagebuch/releases/download/v0.3.0/lagebuch-0.3.0-x64.msi
+  InstallerSha256: 23184DD667E24DBBA219121BB039643F61A16589E074A0026B1E9F10AD89714D
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{A03EAA1B-3D77-4FF0-A60A-5ABE27C27B18}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.locale.en-US.yaml
+++ b/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CodeForFire.Lagebuch
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: CodeForFire
+PublisherUrl: https://github.com/CodeForFire
+PackageName: Lagebuch
+PackageUrl: https://github.com/CodeForFire/lagebuch
+License: MIT
+LicenseUrl: https://github.com/CodeForFire/lagebuch/blob/main/LICENSE
+ShortDescription: Offline-first incident documentation (Einsatzdokumentation) app for fire brigades.
+Description: >-
+  Lagebuch ("log book") is a robust, cross-platform desktop application for the
+  fire brigade command vehicle (ELW). It provides offline-first incident
+  documentation with optional multi-device sync and PDF report generation.
+  Built with .NET and Avalonia.
+Moniker: lagebuch
+Tags:
+- firefighting
+- fire-department
+- incident-management
+- emergency-management
+ReleaseNotesUrl: https://github.com/CodeForFire/lagebuch/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.yaml
+++ b/manifests/c/CodeForFire/Lagebuch/0.3.0/CodeForFire.Lagebuch.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CodeForFire.Lagebuch
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the manifest for Lagebuch, an offline-first incident documentation (Einsatzdokumentation) desktop app for fire brigades, version 0.5.0. MIT licensed, released on GitHub. The MSI installer is not code-signed — flagging that up front since it may trigger the unsigned-installer warning in review. SignPath Foundation declined the project and OSSign requires six months of account age, so February 2027 is the earliest a free certificate is possible; in the meantime every release publishes SHA-256 checksums and Sigstore build provenance (`gh attestation verify`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — no Windows environment available; instead validated all four files against the published 1.12.0 JSON schemas (`manifest.version`, `manifest.installer`, `manifest.defaultLocale`, `manifest.locale`) with `jsonschema`, all pass
- [ ] Tested manifest locally with `winget install --manifest <path>` — same constraint, not run
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429479)
