### PR TITLE
New package: Cenvero.Fleet version 2.4.1

### DIFF
--- a/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.installer.yaml
+++ b/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with https://github.com/microsoft/winget-create
+PackageIdentifier: Cenvero.Fleet
+PackageVersion: 2.4.1
+Commands:
+  - fleet
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/cenvero/fleet/releases/download/v2.4.1/fleet_2.4.1_windows_amd64.zip
+    InstallerSha256: A6A6B3DF61FAAF2B84BE18EB4851A4F1CEEC057D48661A0C3A2E53C25CEDE4A0
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: fleet.exe
+        PortableCommandAlias: fleet
+    UpgradeBehavior: install
+    ReleaseDate: 2026-09-05
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://github.com/cenvero/fleet/releases/download/v2.4.1/fleet_2.4.1_windows_arm64.zip
+    InstallerSha256: 73A9024C27CF73893B3D2B39054C6C38DB0C9D4F9094D4DBFF627B72C0C16465
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: fleet.exe
+        PortableCommandAlias: fleet
+    UpgradeBehavior: install
+    ReleaseDate: 2026-09-05
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.locale.en-US.yaml
+++ b/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with https://github.com/microsoft/winget-create
+PackageIdentifier: Cenvero.Fleet
+PackageVersion: 2.4.1
+PackageLocale: en-US
+Publisher: Cenvero
+PublisherUrl: https://cenvero.org
+PublisherSupportUrl: https://github.com/cenvero/fleet/issues
+Author: Cenvero
+PackageName: Cenvero Fleet
+PackageUrl: https://github.com/cenvero/fleet
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/cenvero/fleet/blob/v2.4.1/LICENSE
+Copyright: Copyright (C) 2026 Cenvero / Shubhdeep Singh
+ShortDescription: Self-hosted, operator-owned fleet management controller
+Description: |-
+  Cenvero Fleet is a self-hosted fleet management controller for Linux, macOS,
+  and Windows. It manages remote nodes over authenticated SSH-based direct and
+  reverse transport modes while keeping controller data under operator control.
+Moniker: fleet
+Tags:
+  - cli
+  - devops
+  - fleet-management
+  - self-hosted
+  - ssh
+ReleaseNotesUrl: https://github.com/cenvero/fleet/releases/tag/v2.4.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.yaml
+++ b/manifests/c/Cenvero/Fleet/2.4.1/Cenvero.Fleet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with https://github.com/microsoft/winget-create
+PackageIdentifier: Cenvero.Fleet
+PackageVersion: 2.4.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the new `Cenvero.Fleet` package at version `2.4.1` as a portable ZIP package for x64 and ARM64 Windows systems.

The manifests use the published Cenvero Fleet release archives and their verified SHA-256 hashes. The bundle was validated, installed, executed (`fleet --version`), and uninstalled with WinGet on `windows-latest`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable for this new package submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
