### PR TITLE
New package: mory-dev.NomadWiFi version 1.3.1

### DIFF
--- a/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.installer.yaml
+++ b/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: mory-dev.NomadWiFi
+PackageVersion: 1.3.1
+MinimumOSVersion: 10.0.18362.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mory-dev/nomadwifi/releases/download/v1.3.1/NomadWiFi-Setup-1.3.1.exe
+    InstallerSha256: 770294E56247DF14331FC50470CEA7AD5250470956FF33EB23EBA68C5556BBC7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.locale.en-US.yaml
+++ b/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: mory-dev.NomadWiFi
+PackageVersion: 1.3.1
+PackageLocale: en-US
+Publisher: mory.dev
+PublisherUrl: https://mory.dev
+PublisherSupportUrl: https://github.com/mory-dev/nomadwifi/issues
+PackageName: NomadWiFi
+PackageUrl: https://nomadwifi.mory.dev
+License: MIT
+LicenseUrl: https://github.com/mory-dev/nomadwifi/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Dario Mory
+ShortDescription: Wi-Fi roaming and band optimizer for Windows.
+Description: |-
+  NomadWiFi moves you off the access point Windows is clinging to. It ranks every
+  radio in range using the Native Wifi API, prefers 5 GHz and 6 GHz over a weak
+  2.4 GHz link, and switches automatically when the connection degrades or drops.
+
+  Windows reports the access point you are joined to at near-full link quality no
+  matter its real signal, which is why it rarely roams on its own. NomadWiFi
+  scores every access point from measured RSSI instead, so the comparison is fair.
+
+  It also coordinates a VPN around the switch: holding the tunnel, verifying the
+  new link carries traffic, then resuming and flushing DNS. Captive portals are
+  detected and explained rather than mistaken for a bad access point.
+Moniker: nomadwifi
+Tags:
+  - wifi
+  - wireless
+  - networking
+  - roaming
+  - vpn
+  - 5ghz
+  - access-point
+  - captive-portal
+  - travel
+ReleaseNotesUrl: https://github.com/mory-dev/nomadwifi/releases/tag/v1.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.yaml
+++ b/manifests/m/mory-dev/NomadWiFi/1.3.1/mory-dev.NomadWiFi.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: mory-dev.NomadWiFi
+PackageVersion: 1.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **mory-dev.NomadWiFi** version **1.3.1**

NomadWiFi is a Wi-Fi roaming and band optimizer for Windows. It ranks every access point in range using the Native Wifi API, prefers 5 GHz and 6 GHz over a weak 2.4 GHz link, and switches automatically when the connection degrades or drops. It also coordinates a VPN tunnel around the switch and detects captive portals.

- Homepage: https://nomadwifi.mory.dev
- Source: https://github.com/mory-dev/nomadwifi (MIT)
- Release: https://github.com/mory-dev/nomadwifi/releases/tag/v1.3.1

The installer is Inno Setup, per-user (`Scope: user`), needs no elevation, and supports silent install. Every binary and the installer are Authenticode-signed via Azure Artifact Signing (`CN=Bizonbyte, O=Bizonbyte, L=Amsterdam, C=NL`) with RFC3161 timestamps.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — pending, see note below
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — "Manifest validation succeeded."
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Note on the install test

`winget install --manifest` requires the `LocalManifestFiles` admin setting, which I was not able to enable in the environment this was prepared in. The installer itself was tested directly and repeatedly on Windows 11 24H2 (x64):

- Silent install (`/SILENT /SUPPRESSMSGBOXES /NORESTART`) → exit 0
- Silent upgrade over a running instance → exit 0
- Silent uninstall → exit 0, no orphaned registry values, shortcuts or PATH entries
- `Get-AuthenticodeSignature` reports `Valid` for the installer and for both payload executables

Happy to re-run the manifest install test and report back if that is required before merge.

### Note on the CLA

The CLA still needs signing on this account; the checkbox above was ticked in error on the first
submission and has been corrected. It will be signed before this is ready to merge.
