### PR TITLE
Fix installer hash: ghost-him.ZeroLaunch-rs version 0.5.2

### DIFF
--- a/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
+++ b/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
@@ -9,11 +9,11 @@ ReleaseDate: 2025-10-28
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_x64_en-US.msi
-  InstallerSha256: 2CE096B8B7E62C811E9E4FA545FFB091DB865985657B22BA9690486A473B4A11
-  ProductCode: '{22B73771-6D70-4A7C-8021-06F0BAA595EF}'
+  InstallerSha256: D4A4C2740BABA1EE36C5947FA23052CA8008AEC605AD75F0E3509F57CE7898F9
+  ProductCode: '{C13E3E40-8557-4DC0-8907-06467AC39018}'
 - Architecture: arm64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_arm64_en-US.msi
-  InstallerSha256: 671F852F583C8BDEBEF45A566C871BEC33B2FB3C1834308D06EEA434F1B0A92D
-  ProductCode: '{DA4BA608-0767-450A-A29B-DC996C036094}'
+  InstallerSha256: 2E6DF26A73C563548A86D169A2990F0BF06BEF01989A5D3BCE0D772222350939
+  ProductCode: '{29161859-5A55-4194-96DB-53C1C6E75C53}'
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
+++ b/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
@@ -10,16 +10,10 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_x64_en-US.msi
   InstallerSha256: D4A4C2740BABA1EE36C5947FA23052CA8008AEC605AD75F0E3509F57CE7898F9
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   ProductCode: '{C13E3E40-8557-4DC0-8907-06467AC39018}'
 - Architecture: arm64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_arm64_en-US.msi
   InstallerSha256: 2E6DF26A73C563548A86D169A2990F0BF06BEF01989A5D3BCE0D772222350939
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
   ProductCode: '{29161859-5A55-4194-96DB-53C1C6E75C53}'
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
+++ b/manifests/g/ghost-him/ZeroLaunch-rs/0.5.2/ghost-him.ZeroLaunch-rs.installer.yaml
@@ -10,10 +10,16 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_x64_en-US.msi
   InstallerSha256: D4A4C2740BABA1EE36C5947FA23052CA8008AEC605AD75F0E3509F57CE7898F9
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
   ProductCode: '{C13E3E40-8557-4DC0-8907-06467AC39018}'
 - Architecture: arm64
   InstallerUrl: https://github.com/ghost-him/ZeroLaunch-rs/releases/download/v0.5.2/zerolaunch-rs_0.5.2_arm64_en-US.msi
   InstallerSha256: 2E6DF26A73C563548A86D169A2990F0BF06BEF01989A5D3BCE0D772222350939
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
   ProductCode: '{29161859-5A55-4194-96DB-53C1C6E75C53}'
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description
The installers at the ZeroLaunch-rs 0.5.2 URLs were replaced when upstream re-created the release. The tag moved to commit 109717b ("fix release workflow logic"), and the current assets were uploaded on 2025-10-29 at 08:46 UTC, after the manifest had hashed an earlier build. Both MSIs still have ProductVersion 0.5.2.

Both hashes and ProductCodes now match the downloaded MSIs. The hashes were computed from those files and the ProductCodes read from their Property tables. The bot update in #423621 only fixes arm64, so it still fails on x64.

The installation check needs manual review. The original 0.5.2 submission (#307776) was merged with the same Validation-Executable-Error warning.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.10.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429995)