### PR TITLE
Update version: AdGuard.dnsproxy version 0.84.2

### DIFF
--- a/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.installer.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-386/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.2/dnsproxy-windows-386-v0.84.2.zip
+  InstallerSha256: 3D7167F7A64DF96345B052B3FC1F20795B42029853E5F2625294D91163281666
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-amd64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.2/dnsproxy-windows-amd64-v0.84.2.zip
+  InstallerSha256: D295E9B272C8ECD0AD84F4DCC361BD6B5C98CC1ABE1E715DF494872EEA55211F
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: windows-arm64/dnsproxy.exe
+  InstallerUrl: https://github.com/AdguardTeam/dnsproxy/releases/download/v0.84.2/dnsproxy-windows-arm64-v0.84.2.zip
+  InstallerSha256: C03035EBBB96FBE89D7793876C59EEFE6E3D03241436273BCEBABD355FADE29B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.locale.en-US.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.2
+PackageLocale: en-US
+Publisher: AdGuard
+PublisherUrl: https://adguard.com/
+PublisherSupportUrl: https://github.com/AdguardTeam/dnsproxy/issues
+PackageName: DNS Proxy
+PackageUrl: https://github.com/AdguardTeam/dnsproxy
+License: Apache-2.0
+LicenseUrl: https://github.com/AdguardTeam/dnsproxy/blob/HEAD/LICENSE
+ShortDescription: Simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support
+Tags:
+- dns
+- dns-over-https
+- dns-over-quic
+- dns-over-tls
+- dnscrypt
+- golang
+- open-source
+- proxy
+ReleaseNotes: "### Changed\r\n\r\n• The version of Go updated to 1.26.8.\r\n\r\n### Fixed\r\n\r\n• DoQ 0-RTT opcode handling."
+ReleaseNotesUrl: https://github.com/AdguardTeam/dnsproxy/releases/tag/v0.84.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.yaml
+++ b/manifests/a/AdGuard/dnsproxy/0.84.2/AdGuard.dnsproxy.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AdGuard.dnsproxy
+PackageVersion: 0.84.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update AdGuard.dnsproxy to version 0.84.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429630)