### PR TITLE
New version: AllroundAutomations.PLSQLDeveloper version 17.0.0.2241

### DIFF
--- a/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.installer.yaml
+++ b/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AllroundAutomations.PLSQLDeveloper
+PackageVersion: 17.0.0.2241
+InstallerLocale: en-US
+InstallerType: msi
+Scope: machine
+ProductCode: '{40BBB120-D6C0-463D-A4C4-071287C87D51}'
+ReleaseDate: 2026-08-26
+AppsAndFeaturesEntries:
+- DisplayName: PL/SQL Developer 17 (64 bit)
+  ProductCode: '{40BBB120-D6C0-463D-A4C4-071287C87D51}'
+  UpgradeCode: '{32D1C907-182D-4D80-8F22-4F8D56E62078}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\PLSQL Developer 17'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.allroundautomations.com/files/plsqldev1700x64.msi
+  InstallerSha256: 268E3DDEFD9C259A3A46A7EFA8446AFFC25190344FA7A59C4F8CE8033A7D89E3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.locale.en-US.yaml
+++ b/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AllroundAutomations.PLSQLDeveloper
+PackageVersion: 17.0.0.2241
+PackageLocale: en-US
+Publisher: Allround Automations
+PublisherUrl: https://www.allroundautomations.com/
+PublisherSupportUrl: https://www.allroundautomations.com/support/
+PrivacyUrl: https://www.allroundautomations.com/privacy-policy/
+Author: Allround Automations
+PackageName: PL/SQL Developer
+PackageUrl: https://www.allroundautomations.com/products/pl-sql-developer/
+License: Proprietary
+LicenseUrl: https://www.allroundautomations.com/license-terms/
+Copyright: © 2023 Allround Automations
+ShortDescription: 3rd Party ORACLE Database Development Tool
+Description: PL/SQL Developer is an Integrated Development Environment for developing, testing, debugging and optimizing Oracle PL/SQL stored program units like packages, triggers and so on. PL/SQL Developer features context sensitive help and database object descriptions, syntax highlighting, data querying and editing, a graphical browser, and other functions to make a developer’s life easier.
+Moniker: plsql-developer
+Tags:
+- allround
+- oracle
+- pl/sql
+- plsql
+- sql
+PurchaseUrl: https://www.allroundautomations.com/order/
+InstallationNotes: |-
+  The PL/SQL Developer trial version is fully functional and has all the features
+  you'll find in the registered version. It is only limited by a trial period of 30 days.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.yaml
+++ b/manifests/a/AllroundAutomations/PLSQLDeveloper/17.0.0.2241/AllroundAutomations.PLSQLDeveloper.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AllroundAutomations.PLSQLDeveloper
+PackageVersion: 17.0.0.2241
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version: AllroundAutomations.PLSQLDeveloper 17.0.0.2241.

PL/SQL Developer 17 is currently missing from the repository: 17.0.0 (#424326) was removed again by #424830 the same day, and the bot's replacement PR #424829 has been failing validation since 2026-08-26. That PR carries a `ProductCode` (`{CA93B22B-…}`) that does not match the current MSI.

Values in this manifest were read from the file at the installer URL (Last-Modified 2026-08-26):
- SHA256 `268E3DDE…` (same as the bot PR)
- MSI ProductVersion 17.0.0.2241, ProductName "PL/SQL Developer 17 (64 bit)"
- ProductCode `{40BBB120-D6C0-463D-A4C4-071287C87D51}`, UpgradeCode `{32D1C907-182D-4D80-8F22-4F8D56E62078}`

The manifest set follows 16.0.8.2176. `DisplayVersion` is not set because PackageVersion equals the MSI ProductVersion. `DefaultInstallLocation` was read from the MSI Directory table: the app folder `PLSQL Developer 17` is under the 32-bit Program Files folder and `plsqldev.exe` sits directly in it. The 16.x manifests carry a malformed value for this field, which was not copied.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schemas; hash and MSI properties were read from the downloaded installer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430013)
