### PR TITLE
Update locale: jmrplens.gitlab-mcp-server version 2.7.5

### DIFF
--- a/manifests/j/jmrplens/gitlab-mcp-server/2.7.5/jmrplens.gitlab-mcp-server.locale.en-US.yaml
+++ b/manifests/j/jmrplens/gitlab-mcp-server/2.7.5/jmrplens.gitlab-mcp-server.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageUrl: https://github.com/jmrplens/gitlab-mcp-server
 License: MIT
 LicenseUrl: https://github.com/jmrplens/gitlab-mcp-server/blob/HEAD/LICENSE
 ShortDescription: GitLab MCP server exposing the REST v4 and GraphQL APIs as tools for AI assistants.
-Description: A Model Context Protocol (MCP) server that connects AI assistants (Claude, Cursor, VS Code + Copilot, and any MCP client) to GitLab.com or self-managed GitLab instances. Covers the full REST API v4 and GraphQL with automatic edition gating — roughly 850 to 1070 tools depending on the GitLab tier — plus 45 MCP resources, 37 prompts, argument completions, and progress notifications. Single static binary, stdio and HTTP transports, read-only and safe (mutation-preview) modes, and an interactive setup wizard (gitlab-mcp-server --setup) that auto-configures most MCP clients.
+Description: A Model Context Protocol (MCP) server that connects AI assistants (Claude, Cursor, VS Code + Copilot, and any MCP client) to GitLab.com or self-managed GitLab instances. Covers the full REST API v4 and GraphQL with automatic edition gating, roughly 850 to 1080 tools depending on the GitLab tier, plus 45 MCP resources, 37 prompts, argument completions, progress notifications and resource subscriptions. Single static binary, stdio and HTTP transports, read-only and safe (mutation-preview) modes, and per-client configuration examples in the documentation.
 Moniker: gitlab-mcp-server
 Tags:
 - ai
@@ -81,6 +81,6 @@ ReleaseNotes: |-
 ReleaseNotesUrl: https://github.com/jmrplens/gitlab-mcp-server/releases/tag/v2.7.5
 Documentations:
 - DocumentLabel: Documentation
-  DocumentUrl: https://jmrplens.github.io/gitlab-mcp-server/
+  DocumentUrl: https://jmrp.io/docs/gitlab-mcp-server/
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Locale-only update for `jmrplens.gitlab-mcp-server` 2.7.5. The installer manifest is unchanged.

- `Description`: the previous text described an interactive setup wizard (`gitlab-mcp-server --setup`) that the project removed; the flag no longer exists. The new text describes the current server and its current counts.
- `DocumentUrl`: the documentation moved to https://jmrp.io/docs/gitlab-mcp-server/; the old GitHub Pages address is now a redirect.

The release notes and every other field are unchanged. I am the package publisher.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (submitted from Linux; the change is two text fields of the locale file, and the schema line is untouched)
- [ ] Tested manifest locally with `winget install --manifest <path>` (installer manifest unchanged)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429486)