### PR TITLE
Fix installer hash: Okabe-Rintarou-0.SJTUCanvasHelper version 3.0.10

### DIFF
--- a/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/3.0.10/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
+++ b/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/3.0.10/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
@@ -10,28 +10,28 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.10/SJTU.Canvas.Helper_3.0.10_x86-setup.exe
-  InstallerSha256: 8CE7B8B4C2E39095F8565049D594DAF0433090ECAEC4C1461440CE50BE3D06F6
+  InstallerSha256: 359D8953E553676169A621F76B547DF9148366ACA89EE9F9D0000C9916E60D97
   ProductCode: SJTU Canvas Helper
 - Architecture: x64
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.10/SJTU.Canvas.Helper_3.0.10_x64-setup.exe
-  InstallerSha256: 16751EA717903BC4963A6D685C0A5AB1B40874D528474687633972C2496C80D5
+  InstallerSha256: 1A932DD36B8DFBD369C24637B999D790F878AF37FB681327C4A6E5C36A1B0994
   ProductCode: SJTU Canvas Helper
 - Architecture: x86
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.10/SJTU.Canvas.Helper_3.0.10_x86_en-US.msi
-  InstallerSha256: 716B1433B6577544E1D9A641257CF30123CDD952958EBCC7E21B456EFD30F4CA
-  ProductCode: '{247A4C88-E79B-40FA-B30E-779324B47635}'
+  InstallerSha256: AA6CABB4399B3705EC83964590DD789AFC72EAA82835EFA125CAA51C0AEC8CBE
+  ProductCode: '{85BDB740-67F5-4429-843F-A905D731072B}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 - Architecture: x64
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.10/SJTU.Canvas.Helper_3.0.10_x64_en-US.msi
-  InstallerSha256: 76B1A6A6DE0ABF0716B8BBF74810C85F0983FEC0AE2ED53B8FAEC798F879E783
-  ProductCode: '{E4AAFE2B-E4F2-468B-8F17-921630DA54EA}'
+  InstallerSha256: A02827B17D8640464BC0F900E3613310E2BF17A58DFBCE03799ED1FABFADA323
+  ProductCode: '{3961D941-7D2B-45BF-8A34-0A39EE16CE3D}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for Okabe-Rintarou-0.SJTUCanvasHelper 3.0.10.

Upstream's publish workflow for app-v3.0.10 failed on the tag commit (42c747c, 06:20 UTC) and was re-run from 1c8e8f7 (09:32 UTC). The assets now at the manifest URLs were uploaded 09:58 to 10:00 UTC on 2026-08-23, after the manifest had hashed the first upload. All four installers are still version 3.0.10.

Changes:
- both setup.exe installers: SHA256 updated to the current files
- both MSIs: SHA256 and `ProductCode` updated to the current files; `UpgradeCode` is unchanged

The bot PR #424975 for the same version only updates the two setup.exe installers, so it fails on the MSIs.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429996)