### PR TITLE
New package: DevallCompany.ChungooseCertAgent version 3.4.0

### DIFF
--- a/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.installer.yaml
+++ b/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DevallCompany.ChungooseCertAgent
+PackageVersion: 3.4.0
+InstallModes:
+- silent
+- silentWithProgress
+ReleaseDate: 2026-08-31
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://etax.chungoose.kr/download/cert-agent/releases/3.4.0/chungoose-cert-agent-setup.exe
+  InstallerSha256: D795AEF5CFD12E6A68EC488E1440D783147597B6AAF5F20060158A7F95C3BDB3
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+  ProductCode: ChungooseCertAgent
+  AppsAndFeaturesEntries:
+  - DisplayName: 청구스 인증서 도우미
+    DisplayVersion: 3.4.0
+    Publisher: 주식회사 데브올컴퍼니
+    ProductCode: ChungooseCertAgent
+    InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.locale.en-US.yaml
+++ b/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DevallCompany.ChungooseCertAgent
+PackageVersion: 3.4.0
+PackageLocale: en-US
+Publisher: DEVALL COMPANY
+PublisherUrl: https://chungoose.kr
+PublisherSupportUrl: https://chungoose.kr
+PrivacyUrl: https://etax.chungoose.kr/privacy
+PackageName: Chungoose Certificate Agent
+PackageUrl: https://etax.chungoose.kr
+License: Proprietary
+Copyright: © 2026 DEVALL COMPANY Co., Ltd.
+ShortDescription: Local helper agent that connects Korean NTS Hometax joint certificates to the Chungoose e-tax invoice console.
+Description: |-
+  Chungoose Certificate Agent is a background helper for the Chungoose e-tax invoice service (etax.chungoose.kr).
+  It lets users link their Hometax joint certificate to the Chungoose console so that
+  electronic tax invoices can be collected and issued. Installs per-user (no administrator rights
+  required), runs in the background, and registers itself for automatic start at sign-in.
+Tags:
+- chungoose
+- hometax
+- e-tax
+- tax-invoice
+- certificate
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.yaml
+++ b/manifests/d/DevallCompany/ChungooseCertAgent/3.4.0/DevallCompany.ChungooseCertAgent.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DevallCompany.ChungooseCertAgent
+PackageVersion: 3.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (validated with `winget validate`; the same signed installer is already deployed to users via the vendor site)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/doc/ManifestSpecv1.12.md)?

Chungoose Certificate Agent (청구스 인증서 도우미) — a small per-user background helper (NSIS installer, Authenticode-signed by DEVALL COMPANY / Certum OV) that connects Korean NTS Hometax joint certificates to the Chungoose e-tax invoice console. Installer URL is version-pinned and immutable. Silent install via `/S`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429959)