### PR TITLE
Fix installer hash: Okabe-Rintarou-0.SJTUCanvasHelper version 2.0.0

### DIFF
--- a/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/2.0.0/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
+++ b/manifests/o/Okabe-Rintarou-0/SJTUCanvasHelper/2.0.0/Okabe-Rintarou-0.SJTUCanvasHelper.installer.yaml
@@ -10,31 +10,31 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v2.0.0/SJTU.Canvas.Helper_2.0.0_x86-setup.exe
-  InstallerSha256: 67B12AB9114BBE0ADA15619443A4633766CCB8AA5E1BA1B7F5B0018C24B5FA1A
+  InstallerSha256: 4EAE771AC1DDEEAA5A50DC44806E8B01ADEBFBC8E8C8F95FFCF04163A423AC15
   ProductCode: SJTU Canvas Helper
 - Architecture: x64
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v2.0.0/SJTU.Canvas.Helper_2.0.0_x64-setup.exe
-  InstallerSha256: 3D36AF37B7E30AD151CAB89C62A4B5000672AAC4073F4A153A9A4672724A1F83
+  InstallerSha256: 1A19A88B5074521C636DF53CAF65D1A344C83A96C541E3E61BA079ACA24833FE
   ProductCode: SJTU Canvas Helper
 - Architecture: x86
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v2.0.0/SJTU.Canvas.Helper_2.0.0_x86_en-US.msi
-  InstallerSha256: E38256459A9ED04647F6A03191C3F6BAFAEEFB453674DE6EAD0225AB9E76C381
-  ProductCode: '{68B5FF0C-7ABF-4F6E-B550-2A464EA1D7C5}'
+  InstallerSha256: F7FA2FAF15C9EA93D9AC47F57CCCA38D51C69FEF9E312C26B13FA9123B469609
+  ProductCode: '{2B2C2F2E-1F5B-4729-BAB0-2C87DAE179FA}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{68B5FF0C-7ABF-4F6E-B550-2A464EA1D7C5}'
+  - ProductCode: '{2B2C2F2E-1F5B-4729-BAB0-2C87DAE179FA}'
     UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 - Architecture: x64
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/releases/download/app-v2.0.0/SJTU.Canvas.Helper_2.0.0_x64_en-US.msi
-  InstallerSha256: 60972A95FC871B2561CF017DC17EAFA85814C10103E498C04A3F588502250AC8
-  ProductCode: '{AE480752-ACA2-49BD-B4BB-47503F426D64}'
+  InstallerSha256: F8882ED97C8EBDC8391724CE74CFE042256CA482A7BBE31984ACADEB90489989
+  ProductCode: '{BE6C163E-609B-46F8-9E80-09BE4536D197}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{AE480752-ACA2-49BD-B4BB-47503F426D64}'
+  - ProductCode: '{BE6C163E-609B-46F8-9E80-09BE4536D197}'
     UpgradeCode: '{7D1805A0-A89C-54EF-B4AA-AAE673D794E0}'
 ManifestType: installer
 ManifestVersion: 1.10.0


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for Okabe-Rintarou-0.SJTUCanvasHelper 2.0.0.

The assets now at the manifest URLs were uploaded by upstream's publish workflow on 2025-10-14 (02:26 to 02:30 UTC), four days after the app-v2.0.0 release was published on 2025-10-10 and after the manifest had hashed the first upload. All four installers are still version 2.0.0.

Changes:
- both setup.exe installers: SHA256 updated to the current files
- both MSIs: SHA256 and `ProductCode` updated to the current files; `UpgradeCode` is unchanged

The bot PR #423688 for the same version fails on the same hash mismatch.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.10.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430001)