### PR TITLE
Fix installer hash: OpenLess.OpenLess version 1.3.10

### DIFF
--- a/manifests/o/OpenLess/OpenLess/1.3.10/OpenLess.OpenLess.installer.yaml
+++ b/manifests/o/OpenLess/OpenLess/1.3.10/OpenLess.OpenLess.installer.yaml
@@ -10,16 +10,16 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Open-Less/openless/releases/download/v1.3.10-tauri/OpenLess_1.3.10_x64-setup.exe
-  InstallerSha256: 0EC1F06C43F48B763CFB93A4EE787F588E0D58CB984D01AD012FD5C8F595E800
+  InstallerSha256: 4C9DABC713F94A7374588672BC5C211E262C022462ECE87D787B048CA13D9EC4
   ProductCode: OpenLess
 - Architecture: x64
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Open-Less/openless/releases/download/v1.3.10-tauri/OpenLess_1.3.10_x64_en-US.msi
-  InstallerSha256: F171B5EF1E120E8C038F78C8871475403BFFA9C57E75A347ED0BA778AD30A860
+  InstallerSha256: 814956A7E814AF60FA750F4AF166CF6686D50198A69117FBC12534D7A278D1B1
   InstallerSwitches:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
-  ProductCode: '{BA5529B1-DE75-4182-93C3-8EFAF0BD5B25}'
+  ProductCode: '{A0E21378-E0F2-4B0E-AD43-D06426F3A435}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{CA8062EF-C000-5953-BFB0-27B8F4AC4980}'
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for OpenLess.OpenLess 1.3.10.

The assets now at the manifest URLs were re-uploaded by upstream's release workflow on 2026-06-18 03:50 UTC, about 11 hours after the v1.3.10-tauri release was published (2026-06-17 16:41 UTC) and after the manifest had hashed the first upload. Both installers are still version 1.3.10.

Changes:
- `OpenLess_1.3.10_x64-setup.exe`: SHA256 updated to the current file
- `OpenLess_1.3.10_x64_en-US.msi`: SHA256 and `ProductCode` updated to the current file; `UpgradeCode` is unchanged

The bot PR #423706 for the same version only updates the setup.exe hash, so it fails on the MSI.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429997)