### PR TITLE
New version: M-Igashi.baken version 3.1.0

### DIFF
--- a/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.installer.yaml
+++ b/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.installer.yaml
@@ -1,0 +1,20 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: baken.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/baken/releases/download/v3.1.0/baken-v3.1.0-windows-x86_64.zip
+    InstallerSha256: 4F3C0FEE9DD5E48B8E1F63E40FDAD96348707644BC5D33F8A6E1FE25018D2C69
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/baken/issues
+Author: M-Igashi
+PackageName: Bake'n Deck
+PackageUrl: https://github.com/M-Igashi/baken
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/baken/blob/main/LICENSE
+ShortDescription: Rekordbox to CDJ prep toolkit - loudness gain, Key+BPM playlist sort, and CDJ-safe MP3 transcode
+Description: |-
+  Bake'n Deck (baken) is a Rekordbox to CDJ prep toolkit, the successor to headroom (renamed at v3.0.0).
+  The headroom subcommand analyzes audio files for loudness (LUFS) and True Peak headroom, then applies lossless gain adjustment. It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files, with batch processing, lossless MP3/AAC gain via mp3rgain, and a scriptable non-interactive CLI mode.
+  The rbsort subcommand sorts every playlist in a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep, in place and without touching any audio - no ffmpeg required.
+  The cdjsafe subcommand converts every track in a playlist to 320 kbps CBR MP3 at 44.1 kHz for pre-NXS2 CDJs, emitting an updated XML in which converted tracks inherit beatgrids and cue points verbatim.
+Moniker: baken
+Tags:
+  - aac
+  - audio
+  - cdj
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/baken/releases/tag/v3.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.yaml
+++ b/manifests/m/M-Igashi/baken/3.1.0/M-Igashi.baken.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been created with the following manifests

- M-Igashi.baken version 3.1.0

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes

New version of Bake'n Deck (`baken`), a Rekordbox to CDJ prep toolkit. The manifests are the merged 3.0.4 set with the version, installer URL, `InstallerSha256`, `ReleaseDate` and `ReleaseNotesUrl` updated, plus a one-line description refresh for the reworked `rbsort` subcommand. Nothing else changed, including the declared dependencies.

`InstallerSha256` was verified by downloading the release asset and hashing it, not only against the published `baken-v3.1.0-checksums.txt`. The archive contains a single `baken.exe`, matching `NestedInstallerFiles`.

I have no Windows machine, so the two boxes above are left unchecked: `winget validate` and `winget install` were not run locally. The manifests were checked against the 1.12 schema and diffed against the merged 3.0.4 manifests instead, and I am relying on the repository's validation pipeline.

Release: https://github.com/M-Igashi/baken/releases/tag/v3.1.0

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429714)