### PR TITLE
Fix installer hash: AnInsomniacy.MotrixNext version 3.9.0

### DIFF
--- a/manifests/a/AnInsomniacy/MotrixNext/3.9.0/AnInsomniacy.MotrixNext.installer.yaml
+++ b/manifests/a/AnInsomniacy/MotrixNext/3.9.0/AnInsomniacy.MotrixNext.installer.yaml
@@ -18,9 +18,9 @@ ReleaseDate: 2026-05-21
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.0/MotrixNext_3.9.0_x64-setup.exe
-  InstallerSha256: 5A6DAEC0AC70CCEDA0FB88571BF8C35C27113FD3FAD0B880F284304CF2B54EE5
+  InstallerSha256: 7E36F0429C605EA7843B527CA85FD3B71A7008212602A4923B25573B3339A35A
 - Architecture: arm64
   InstallerUrl: https://github.com/AnInsomniacy/motrix-next/releases/download/v3.9.0/MotrixNext_3.9.0_arm64-setup.exe
-  InstallerSha256: 1579F7FF576D175CBFDE4CF682EBCBC1FF34F739B5B8007F8CF57B3893E7EBCF
+  InstallerSha256: 5127F5435AA3BF56435F4678DCF5DF895090899E244CF26CBFDE27B318ABD579
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for AnInsomniacy.MotrixNext 3.9.0.

Upstream replaced both Windows installers on 2026-05-23 04:36 UTC through its "SignPath Windows Release" workflow (run at 04:32), two days after the v3.9.0 release was published and after the manifest had hashed the first upload. Both installers are still version 3.9.0 (file version resource).

Changes:
- `MotrixNext_3.9.0_x64-setup.exe` and `MotrixNext_3.9.0_arm64-setup.exe`: SHA256 updated to the current files

The bot PR #423532 for the same version only updates the x64 hash, so it fails on arm64.

Hashes were computed from the files downloaded from the manifest URLs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430006)