### PR TITLE
Fix installer hash: Okabe-Rintarou-0.SJTUCanvasHelper version 3.0.1

### DIFF
--- a/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/3.0.1/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
+++ b/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/3.0.1/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
@@ -10,31 +10,31 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.1/SJTU.Canvas.Helper_3.0.1_x86-setup.exe
-  InstallerSha256: 6A791DCA0A1702C5A3B52767C93EEA8986ECA5E1BFF6AAD8403B5A3BA723CCF4
+  InstallerSha256: 39EE2F18E9FCC22BDFA8221397507DDDE7AAEBA41BF296A2AD3295683334D119
   ProductCode: SJTU Canvas Helper
 - Architecture: x64
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.1/SJTU.Canvas.Helper_3.0.1_x64-setup.exe
-  InstallerSha256: 52A3436B6C22E1DD3969EC2C516DCBE81409D55ABDBC7F95B5A5F751A694386F
+  InstallerSha256: 96F10C459073489B4EBEAF04878CA4BA2295640D07D60A411ABDE8D7F1D88CE9
   ProductCode: SJTU Canvas Helper
 - Architecture: x86
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.1/SJTU.Canvas.Helper_3.0.1_x86_en-US.msi
-  InstallerSha256: B0903DDDE780067D7AD6FDEE56CC9D4802F3C29D55874C09C6D3B6EB30B2BE4A
-  ProductCode: '{88B09E8A-A9E3-4F75-8EF4-3A27FE4776EF}'
+  InstallerSha256: 42C9BA0ECA9D14253B1DCE39530DA067802796155318035BD94E71CB746B74F0
+  ProductCode: '{226DC75E-9482-411C-B51F-D5ADF1AA7B48}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{88B09E8A-A9E3-4F75-8EF4-3A27FE4776EF}'
+  - ProductCode: '{226DC75E-9482-411C-B51F-D5ADF1AA7B48}'
     UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 - Architecture: x64
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v3.0.1/SJTU.Canvas.Helper_3.0.1_x64_en-US.msi
-  InstallerSha256: 080E8BCDEB864DE56971E3D0B48BA7C85226B72F748489E9ECDDC652751CB40D
-  ProductCode: '{A670F946-2596-4780-BFC7-029D118DEBCC}'
+  InstallerSha256: E443336CAC903BCE786C0BB634A8CDB61B408A0DB92864126CBEEDDF336298AC
+  ProductCode: '{586BA9B7-87DB-4219-A074-FE2E5097BA41}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{A670F946-2596-4780-BFC7-029D118DEBCC}'
+  - ProductCode: '{586BA9B7-87DB-4219-A074-FE2E5097BA41}'
     UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for Okabe-Rintarou-0.SJTUCanvasHelper 3.0.1.

Upstream re-ran the publish workflow for app-v3.0.1 on 2026-04-15 (commit 7334f26, two days after the release was published on 2026-04-13). The assets now at the manifest URLs were uploaded 03:40 to 03:43 UTC that day, after the manifest had hashed the first upload. All four installers are still version 3.0.1.

Changes:
- both setup.exe installers: SHA256 updated to the current files
- both MSIs: SHA256 and `ProductCode` updated to the current files; `UpgradeCode` is unchanged

The bot PR #423691 for the same version fails on the same hash mismatch.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430000)