### PR TITLE
New package: r2cuerdame.CapturePack version 0.5.0

### DIFF
--- a/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.installer.yaml
+++ b/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CapturePack
+PackageVersion: 0.5.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/r2cuerdame/capturepack/releases/download/v0.5.0/CapturePack-Setup-0.5.0.exe
+    InstallerSha256: 7F076F05E5220940C4E0F0A3F0C3BFF64F0D89524B2620C4144DD25E4C2D81D9
+    ProductCode: e2882de7-4701-50c8-9b29-3229ccb6fbcc
+    AppsAndFeaturesEntries:
+      - DisplayName: CapturePack 0.5.0
+        Publisher: r2cuerdame
+        DisplayVersion: 0.5.0
+        ProductCode: e2882de7-4701-50c8-9b29-3229ccb6fbcc
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.locale.en-US.yaml
+++ b/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CapturePack
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: r2cuerdame
+PublisherUrl: https://github.com/r2cuerdame
+PublisherSupportUrl: https://github.com/r2cuerdame/capturepack/issues
+Author: r2cuerdame
+PackageName: CapturePack
+PackageUrl: https://capturepack.dev
+License: MIT
+LicenseUrl: https://github.com/r2cuerdame/capturepack/blob/v0.5.0/LICENSE
+Copyright: Copyright © 2026 r2cuerdame
+ShortDescription: Rewind recent screen activity, pick captured UI objects, and save structured local evidence for humans and AI.
+Description: >-
+  CapturePack is an open-source, local-first screen capture and structured evidence
+  collection tool for Windows. It lets you rewind recent screen activity, pick
+  captured UI objects with accessibility and window metadata, annotate replays, and
+  save self-contained, browsable capture packs for debugging, documentation, bug
+  reporting, and AI analysis. All data remains strictly local and offline by default.
+Moniker: capturepack
+Tags:
+  - developer-tools
+  - electron
+  - evidence
+  - mcp
+  - screen-capture
+  - screen-recorder
+  - screenshot
+ReleaseNotes: >-
+  CapturePack 0.5.0 introduces After Save Actions — post-save automation pipelines
+  that run sequentially after a pack is durable on disk, with isolated error handling
+  and a reference HTTP webhook action using Windows DPAPI encryption. Settings > Plugins
+  is organized into separate lists for Temporal Context Providers and After Save Actions.
+ReleaseNotesUrl: https://github.com/r2cuerdame/capturepack/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.yaml
+++ b/manifests/r/r2cuerdame/CapturePack/0.5.0/r2cuerdame.CapturePack.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CapturePack
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds the x64 per-user NSIS installer for CapturePack 0.5.0.

The manifest references the versioned public v0.5.0 GitHub release asset. Observed release evidence:
- URL: https://github.com/r2cuerdame/capturepack/releases/download/v0.5.0/CapturePack-Setup-0.5.0.exe
- Size: 104,544,811 bytes
- SHA-256: `7F076F05E5220940C4E0F0A3F0C3BFF64F0D89524B2620C4144DD25E4C2D81D9` (verified against SHA256SUMS.txt and downloaded asset)
- Architecture: x64
- InstallerType: nullsoft (NSIS oneClick user-scope installer)
- Install Scope: user (`%LOCALAPPDATA%\Programs\capturepack`)
- ProductCode / ARP Registry Key: `e2882de7-4701-50c8-9b29-3229ccb6fbcc`
- AppsAndFeatures DisplayName: `CapturePack 0.5.0`
- Silent Install / Uninstall: `/S` supported
- Local validation: `winget validate` passed with `Manifest validation succeeded.`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429924)
