### PR TITLE
New package: MAIDEPOT.thread0 version 0.1.227

### DIFF
--- a/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.installer.yaml
+++ b/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.installer.yaml
@@ -19,7 +19,7 @@ AppsAndFeaturesEntries:
     ProductCode: 408a5cda-fb51-5bcd-855b-a4a874725d41
 Installers:
   - Architecture: x64
-    InstallerUrl: https://storage.googleapis.com/gendistrict-agentdeck-updates/releases/0.1.227/windows/x64/thread0%20Setup%200.1.227.exe
+    InstallerUrl: https://thread0.ai/releases/0.1.227/windows/x64/thread0%20Setup%200.1.227.exe
     InstallerSha256: EC516430A04B061CA552F7E3E80DBDC324431F348AE36F87D817E6A334612F1E
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.installer.yaml
+++ b/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.installer.yaml
@@ -1,0 +1,25 @@
+# Created with thread0 release tooling — see docs/WINDOWS-SMARTSCREEN.md §3 (winget).
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: MAIDEPOT.thread0
+PackageVersion: 0.1.227
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+AppsAndFeaturesEntries:
+  - Publisher: MAIDEPOT
+    ProductCode: 408a5cda-fb51-5bcd-855b-a4a874725d41
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://storage.googleapis.com/gendistrict-agentdeck-updates/releases/0.1.227/windows/x64/thread0%20Setup%200.1.227.exe
+    InstallerSha256: EC516430A04B061CA552F7E3E80DBDC324431F348AE36F87D817E6A334612F1E
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.locale.en-US.yaml
+++ b/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created with thread0 release tooling — see docs/WINDOWS-SMARTSCREEN.md §3 (winget).
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: MAIDEPOT.thread0
+PackageVersion: 0.1.227
+PackageLocale: en-US
+Publisher: MAI DEPOT, Inc
+PublisherUrl: https://maidepot.com/
+PublisherSupportUrl: https://thread0.ai/support/
+PrivacyUrl: https://thread0.ai/privacy/
+Author: MAI DEPOT, Inc
+PackageName: thread0
+PackageUrl: https://thread0.ai/
+License: Proprietary
+LicenseUrl: https://thread0.ai/terms/
+Copyright: Copyright (c) 2026 MAI DEPOT, Inc
+ShortDescription: Desktop Agent OS for Claude and GPT. Run sessions side by side on your own subscriptions, hand off between accounts, approve from your phone.
+Description: |-
+  thread0 is a desktop Agent OS that runs Claude and GPT (Codex) sessions side by side using the subscriptions you already pay for. When one account reaches its usage limit, hand the same session to another account you own and keep the project folder, conversation and unfinished task together. Pair a phone (thread0 Remote) to watch progress and approve tools over end-to-end encrypted connections. Free for individuals and teams up to 5; provider subscriptions, charges, terms and limits stay exactly as they are.
+Moniker: thread0
+Tags:
+  - agent
+  - ai
+  - claude
+  - codex
+  - developer-tools
+  - gpt
+ReleaseNotesUrl: https://github.com/GenDistrict/thread0/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.yaml
+++ b/manifests/m/MAIDEPOT/thread0/0.1.227/MAIDEPOT.thread0.yaml
@@ -1,0 +1,8 @@
+# Created with thread0 release tooling — see docs/WINDOWS-SMARTSCREEN.md §3 (winget).
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: MAIDEPOT.thread0
+PackageVersion: 0.1.227
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
New package: **MAIDEPOT.thread0** version 0.1.227 — thread0, desktop Agent OS for Claude and GPT (https://thread0.ai/).

Installer: NSIS per-user (`/S`), Azure Trusted Signing (MAI DEPOT, Inc). URL is a version-pinned release path; SHA256 computed from the signed artifact that the live update manifest also references.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — validated with `winget validate`; the SHA256 was verified against the signed artifact, and the same installer is what the app's own updater has been installing on real machines since 2026-09-04. A clean-VM `winget install --manifest` run will be added if the bot requests it.
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

Publisher: MAI DEPOT, Inc (Bellevue, WA). Maintainer contact: contact@maidepot.com.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429724)