### PR TITLE
New version: Microsoft.VSDotNetLogCollect version 18.0.12127.99

### DIFF
--- a/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.installer.yaml
+++ b/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VSDotNetLogCollect
+PackageVersion: 18.0.12127.99
+InstallerType: portable
+Commands:
+- vsdotnetlogcollect
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.microsoft.com/download/8/3/4/834e83f6-c377-4dce-a757-69a418b6c6df/Collect.exe
+  InstallerSha256: C0466D681BB619A4712DF601F1602D444D02EAD3EEAAF89372D37C1D9A7E9E43
+ReleaseDate: 2026-09-02
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VSDotNetLogCollect
+PackageVersion: 18.0.12127.99
+PackageLocale: en-US
+Publisher: Microsoft
+PackageName: Microsoft Visual Studio/.NET Log Collection Tool
+PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=12493
+License: Proprietary
+Copyright: © Microsoft Corporation. All rights reserved.
+ShortDescription: Collect information from Microsoft Visual Studio and .NET installations, for instance for when contacting Microsoft's Visual Studio customer service.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.yaml
+++ b/manifests/m/Microsoft/VSDotNetLogCollect/18.0.12127.99/Microsoft.VSDotNetLogCollect.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.VSDotNetLogCollect
+PackageVersion: 18.0.12127.99
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version: Microsoft.VSDotNetLogCollect 18.0.12127.99.

The file at the existing download URL was updated on 2026-09-02 (Last-Modified header). Its version resource reports ProductVersion 18.0.12127.99; the FileVersion string is "18.0.12127.99 built by: stable", which is why the bot PR #429848 proposed an invalid PackageVersion. This manifest uses 18.0.12127.99 and the SHA256 of the current file. The manifest set is otherwise the same as 17.0.35214.149, moved to schema 1.12.0, with ReleaseDate set from the file's Last-Modified date.

Note: the download URL is not version-specific, so the 17.0.35214.149 manifest no longer matches the file it points to.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas; the hash and version were read from the downloaded file.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430011)