### PR TITLE
New version: MitSoft.Signa version 1.3.2026.0831

### DIFF
--- a/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.installer.yaml
+++ b/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.installer.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MitSoft.Signa
+PackageVersion: 1.3.2026.0831
+InstallerLocale: lt-LT
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: '{1D2A2CA6-6FD5-4A72-A62A-B78F5C2B930B}'
+ReleaseDate: 2026-08-31
+AppsAndFeaturesEntries:
+- DisplayName: Signa 2010 (beta)
+  ProductCode: '{1D2A2CA6-6FD5-4A72-A62A-B78F5C2B930B}'
+  UpgradeCode: '{CEFBF7A8-9B30-4536-BCDC-78FC770DF6A5}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\Signa 2010 (beta)'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.mitsoft.lt/sites/mitsoft/files/Signa_v1.3_2026-08-31_lt_jre.msi
+  InstallerSha256: B19453E338F716BD532357BE9597918515C6A0D99461EBEFF2802F61AA680CE1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.locale.lt-LT.yaml
+++ b/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.locale.lt-LT.yaml
@@ -1,0 +1,14 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MitSoft.Signa
+PackageVersion: 1.3.2026.0831
+PackageLocale: lt-LT
+Publisher: MitSoft
+PublisherUrl: https://www.mitsoft.lt/lt
+PublisherSupportUrl: https://www.mitsoft.lt/kontaktai/
+PackageName: Signa 2010
+License: Proprietary, Freeware
+ShortDescription: Taikomoji programa, skirta oficialių elektroninių dokumentų, atitinkančių elektroniniu parašu pasirašyto elektroninio dokumento specifikacijos ADOC-V1.0 reikalavimus, sudarymui ir tikrinimui.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.yaml
+++ b/manifests/m/MitSoft/Signa/1.3.2026.0831/MitSoft.Signa.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MitSoft.Signa
+PackageVersion: 1.3.2026.0831
+DefaultLocale: lt-LT
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates MitSoft.Signa from 1.3.2025.0709 to the current stable release 1.3.2026.0831, published on the vendor's site 2026-08-31. The package has had no updates in winget for over a year (previous manifest is from July 2025) and has no bot coverage — it has historically only been kept current via manual community PRs.

- Installer downloaded directly from https://www.mitsoft.lt/sites/mitsoft/files/Signa_v1.3_2026-08-31_lt_jre.msi and hash verified independently via `Get-FileHash`/`sha256sum`.
- ProductCode/UpgradeCode extracted directly from the MSI via the Windows Installer COM API (`ProductVersion` in the MSI itself confirms 1.3.2026.0831). UpgradeCode is unchanged from the prior release; ProductCode changed as expected for a new MSI build.
- `winget validate` passes locally.

## Checklist

- [x] I've verified this is the newest version
- [x] I've checked there aren't other open pull requests for the same manifest change
- [x] I've validated the manifest locally with `winget validate --manifest <path>`
- [x] This PR only modifies one manifest
- [ ] I have used the [Manifest Creator tool](https://github.com/microsoft/winget-create#readme)
- [ ] I have tested and confirmed the changes in this PR by using the manifest with `winget install --manifest <path>`
- [ ] I have confirmed this PR is not a duplicate PR of #119145 and #119147
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429962)