### PR TITLE
New package: kreatzzz.Woofer version 0.4.0

### DIFF
--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.installer.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: kreatzzz.Woofer
 PackageVersion: 0.4.0
 Platform:

--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.installer.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.installer.yaml
@@ -1,0 +1,35 @@
+PackageIdentifier: kreatzzz.Woofer
+PackageVersion: 0.4.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{FCED1EA0-EBF5-4C32-BA3B-A3AD724BACC3}_is1'
+AppsAndFeaturesEntries:
+- DisplayName: Woofer
+  Publisher: Carmine Paolino
+  ProductCode: '{FCED1EA0-EBF5-4C32-BA3B-A3AD724BACC3}_is1'
+Installers:
+- Architecture: x64
+  Scope: user
+  ProductCode: '{FCED1EA0-EBF5-4C32-BA3B-A3AD724BACC3}_is1'
+  InstallerUrl: https://github.com/kreatzzz/woofer/releases/download/v0.4.0/woofer-v0.4.0-x86_64-pc-windows-msvc-setup.exe
+  InstallerSha256: bd2298be6fb19cfd8d5f02bfdefc3f30a1122c391e3396b0bd48ee0102595180
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+    SilentWithProgress: /SILENT
+- Architecture: arm64
+  Scope: user
+  ProductCode: '{FCED1EA0-EBF5-4C32-BA3B-A3AD724BACC3}_is1'
+  InstallerUrl: https://github.com/kreatzzz/woofer/releases/download/v0.4.0/woofer-v0.4.0-aarch64-pc-windows-msvc-setup.exe
+  InstallerSha256: 1263ecec8a655ad44f65d3d034fad05a6355e1f3583a8ef870d2843fd3d849c0
+  InstallerSwitches:
+    Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+    SilentWithProgress: /SILENT
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.locale.en-US.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: kreatzzz.Woofer
 PackageVersion: 0.4.0
 PackageLocale: en-US

--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.locale.en-US.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: kreatzzz.Woofer
+PackageVersion: 0.4.0
+PackageLocale: en-US
+Publisher: kreatzzz
+PublisherUrl: https://github.com/kreatzzz
+PublisherSupportUrl: https://github.com/kreatzzz/woofer/issues
+PackageName: Woofer
+PackageUrl: https://github.com/kreatzzz/woofer
+License: MIT
+LicenseUrl: https://github.com/kreatzzz/woofer/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Carmine Paolino
+ShortDescription: A fast, lightweight, native Spotify client.
+Description: |
+  Woofer is a native Spotify desktop client written in Rust and egui.
+  It plays through librespot, stays lightweight, and supports playback,
+  library access, lyrics, Spotify Connect, and keyboard-first controls.
+Tags:
+- spotify
+- music
+- player
+- streaming
+- desktop
+Moniker: woofer
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: kreatzzz.Woofer
 PackageVersion: 0.4.0
 DefaultLocale: en-US

--- a/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.yaml
+++ b/manifests/k/kreatzzz/Woofer/0.4.0/kreatzzz.Woofer.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: kreatzzz.Woofer
+PackageVersion: 0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description of change\n\nAdd the initial Woofer package manifests for version 0.4.0.\n\n- Publisher: kreatzzz\n- Package: Woofer\n- Release: https://github.com/kreatzzz/woofer/releases/tag/v0.4.0\n- Installers: Inno Setup per-user installers for x64 and arm64\n- SHA-256 values were generated from and verified against the public release checksums.txt.\n\n## Validation\n\nThe three manifests were generated from the release handoff templates and parsed locally as YAML. The installer URLs and hashes point to the public GitHub release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429939)