### PR TITLE
New package: Ajunior.Qub version 0.44.10

### DIFF
--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Ajunior.Qub
 PackageVersion: 0.44.10
 InstallerType: inno
@@ -15,4 +15,4 @@ Installers:
     InstallerUrl: https://github.com/ajunior/qub/releases/download/v0.44.10/qub-0.44.10-setup.exe
     InstallerSha256: D90F63036FB3593F2DB9CC651A20C1DFF5ABC7BF730FBC005DC802BCD518CEAB
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
@@ -9,6 +9,15 @@ InstallModes:
   - silentWithProgress
 UpgradeBehavior: install
 ProductCode: '{F6A1B2C3-D4E5-4F60-A7B8-C9D0E1F2A3B4}_is1'
+# Inno registers the uninstall entry as "qub version 0.44.10", not "qub", so
+# the name heuristic never matches the package and `winget list` falls back to
+# the raw ARP id. Spelling the entry out here is what pins the correlation.
+AppsAndFeaturesEntries:
+  - DisplayName: qub version 0.44.10
+    DisplayVersion: 0.44.10
+    Publisher: ajunior
+    ProductCode: '{F6A1B2C3-D4E5-4F60-A7B8-C9D0E1F2A3B4}_is1'
+    InstallerType: inno
 ReleaseDate: '2026-09-04'
 Installers:
   - Architecture: x64

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Ajunior.Qub
+PackageVersion: 0.44.10
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{F6A1B2C3-D4E5-4F60-A7B8-C9D0E1F2A3B4}_is1'
+ReleaseDate: '2026-09-04'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ajunior/qub/releases/download/v0.44.10/qub-0.44.10-setup.exe
+    InstallerSha256: D90F63036FB3593F2DB9CC651A20C1DFF5ABC7BF730FBC005DC802BCD518CEAB
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.locale.en-US.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Ajunior.Qub
+PackageVersion: 0.44.10
+PackageLocale: en-US
+Publisher: ajunior
+PublisherUrl: https://github.com/ajunior
+PublisherSupportUrl: https://github.com/ajunior/qub/issues
+PackageName: qub
+PackageUrl: https://qubeditor.com/
+License: GPL-3.0
+LicenseUrl: https://github.com/ajunior/qub/blob/main/LICENSE
+ShortDescription: A SQL editor for people who work in SQL all day
+Description: |-
+  qub is a SQL editor that keeps the query at the centre of the window and
+  everything else a keystroke away. It connects to PostgreSQL, MySQL/MariaDB,
+  SQLite, Oracle, Firebird and ODBC at the same time, with passwords kept in
+  the OS credential store rather than on disk.
+
+  The same result set opens as a grid, a chart, a per-column profile, a pivot
+  table, a query plan, a set of data-quality checks or a diff against an
+  earlier run. Completion knows the columns of the tables actually in scope,
+  queries take named and positional parameters, and exports go out as CSV,
+  TSV, JSON, Excel, Markdown or SQL INSERTs without being truncated to what
+  the grid happens to be showing.
+Moniker: qub
+Tags:
+  - database
+  - db
+  - editor
+  - mariadb
+  - mysql
+  - oracle
+  - postgresql
+  - sql
+  - sqlite
+ReleaseNotesUrl: https://github.com/ajunior/qub/releases/tag/v0.44.10
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://qubeditor.com/help.html
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.locale.en-US.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Ajunior.Qub
 PackageVersion: 0.44.10
 PackageLocale: en-US
@@ -38,4 +38,4 @@ Documentations:
   - DocumentLabel: Documentation
     DocumentUrl: https://qubeditor.com/help.html
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Ajunior.Qub
 PackageVersion: 0.44.10
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.yaml
+++ b/manifests/a/Ajunior/Qub/0.44.10/Ajunior.Qub.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Ajunior.Qub
+PackageVersion: 0.44.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

New package: **Ajunior.Qub** version **0.44.10**.

  qub is a SQL editor for PostgreSQL, MySQL/MariaDB, SQLite, Oracle, Firebird and
  ODBC. Free software under the GPL-3.0 — https://github.com/ajunior/qub

  Submitted by the author of the package. The installer is the artifact the GitHub
  release serves, built by Inno Setup 6 in the project's release workflow: x64,
  `PrivilegesRequired=lowest` hence `Scope: user`.

  Verification:

  - `winget validate --manifest` and `winget install --manifest` both run clean on
    Windows 11.
  - The `ProductCode` was confirmed against the uninstall key Inno actually
    writes, read back from `HKCU\...\Uninstall` after installing, rather than
    inferred from the installer script.
  - `AppsAndFeaturesEntries` records the ARP entry as it really appears — Inno
    registers the DisplayName as `qub version 0.44.10`, which differs from the
    package name.
  - `InstallerSha256` was produced by downloading the published installer and
    hashing it, not by copying the release's `SHA256SUMS.txt`, so the manifest is
    checked against the same bytes a user will receive.
  - All three manifests validate against the official 1.12.0 JSON schemas.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429759)