### PR TITLE
Fix installer hash: IvanCharapanau.Harbor version 0.3.28

### DIFF
--- a/manifests/i/IvanCharapanau/Harbor/0.3.28/IvanCharapanau.Harbor.installer.yaml
+++ b/manifests/i/IvanCharapanau/Harbor/0.3.28/IvanCharapanau.Harbor.installer.yaml
@@ -10,7 +10,7 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/av/harbor/releases/download/v0.3.28/Harbor_0.3.28_x64-setup.exe
-  InstallerSha256: A8B9384EFD7FD5E88498EA79745AA8AAF6EC0EC3883A51400290DD9F50372FB7
+  InstallerSha256: 4B5EF1DACBFC7FD8369E9B81E066ABA24B29EB67F3928E169864EECF55492DED
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.EdgeWebView2Runtime
@@ -19,10 +19,10 @@ Installers:
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/av/harbor/releases/download/v0.3.28/Harbor_0.3.28_x64_en-US.msi
-  InstallerSha256: 52101FAFF83D8D09315F86C95C6A60434BD603D32384DB2ECDD76C8D10A60515
+  InstallerSha256: 100DAB39886C2953BE9FCAEBB3B2976AC25384A9B35F417654A6C3734E75A2B2
   InstallerSwitches:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
-  ProductCode: '{03A019D7-E6CE-4AC2-95E0-D4DD72C08D95}'
+  ProductCode: '{27D154A7-77DF-4401-916C-712BFB9BA9F2}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{8389C8AD-7952-5AB4-B907-63255087F027}'
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for IvanCharapanau.Harbor 0.3.28.

The assets now at the manifest URLs were re-uploaded by upstream's release workflow on 2025-12-16 22:31 UTC, two days after the v0.3.28 release was published (2025-12-14) and after the manifest had hashed the first upload. Both installers are still version 0.3.28.

Changes:
- `Harbor_0.3.28_x64-setup.exe`: SHA256 updated to the current file
- `Harbor_0.3.28_x64_en-US.msi`: SHA256 and `ProductCode` updated to the current file; `UpgradeCode` is unchanged

The bot PR #423544 for the same version only updates the setup.exe hash, so it fails on the MSI.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430004)