### PR TITLE
Update: JiaPeng.LanTransfer to 0.7.0

### DIFF
--- a/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.installer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.7.0'
+InstallerType: 'inno'
+InstallModes:
+- 'silent'
+- 'silentWithProgress'
+InstallerSwitches:
+  Silent: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+  SilentWithProgress: '/SILENT /SUPPRESSMSGBOXES /NORESTART'
+ReleaseDate: '2026-09-05'
+Installers:
+- Architecture: x64
+  InstallerUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/download/v0.7.0/LanTransfer-0.7.0-win-x64-Setup.exe'
+  InstallerSha256: 23E92351FF87FB458870F5AC98D52848A270FB95815B7A2083D5CADED02B9862
+ManifestType: installer
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.locale.en-US.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.7.0'
+PackageLocale: 'en-US'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: 'Transfer files and text between devices on the same local network through a browser.'
+Description: 'LanTransfer is a cross-platform local-network file and text transfer tool with a browser-based interface, QR-code connection, and no cloud dependency.'
+Moniker: 'lantransfer'
+Tags:
+- 'file-transfer'
+- 'lan'
+- 'local-network'
+- 'qr-code'
+- 'text-transfer'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.7.0'
+ManifestType: defaultLocale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.locale.zh-CN.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.7.0'
+PackageLocale: 'zh-CN'
+Publisher: 'JiaPeng'
+PublisherUrl: 'https://github.com/hongjiapeng'
+PublisherSupportUrl: 'https://github.com/hongjiapeng/LanTransfer/issues'
+PackageName: 'LanTransfer'
+PackageUrl: 'https://github.com/hongjiapeng/LanTransfer'
+License: 'MIT'
+LicenseUrl: 'https://github.com/hongjiapeng/LanTransfer/blob/main/LICENSE'
+ShortDescription: '通过浏览器在同一局域网的设备之间传输文件和文字。'
+Description: 'LanTransfer 是一个跨平台局域网文件和文字传输工具，提供浏览器界面、二维码连接，并且不依赖云服务。'
+Tags:
+- '二维码'
+- '局域网'
+- '文件传输'
+- '文字传输'
+ReleaseNotesUrl: 'https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.7.0'
+ManifestType: locale
+ManifestVersion: '1.12.0'

--- a/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.yaml
+++ b/manifests/j/JiaPeng/LanTransfer/0.7.0/JiaPeng.LanTransfer.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'JiaPeng.LanTransfer'
+PackageVersion: '0.7.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: '1.12.0'


### PR DESCRIPTION
## Release

- Release: https://github.com/hongjiapeng/LanTransfer/releases/tag/v0.7.0
- Installer: https://github.com/hongjiapeng/LanTransfer/releases/download/v0.7.0/LanTransfer-0.7.0-win-x64-Setup.exe
- SHA256: `23E92351FF87FB458870F5AC98D52848A270FB95815B7A2083D5CADED02B9862`

## Validation

- `winget validate`: succeeded
- Manifest generated with the LanTransfer release generator and validated offline.
- Full install/upgrade/uninstall testing was not run in the user's environment to avoid interfering with a running LanTransfer instance.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429835)