### PR TITLE
New package: Cytoscape.Cytoscape version 3.10.4

### DIFF
--- a/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
+++ b/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
@@ -14,6 +14,9 @@ InstallerSwitches:
   InstallLocation: -dir "<INSTALLPATH>"
   Log: -Dinstall4j.log="<LOGPATH>"
 UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: EclipseAdoptium.Temurin.17.JRE
 ReleaseDate: 2025-09-26
 Installers:
 - Architecture: x64

--- a/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
+++ b/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
@@ -1,0 +1,23 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Cytoscape.Cytoscape
+PackageVersion: 3.10.4
+InstallerType: exe
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: -q -Dinstall4j.suppressUnattendedReboot=true
+  SilentWithProgress: -q -splash "" -Dinstall4j.suppressUnattendedReboot=true
+  InstallLocation: -dir "<INSTALLPATH>"
+  Log: -Dinstall4j.log="<LOGPATH>"
+UpgradeBehavior: install
+ReleaseDate: 2025-09-26
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cytoscape/cytoscape/releases/download/3.10.4/Cytoscape_3_10_4_windows_64bit.exe
+  InstallerSha256: 4BD1CE47281D5CA03EC3D90DE6A7BC03320A7F81DF81D2D6F0C5FEBBD7A4346B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
+++ b/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.installer.yaml
@@ -13,6 +13,10 @@ InstallerSwitches:
   SilentWithProgress: -q -splash "" -Dinstall4j.suppressUnattendedReboot=true
   InstallLocation: -dir "<INSTALLPATH>"
   Log: -Dinstall4j.log="<LOGPATH>"
+ExpectedReturnCodes:
+- InstallerReturnCode: 83
+  ReturnResponse: missingDependency
+  ReturnResponseUrl: https://www.ej-technologies.com/resources/install4j/help/doc/installers/errors.html
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:

--- a/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.locale.en-US.yaml
+++ b/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Cytoscape.Cytoscape
+PackageVersion: 3.10.4
+PackageLocale: en-US
+Publisher: Cytoscape Consortium
+PublisherUrl: https://cytoscape.org/
+PublisherSupportUrl: https://github.com/cytoscape/cytoscape/issues
+PackageName: Cytoscape
+PackageUrl: https://cytoscape.org/
+License: LGPL-2.1-only
+LicenseUrl: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+Copyright: Copyright (c) Cytoscape Consortium
+ShortDescription: Open source software platform for visualizing complex networks and integrating these with any type of attribute data
+Moniker: cytoscape
+Tags:
+- bioinformatics
+- data-visualization
+- graph
+- network-analysis
+- science
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.yaml
+++ b/manifests/c/Cytoscape/Cytoscape/3.10.4/Cytoscape.Cytoscape.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Cytoscape.Cytoscape
+PackageVersion: 3.10.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Cytoscape, an open-source Java platform for network visualization and analysis maintained by the Cytoscape Consortium (originally for bioinformatics/molecular interaction networks, now used generally for graph/network analysis). Not previously packaged in winget.

- Installer downloaded directly from the official GitHub release: https://github.com/cytoscape/cytoscape/releases/download/3.10.4/Cytoscape_3_10_4_windows_64bit.exe
- SHA256 verified independently and matches the project's own published `sha256sums.txt` for this release.
- Confirmed installer technology by inspecting the binary (embedded `.install4j` directory) and cross-checking against the project's own build docs, which state they use install4j to build Windows installers.
- Silent/SilentWithProgress switches follow the standard install4j pattern already used by other install4j-based packages in this repo (e.g. `DBVis.DBVisualizer`).
- `winget validate` passes locally.
- License: LGPL-2.1 (Cytoscape Core).

## Checklist

- [x] I've verified this is the newest version
- [x] I've checked there aren't other open pull requests for the same manifest change
- [x] I've validated the manifest locally with `winget validate --manifest <path>`
- [x] This PR only modifies one manifest
- [ ] I have used the [Manifest Creator tool](https://github.com/microsoft/winget-create#readme)
- [ ] I have tested and confirmed the changes in this PR by using the manifest with `winget install --manifest <path>`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429969)