### PR TITLE
New package: idk-arsh.MultiTerm version 1.1.0

### DIFF
--- a/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.installer.yaml
+++ b/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.installer.yaml
@@ -1,0 +1,15 @@
+# Created with love for winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: idk-arsh.MultiTerm
+PackageVersion: 1.1.0
+InstallerType: portable
+Commands:
+- multiterm
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/idk-arsh/multiterm/releases/download/v1.1.0/MultiTerm.exe
+  InstallerSha256: 8AE2D02C5A09A674092D402B71FA540F58F0E003E920A19B2FB71520F6511B60
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.locale.en-US.yaml
+++ b/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# Created with love for winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: idk-arsh.MultiTerm
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: idk-arsh
+PublisherUrl: https://github.com/idk-arsh
+PublisherSupportUrl: https://github.com/idk-arsh/multiterm/issues
+PackageName: MultiTerm
+PackageUrl: https://github.com/idk-arsh/multiterm
+License: MIT
+LicenseUrl: https://github.com/idk-arsh/multiterm/blob/main/LICENSE
+ShortDescription: A multi-pane terminal workspace for Windows with workspaces, per-folder startup commands and broadcast typing.
+Description: |-
+  MultiTerm opens several real Windows shells (cmd, PowerShell, PowerShell 7, Git Bash, WSL) side by side over ConPTY.
+  A workspace is a project folder: its subfolders become panes, each can have a startup command, and opening the workspace starts everything in the layout you left it in.
+  Broadcast typing sends every keystroke to every pane in a tab. Panes are a freeform split tree with drag-to-resize, maximise and presets.
+  Single portable executable, no installer, no admin rights, settings in %APPDATA%\MultiTerm.
+Moniker: multiterm
+Tags:
+- conpty
+- console
+- developer-tools
+- multiplexer
+- shell
+- terminal
+- terminal-emulator
+- workspace
+ReleaseNotesUrl: https://github.com/idk-arsh/multiterm/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.yaml
+++ b/manifests/i/idk-arsh/MultiTerm/1.1.0/idk-arsh.MultiTerm.yaml
@@ -1,0 +1,8 @@
+# Created with love for winget-pkgs
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: idk-arsh.MultiTerm
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description

New package: idk-arsh.MultiTerm version 1.1.0.

MultiTerm is an MIT-licensed multi-pane terminal for Windows 10 and 11 (Python and Tk over ConPTY). Workspaces reopen a project's folders with a startup command per folder; broadcast typing sends one keystroke to every pane. Portable single exe, no installer, settings in %APPDATA%\MultiTerm.

Repo: https://github.com/idk-arsh/multiterm
Release: https://github.com/idk-arsh/multiterm/releases/tag/v1.1.0

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.10 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429580)