### PR TITLE
New package: SubnetDesk.SubnetDesk version 1.3.0

### DIFF
--- a/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.installer.yaml
+++ b/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: SubnetDesk.SubnetDesk
+PackageVersion: 1.3.0
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Protocols:
+- subnetdesk
+ReleaseDate: 2026-08-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/zibo-chen/SubnetDesk/releases/download/v1.3.0/subnetdesk-1.3.0-x86_64.msi
+  InstallerSha256: D2469786C2A59ACCDE0E6323C88C856C8D5ABD80C1C4EFFF40FD363FD47A3F4
+  ProductCode: '{AF0652F1-9D9D-4460-B79A-7CA2E66F81CD}'
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 1.3.0.29797570
+    UpgradeCode: '{DC0E791C-3B4D-5A51-9AA8-629D81975868}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\SubnetDesk'
+- Architecture: arm64
+  InstallerUrl: https://github.com/zibo-chen/SubnetDesk/releases/download/v1.3.0/subnetdesk-1.3.0-aarch64.msi
+  InstallerSha256: 5079A39629A1BF359DBA61A6430FCB4E632464E5119BEE326B25AEC1AD37B202
+  ProductCode: '{CF5B569C-DB8F-4859-B524-D981B8A925DD}'
+  AppsAndFeaturesEntries:
+  - DisplayVersion: 1.3.0.29797574
+    UpgradeCode: '{DC0E791C-3B4D-5A51-9AA8-629D81975868}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\SubnetDesk'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.installer.yaml
+++ b/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.installer.yaml
@@ -11,7 +11,7 @@ ReleaseDate: 2026-08-27
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/zibo-chen/SubnetDesk/releases/download/v1.3.0/subnetdesk-1.3.0-x86_64.msi
-  InstallerSha256: D2469786C2A59ACCDE0E6323C88C856C8D5ABD80C1C4EFFF40FD363FD47A3F4
+  InstallerSha256: D2469786C2A59ACCD2E0E6323C88C856C8D5ABD80C1C4EFFF40FD363FD47A3F4
   ProductCode: '{AF0652F1-9D9D-4460-B79A-7CA2E66F81CD}'
   AppsAndFeaturesEntries:
   - DisplayVersion: 1.3.0.29797570

--- a/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.locale.en-US.yaml
+++ b/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: SubnetDesk.SubnetDesk
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: SubnetDesk
+PublisherUrl: https://github.com/zibo-chen
+PublisherSupportUrl: https://github.com/zibo-chen/SubnetDesk/issues
+Author: SubnetDesk contributors
+PackageName: SubnetDesk
+PackageUrl: https://github.com/zibo-chen/SubnetDesk
+License: AGPL-3.0
+LicenseUrl: https://github.com/zibo-chen/SubnetDesk/blob/master/LICENCE
+Copyright: Copyright © 2026 SubnetDesk contributors.
+ShortDescription: LAN/VPN-only remote desktop with direct endpoint connections.
+Description: SubnetDesk is a cross-platform remote desktop for devices that are already reachable through the same LAN, a routed private network, or a VPN. It connects directly by IP address or hostname and can discover nearby devices through mDNS, without a public rendezvous or relay service.
+Moniker: subnetdesk
+Tags:
+- flutter
+- lan
+- mdns
+- privacy
+- remote-access
+- remote-control
+- remote-desktop
+- rust
+- vpn
+ReleaseNotesUrl: https://github.com/zibo-chen/SubnetDesk/releases/tag/v1.3.0
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/zibo-chen/SubnetDesk#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.yaml
+++ b/manifests/s/SubnetDesk/SubnetDesk/1.3.0/SubnetDesk.SubnetDesk.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: SubnetDesk.SubnetDesk
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the SubnetDesk.SubnetDesk package at version 1.3.0 with x64 and ARM64 WiX/MSI installers from the project’s canonical GitHub release. Installer hashes, ProductCodes, UpgradeCode, embedded MSI display versions, scope, install location, and architecture were verified from the released files.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for SubnetDesk.SubnetDesk
- [x] This PR only modifies one manifest
- [ ] Validated locally with `winget validate` (not available on the macOS submission host)
- [ ] Tested locally with `winget install` (not available on the macOS submission host)
- [x] Manifest is authored against the 1.12 schema

The repository automation can perform the Windows-side installer validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429961)