### PR TITLE
New package: paralellterminal.PATerminal version 0.2.5

### DIFF
--- a/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.installer.yaml
+++ b/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: paralellterminal.PATerminal
+PackageVersion: 0.2.5
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: '2026-09-04'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/saisai-web/PATerminal/releases/download/v0.2.5/PATerminal_0.2.5_x64-setup.exe
+    InstallerSha256: BC80D844BEAD837E09B457F119079E588CF4F3591A72AB6F989FC5B8649CF4CF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.locale.en-US.yaml
+++ b/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: paralellterminal.PATerminal
+PackageVersion: 0.2.5
+PackageLocale: en-US
+Publisher: paralellterminal
+PublisherUrl: https://paralellterminal.com
+PublisherSupportUrl: https://github.com/saisai-web/PATerminal/issues
+PackageName: PATerminal
+PackageUrl: https://paralellterminal.com
+License: Proprietary
+LicenseUrl: https://github.com/saisai-web/PATerminal/blob/v0.2.5/LICENSE.md
+ShortDescription: A desktop terminal for running multiple CLI agents in parallel sessions.
+Description: |-
+  PATerminal provides parallel terminal sessions, split panes, session resume,
+  agent status, and Git tools for CLI agent workflows on Windows and macOS.
+  CLI agents must be installed and authenticated separately.
+  Official builds include a 30-day trial of all features. Advanced features
+  require a license after the trial. The source is available under a proprietary license.
+Moniker: paterminal
+Tags:
+  - terminal
+  - developer-tools
+  - git
+  - ai
+ReleaseNotesUrl: https://github.com/saisai-web/PATerminal/releases/tag/v0.2.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.yaml
+++ b/manifests/p/paralellterminal/PATerminal/0.2.5/paralellterminal.PATerminal.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: paralellterminal.PATerminal
+PackageVersion: 0.2.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Add PATerminal 0.2.5 for Windows x64 using the official, version-specific NSIS installer. PATerminal is a desktop terminal for parallel CLI agent sessions, distributed under a proprietary source-available license.

This is a draft pending Windows validation. The downloaded installer SHA-256 matches the GitHub Release asset digest. Static PE inspection confirms installer ProductVersion/FileVersion 0.2.5, embedded app ProductVersion/FileVersion 0.2.5, x64 machine type, and CompanyName `paralellterminal`. The published Tauri configuration specifies a current-user NSIS install. All three manifests pass the upstream 1.12.0 JSON schemas.

Local `winget validate`, unattended install, upgrade, uninstall, and WebView2 provisioning have **not** been tested: the preparation environment is macOS. This PR should remain draft until those checks are complete. No SmartScreen exemption or Windows signing status is claimed.

Release: https://github.com/saisai-web/PATerminal/releases/tag/v0.2.5

## Checklist

- [ ] Signed the Contributor License Agreement (status to be confirmed by the CLA check)
- [x] Checked for an existing PATerminal manifest PR
- [x] One package version, manifest files only
- [ ] Validated with `winget validate --manifest <path>` on Windows
- [ ] Tested with `winget install --manifest <path>` on Windows
- [x] Conforms to the 1.12.0 JSON schemas

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429884)