### PR TITLE
Fix installer hash: AnInsomniacy.MotrixNext version 3.9.4

### DIFF
--- a/manifests/a/AnInsomniacy/MotrixNext/3.9.4/AnInsomniacy.MotrixNext.installer.yaml
+++ b/manifests/a/AnInsomniacy/MotrixNext/3.9.4/AnInsomniacy.MotrixNext.installer.yaml
@@ -18,9 +18,9 @@ ReleaseDate: 2026-06-07
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.4/MotrixNext_3.9.4_x64-setup.exe
-  InstallerSha256: 80481D1E3141138138896AC74B9995D3D22D775E98C401DF1F525C76C910BF42
+  InstallerSha256: 5CB0483478262CBB99AFA77617B9F05F001F02C89DB1B08589AD5ECCD053CFD7
 - Architecture: arm64
   InstallerUrl: https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.4/MotrixNext_3.9.4_arm64-setup.exe
-  InstallerSha256: A8A2C55B78188158380EDB3B795377E0E9743E7EDDCB6AD9A1B6CC73A1D53F60
+  InstallerSha256: 6B4E8BF7BCEFEC41AC5AC8675A10291D99F2904C0E7203C6BCA14B8325BD6AD2
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for AnInsomniacy.MotrixNext 3.9.4.

Upstream replaced both Windows installers on 2026-06-09 03:44 UTC through its "SignPath Windows Release" workflow (run at 03:41), two days after the v3.9.4 release was published and after the manifest had hashed the first upload. Both installers are still version 3.9.4 (file version resource).

Changes:
- `MotrixNext_3.9.4_x64-setup.exe` and `MotrixNext_3.9.4_arm64-setup.exe`: SHA256 updated to the current files

The bot PR #423536 for the same version only updates the x64 hash, so it fails on arm64.

Hashes were computed from the files downloaded from the manifest URLs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430005)