### PR TITLE
New version: M-Igashi.baken version 3.2.0

### DIFF
--- a/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.installer.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.installer.yaml
@@ -1,0 +1,20 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: baken.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/baken/releases/download/v3.2.0/baken-v3.2.0-windows-x86_64.zip
+    InstallerSha256: 2C84BA268D6769B1EB41B6964B7B2F796FC078749AAF2E9AA5A5693F10F621B8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.0
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/baken/issues
+Author: M-Igashi
+PackageName: Bake'n Deck
+PackageUrl: https://github.com/M-Igashi/baken
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/baken/blob/main/LICENSE
+ShortDescription: Rekordbox to CDJ prep toolkit - loudness gain, Key+BPM playlist sort, and CDJ-safe MP3 transcode
+Description: |-
+  Bake'n Deck (baken) is a Rekordbox to CDJ prep toolkit, the successor to headroom (renamed at v3.0.0).
+  The headroom subcommand analyzes audio files for loudness (LUFS) and True Peak headroom, then applies lossless gain adjustment. It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files, with batch processing, lossless MP3/AAC gain via mp3rgain, and a scriptable non-interactive CLI mode.
+  The rbsort subcommand sorts every playlist in a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep, in place and without touching any audio - no ffmpeg required.
+  The cdjsafe subcommand converts every track in a playlist to 320 kbps CBR MP3 at 44.1 kHz for pre-NXS2 CDJs, emitting an updated XML in which converted tracks inherit beatgrids and cue points verbatim.
+Moniker: baken
+Tags:
+  - aac
+  - audio
+  - cdj
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/baken/releases/tag/v3.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.0/M-Igashi.baken.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated your manifest](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validating-a-manifest) locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Authored on macOS, so the local winget validate/install steps could not be run; the SHA256 was verified against the release checksums file and an independent download. Copied from the 3.1.0 manifests with version, installer URL, SHA256 and release notes URL updated. Release: https://github.com/M-Igashi/baken/releases/tag/v3.2.0


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429731)