### PR TITLE
Update: ynjmxn.Gengchou to 2.5.3

### DIFF
--- a/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.installer.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.installer.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.3
+Platform:
+- Windows.Desktop
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gengchou.exe
+  PortableCommandAlias: gengchou
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ynjmxn/gengchou/releases/download/v2.5.3/gengchou-windows-x64.zip
+  InstallerSha256: 53A0A43B8F6EFD4FA8FA987A70677F6C73B07118DEDD99767F3CCBF51A81112C
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-04

--- a/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.locale.en-US.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.3
+PackageLocale: en-US
+Publisher: ynjmxn
+PublisherUrl: https://github.com/ynjmxn
+PublisherSupportUrl: https://github.com/ynjmxn/gengchou/issues
+PrivacyUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.3/README.md#data--privacy
+Author: ynjmxn, lvfeinan and contributors
+PackageName: Gengchou
+PackageUrl: https://github.com/ynjmxn/gengchou
+License: MIT
+LicenseUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.3/LICENSE
+Copyright: Copyright (C) 2025 Craig Constable; modifications Copyright (C) 2026 Jianxin Yin
+CopyrightUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.3/LICENSE
+ShortDescription: A Windows taskbar and tray AI quota monitor for Claude, Codex, Antigravity, and Grok.
+Description: Gengchou is a lightweight native Windows taskbar widget and system-tray app for viewing the quota windows reported by Claude, Codex, Google Antigravity, and Grok without opening a provider dashboard. On first start it asks once for permission, then detects which providers are signed in on this machine and shows only those. Nothing is read before permission is granted, and access can be revoked per provider at any time. It has no analytics, telemetry, or separate backend service, and it does not store provider tokens.
+Moniker: gengchou
+Tags:
+- antigravity
+- claude-code
+- codex
+- grok
+- remote-desktop
+- rust
+- system-tray
+- taskbar
+- usage-monitor
+- windows
+ReleaseNotes: The daily update check now raises a silent balloon once per version. Clicking it asks whether to update. The detail popup footer shows the waiting version while an update is outstanding and that line is clickable. A remembered offer that is not newer than the running build is treated as up to date. A failed automatic check does not clear the last successful offer.
+ReleaseNotesUrl: https://github.com/ynjmxn/gengchou/releases/tag/v2.5.3
+InstallationNotes: WinGet portable packages do not create a Start menu shortcut. Open a new terminal and run "gengchou", then answer the one-time permission prompt that covers every provider. Access can be revoked for a single provider later under "Provider access"; optionally enable "Start with Windows" from the app context menu.
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/ynjmxn/gengchou/blob/v2.5.3/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.locale.zh-CN.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.locale.zh-CN.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.3
+PackageLocale: zh-CN
+Publisher: ynjmxn
+PackageName: 更筹 Gengchou
+License: MIT
+ShortDescription: 面向 Windows 的 Claude、Codex、Antigravity 和 Grok 配额监视器，提供任务栏组件、浮窗和托盘图标。
+Description: 更筹是轻量级原生 Windows 任务栏组件与系统托盘应用，无需打开服务商控制台 即可查看 Claude、Codex、Google Antigravity 和 Grok 实际报告的配额窗口。 首次启动只请求一次授权，随后探测本机有哪些服务商已登录，并只显示探测到的。 未获授权前不读取任何凭据，且可随时按服务商单独撤销。 应用不包含分析、遥测或独立后端服务，也不会保存服务商令牌。
+InstallationNotes: WinGet 的 portable 包不会创建开始菜单快捷方式。安装后请在新终端中运行“gengchou”，并回答那一次覆盖全部服务商的授权提示；之后可在“服务商访问权限”菜单中按服务商单独撤销。如需开机启动，可在应用右键菜单中启用“Start with Windows”。
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.yaml
+++ b/manifests/y/ynjmxn/Gengchou/2.5.3/ynjmxn.Gengchou.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ynjmxn.Gengchou
+PackageVersion: 2.5.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request type

- [x] Package update (`ynjmxn.Gengchou` 2.5.2 -> 2.5.3)

### What is this PR for

Updates `ynjmxn.Gengchou` to 2.5.3, published at https://github.com/ynjmxn/gengchou/releases/tag/v2.5.3

Changes against the 2.5.2 manifests: `PackageVersion`, the installer URL, `InstallerSha256`, `ReleaseDate`, the four tag-pinned URLs in the en-US locale (privacy, license, copyright, README), `ReleaseNotes` and `ReleaseNotesUrl`. `Publisher`, `Author`, `Copyright`, the package description and the installation notes are unchanged and still accurate for this version.

### Validation

- `winget validate --manifest <dir>` passes.
- The installer hash was taken from the published release asset, not from a local build: `gengchou-windows-x64.zip` was downloaded from the release and its SHA-256 recomputed as `53A0A43B8F6EFD4FA8FA987A70677F6C73B07118DEDD99767F3CCBF51A81112C`, matching the `SHA256SUMS` asset of the same release.
- The zip contains `gengchou.exe` at its root, which is the `RelativeFilePath` in the installer manifest.
- The release also carries GitHub build provenance attestations; `gh attestation verify gengchou-windows-x64.zip --repo ynjmxn/gengchou` succeeds for the downloaded asset.

`winget install --manifest` was **not** run: it requires enabling `LocalManifestFiles`, which needs an elevated policy change on this machine. The checks above were used instead, and this box is left unchecked rather than claimed.

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (see note above)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429617)