### PR TITLE
Fix installer hash: kisChang.ZenSSH version 0.6.0

### DIFF
--- a/manifests/k/kisChang/ZenSSH/0.6.0/kisChang.ZenSSH.installer.yaml
+++ b/manifests/k/kisChang/ZenSSH/0.6.0/kisChang.ZenSSH.installer.yaml
@@ -10,7 +10,7 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/kisChang/ZenSSH/releases/download/v0.6.0/ZenSSH_0.6.0_windows_x64_setup.exe
-  InstallerSha256: 1458119D252129BEF0EB13D294831F4EDD8123751A35D0C4499C9CA44D902945
+  InstallerSha256: E668C22748184FCB7D3E95C09B2204164A6DD60949F5E1A1CC5978FF4BA958C0
   ProductCode: ZenSSH
   InstallationMetadata:
     DefaultInstallLocation: '%LocalAppData%\ZenSSH'
@@ -18,10 +18,10 @@ Installers:
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/kisChang/ZenSSH/releases/download/v0.6.0/ZenSSH_0.6.0_windows_x64.msi
-  InstallerSha256: 8F78EB916DE842AA801211A39FE9CDB492BE115126F8171547FCADED504C7F1B
+  InstallerSha256: 4A953C807A2B03B80055A1B8A0237AB0C3C51CFE9560F9FC4704C0436CD128D4
   InstallerSwitches:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
-  ProductCode: '{66A73905-30EF-4577-A084-1D016B8DC720}'
+  ProductCode: '{FE8ACC22-8E89-461B-A5E6-86F5F570622E}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{52ADD501-6EEF-5F2F-888F-0AB1747DE037}'
   InstallationMetadata:


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for kisChang.ZenSSH 0.6.0.

Upstream re-ran the v0.6.0 release on 2026-08-17 (tag moved from 6595783 to 32e919f, second release workflow at 06:30 UTC), which replaced both Windows assets after the manifest had hashed the first build. Both installers at the existing URLs are still version 0.6.0.

Changes:
- `ZenSSH_0.6.0_windows_x64_setup.exe`: SHA256 updated to the current file
- `ZenSSH_0.6.0_windows_x64.msi`: SHA256 updated to the current file; `ProductCode` updated to the one embedded in the current MSI (`{FE8ACC22-8E89-461B-A5E6-86F5F570622E}`), `UpgradeCode` is unchanged

Hashes were computed from the files downloaded from the manifest URLs. The bot PR #426288 for the same version only updates the setup.exe hash, so it fails on the MSI.

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas and the hashes were verified against the downloaded installers.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429992)