### PR TITLE
Fix installer hash: codexu.NoteGen version 0.30.0

### DIFF
--- a/manifests/c/codexu/NoteGen/0.30.0/codexu.NoteGen.installer.yaml
+++ b/manifests/c/codexu/NoteGen/0.30.0/codexu.NoteGen.installer.yaml
@@ -10,16 +10,16 @@ Installers:
   InstallerType: nullsoft
   Scope: user
   InstallerUrl: https://github.com/codexu/note-gen/releases/download/note-gen-v0.30.0/NoteGen_0.30.0_x64-setup.exe
-  InstallerSha256: BD2C8970FE6D675B5195F90794EFDC0D7A6413718A969AE65B42BE84F5807F86
+  InstallerSha256: E99104E8739961982179D33641DEC1265FD29C902DC9364C94DB66641882FA94
   ProductCode: NoteGen
 - Architecture: x64
   InstallerType: wix
   Scope: machine
   InstallerUrl: https://github.com/codexu/note-gen/releases/download/note-gen-v0.30.0/NoteGen_0.30.0_x64_en-US.msi
-  InstallerSha256: 4BD9D2F54BE924111E110FE276FDD624AC159B660DC32D7FF536EF9A01C4B420
+  InstallerSha256: 62E874AF5A3C219624F031570C3F596B6C6AFCD2A5D442A582EFD5EF9727C904
   InstallerSwitches:
     InstallLocation: INSTALLDIR="<INSTALLPATH>"
-  ProductCode: '{4A1BA6D4-1184-4A37-A1AE-9B4893C228DA}'
+  ProductCode: '{08E3FABB-4E7D-4246-8224-3B91512FF8E5}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{E353DB5D-25D7-5FA9-B7DC-C4BC524A075E}'
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for codexu.NoteGen 0.30.0.

Upstream ran the publish workflow for note-gen-v0.30.0 twice on 2026-06-22 (01:07 UTC from the tag commit 0b6ef9b, then 02:14 UTC from 3a77551). The assets now at the manifest URLs are from the second run (uploaded 02:31 UTC); the manifest had hashed the first build. Both installers are still version 0.30.0.

Changes:
- `NoteGen_0.30.0_x64-setup.exe`: SHA256 updated to the current file
- `NoteGen_0.30.0_x64_en-US.msi`: SHA256 and `ProductCode` updated to the current file; `UpgradeCode` is unchanged

The bot PR #423524 for the same version only updates the setup.exe hash, so it fails on the MSI.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430007)