### PR TITLE
New version: M-Igashi.mp3rgain version 3.6.0

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.0/mp3rgain-v3.6.0-windows-x86_64.zip
+    InstallerSha256: 7EE6B0118F638923009D40812B62E05D16C00AEF12DEBD41D2D390C40BE911E7
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.0/mp3rgain-v3.6.0-windows-arm64.zip
+    InstallerSha256: C1FC1562F990DC54C81A5FB2894088FA793B29F400ED968059A717A2FC00EC84
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.0/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

New version of mp3rgain, a lossless MP3/AAC volume normalizer written in Rust.

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.0

`winget validate` and `winget install` were not run: this package is built and maintained on macOS, so neither command is available here. What was verified instead: the manifests carry over the schema and metadata of the merged 3.5.1 submission with only the version, release date, URLs and checksums changed, and each `InstallerSha256` matches the `.sha256` file published alongside its release asset.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429481)