### PR TITLE
New package: r2cuerdame.CodeSampleX version 0.1.134

### DIFF
--- a/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.installer.yaml
+++ b/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CodeSampleX
+PackageVersion: 0.1.134
+InstallerType: portable
+Commands:
+  - csx
+ReleaseDate: 2026-09-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/r2cuerdame/CodeSampleX/releases/download/v0.1.134/csx-windows-amd64.exe
+    InstallerSha256: B4D567E9C992973FE41DAAE137C16D70F7CA2A285EB582563B2B8A310BD559CB
+  - Architecture: arm64
+    InstallerUrl: https://github.com/r2cuerdame/CodeSampleX/releases/download/v0.1.134/csx-windows-arm64.exe
+    InstallerSha256: 374F7D928831276D6A819C8F9EECB3F9C3D5989760CD7D17501F1295573CABEE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.locale.en-US.yaml
+++ b/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CodeSampleX
+PackageVersion: 0.1.134
+PackageLocale: en-US
+Publisher: r2cuerdame
+PublisherUrl: https://github.com/r2cuerdame
+PublisherSupportUrl: https://github.com/r2cuerdame/CodeSampleX/issues
+PackageName: CodeSampleX
+PackageUrl: https://codesamplex.dev
+License: Apache-2.0
+LicenseUrl: https://github.com/r2cuerdame/CodeSampleX/blob/main/LICENSE
+ShortDescription: An open compatibility testing network for developer libraries and runtimes
+Description: >-
+  CodeSampleX is an open compatibility testing network for developer libraries, runtimes,
+  and toolchains. It records what real builds actually did in recorded environments,
+  answering whether an API runs on your version, OS, and runtime with real build evidence
+  and verified contracts.
+Moniker: csx
+Tags:
+  - cli
+  - compatibility
+  - developer-tools
+  - go
+  - mcp
+  - testing
+ReleaseNotes: >-
+  v0.1.134 refreshes shipped feature and README surface, turns features into a full product
+  capability overview, and hardens Windows launcher recovery.
+ReleaseNotesUrl: https://github.com/r2cuerdame/CodeSampleX/releases/tag/v0.1.134
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.yaml
+++ b/manifests/r/r2cuerdame/CodeSampleX/0.1.134/r2cuerdame.CodeSampleX.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: r2cuerdame.CodeSampleX
+PackageVersion: 0.1.134
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the x64 and arm64 portable CLI executable for CodeSampleX (csx).

The manifest references the immutable public v0.1.134 GitHub release assets. Observed download evidence:
- csx-windows-amd64.exe:
  - size: 17,265,664 bytes
  - SHA-256: B4D567E9C992973FE41DAAE137C16D70F7CA2A285EB582563B2B8A310BD559CB (matches release SHA256SUMS.txt)
  - version check: csx v0.1.134
  - Microsoft Defender static scan (intelligence 1.459.55.0): CLEAN (0 detections)
- csx-windows-arm64.exe:
  - size: 15,962,624 bytes
  - SHA-256: 374F7D928831276D6A819C8F9EECB3F9C3D5989760CD7D17501F1295573CABEE (matches release SHA256SUMS.txt)
  - Microsoft Defender static scan (intelligence 1.459.55.0): CLEAN (0 detections)
- local winget validate: succeeded (Windows Package Manager v1.29.290)

Canonical release: https://github.com/r2cuerdame/CodeSampleX/releases/tag/v0.1.134
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429928)