### PR TITLE
Fix installer hash: AdamGell.CMTraceOpen version 1.5.2

### DIFF
--- a/manifests/a/AdamGell/CMTraceOpen/1.5.2/AdamGell.CMTraceOpen.installer.yaml
+++ b/manifests/a/AdamGell/CMTraceOpen/1.5.2/AdamGell.CMTraceOpen.installer.yaml
@@ -8,20 +8,20 @@ Installers:
 - Architecture: x64
   InstallerType: portable
   InstallerUrl: https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_x64.exe
-  InstallerSha256: AA1239BB708179C58D4011DECBBE41B33D26BDF4F7D6424986EE69A15ABD5007
+  InstallerSha256: B052B2C6CC3DAD05284326B141DD2102AE7CD515269278F324289D1949B2D921
 - Architecture: arm64
   InstallerType: portable
   InstallerUrl: https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_arm64.exe
-  InstallerSha256: 5C9CA8F41834C0BF8F14B4B7BC294EF17014E71651FDAD9708A8A514CE9541AE
+  InstallerSha256: D70922BFBC8E77ED0FF029ECDCF764AE023E8A57611BB857DDBC15B2B1F27C63
 - InstallerLocale: und
   Architecture: x64
   InstallerType: msi
   Scope: machine
   InstallerUrl: https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_x64.msi
-  InstallerSha256: 0B08C9A94FB5E2AFB6B20F5349562C5382FC4EF56E93163A278AF38C99E723CD
-  ProductCode: '{F86B8EC0-24D1-4B31-84B0-4532BAE71D15}'
+  InstallerSha256: 6986DD46D43A6F2AAABA551729535DA6F5781491B4F076BBD59CBFDD3465B17C
+  ProductCode: '{B27C1E69-C71B-494B-A5EF-27471DEA54E2}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{F86B8EC0-24D1-4B31-84B0-4532BAE71D15}'
+  - ProductCode: '{B27C1E69-C71B-494B-A5EF-27471DEA54E2}'
     UpgradeCode: '{E8F1A3B7-5C2D-4F6E-9A8B-1D3E5F7A9C2B}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%/CMTrace Open'
@@ -30,10 +30,10 @@ Installers:
   InstallerType: msi
   Scope: machine
   InstallerUrl: https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_arm64.msi
-  InstallerSha256: 51CA2AD2C3AAF0D8EBC627211B80A48898C1297710E9636C78FD900E5292E2E9
-  ProductCode: '{37ED64AC-B11F-46F9-9C7F-05E13075F27A}'
+  InstallerSha256: C3E791C9106DE20BCAA7DAB627EDB9B7098EBB7813D535325FB934D62B99E364
+  ProductCode: '{5073BEC8-606B-4906-B2F9-BF649B6F1AB8}'
   AppsAndFeaturesEntries:
-  - ProductCode: '{37ED64AC-B11F-46F9-9C7F-05E13075F27A}'
+  - ProductCode: '{5073BEC8-606B-4906-B2F9-BF649B6F1AB8}'
     UpgradeCode: '{E8F1A3B7-5C2D-4F6E-9A8B-1D3E5F7A9C2B}'
   InstallationMetadata:
     DefaultInstallLocation: '%ProgramFiles%/CMTrace Open'


### PR DESCRIPTION
## 📖 Description
Fix the installer hashes for AdamGell.CMTraceOpen 1.5.2.

All four assets at the manifest URLs were re-uploaded by upstream on 2026-08-13 19:06 UTC, two days after the v1.5.2 release was published (2026-08-11) and after the manifest had hashed the first upload. All four files are still version 1.5.2.

Changes:
- both portable executables: SHA256 updated to the current files
- both MSIs: SHA256 and `ProductCode` updated to the current files (installer entry and `AppsAndFeaturesEntries`); `UpgradeCode` is unchanged

The bot PR #423490 for the same version does not update the x64 portable executable, so it fails on that installer.

Hashes were computed from the files downloaded from the manifest URLs; ProductCodes were read from the Property table of the downloaded MSIs.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430008)