### PR TITLE
Fix installer hash: gg.ai.ggcode-desktop version 1.3.157

### DIFF
--- a/manifests/g/gg/ai/ggcode-desktop/1.3.157/gg.ai.ggcode-desktop.installer.yaml
+++ b/manifests/g/gg/ai/ggcode-desktop/1.3.157/gg.ai.ggcode-desktop.installer.yaml
@@ -16,32 +16,32 @@ InstallerSwitches:
   Silent: /qn
   SilentWithProgress: /qb
 UpgradeBehavior: install
-ProductCode: '{4D14CF69-39A3-42F4-805F-1CFEFCFB3666}'
+ProductCode: '{48C090E7-AD8D-4A6E-83A7-CCEB7B198961}'
 AppsAndFeaturesEntries:
 - DisplayName: GGCode Desktop
   Publisher: GG AI Studio
-  ProductCode: '{4D14CF69-39A3-42F4-805F-1CFEFCFB3666}'
+  ProductCode: '{48C090E7-AD8D-4A6E-83A7-CCEB7B198961}'
   UpgradeCode: '{D4E5F6A7-B8C9-0123-CDEF-345678901234}'
   InstallerType: wix
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/topcheer/ggcode/releases/download/v1.3.157/ggcode-desktop_1.3.157_windows_x64.msi
-  InstallerSha256: ED60FEF5A12C90B5A6954AFCB445658A42CDD997B88AA9FFBF40D8107095A077
-  ProductCode: '{4D14CF69-39A3-42F4-805F-1CFEFCFB3666}'
+  InstallerSha256: A597B15FCC6B61E781E515057159F92A81681E89CB935F5CE8A8E0A66FD4716D
+  ProductCode: '{48C090E7-AD8D-4A6E-83A7-CCEB7B198961}'
   AppsAndFeaturesEntries:
   - DisplayName: GGCode Desktop
     Publisher: GG AI Studio
-    ProductCode: '{4D14CF69-39A3-42F4-805F-1CFEFCFB3666}'
+    ProductCode: '{48C090E7-AD8D-4A6E-83A7-CCEB7B198961}'
     UpgradeCode: '{D4E5F6A7-B8C9-0123-CDEF-345678901234}'
     InstallerType: wix
 - Architecture: arm64
   InstallerUrl: https://github.com/topcheer/ggcode/releases/download/v1.3.157/ggcode-desktop_1.3.157_windows_arm64.msi
-  InstallerSha256: 9E5E247AFD27D07C83E11555E7293BBFD54BA928643917C1B85E28574073C731
-  ProductCode: '{5F8E5E73-D7EA-4DAB-A528-90D16D31D0F9}'
+  InstallerSha256: D2A7DA6F3F839D46ED56F0DB76D6D0145685EE14304A1DB00FD96C09114C947F
+  ProductCode: '{91707FBE-1A2E-4412-BA8C-DE862674355D}'
   AppsAndFeaturesEntries:
   - DisplayName: GGCode Desktop
     Publisher: GG AI Studio
-    ProductCode: '{5F8E5E73-D7EA-4DAB-A528-90D16D31D0F9}'
+    ProductCode: '{91707FBE-1A2E-4412-BA8C-DE862674355D}'
     UpgradeCode: '{D4E5F6A7-B8C9-0123-CDEF-345678901234}'
     InstallerType: wix
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for gg.ai.ggcode-desktop 1.3.157.

Upstream ran the v1.3.157 release twice on 2026-07-17 (03:04 UTC from 4aed3b8, then 04:27 UTC from 62b4eb9 after moving the tag). The assets now at the manifest URLs are from the second run (uploaded 04:42 UTC); the manifest had hashed the first build. Both MSIs are still ProductVersion 1.3.157.

Changes:
- x64 MSI: SHA256 and `ProductCode` updated to the current file (root default, installer entry and `AppsAndFeaturesEntries`)
- arm64 MSI: SHA256 and `ProductCode` updated to the current file (installer entry and `AppsAndFeaturesEntries`)
- `UpgradeCode` is unchanged

The bot PR #423628 for the same version only updates the arm64 installer, so it fails on x64.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/429998)