### PR TITLE
New package: ToolsMonk.ToolsMonk version 1.1.18

### DIFF
--- a/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.installer.yaml
+++ b/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ToolsMonk.ToolsMonk
+PackageVersion: 1.1.12
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vksingh5995/toolsmonk-releases/releases/download/v1.1.12/ToolsMonk-Setup-1.1.12.exe
+  InstallerSha256: 83A6AEC9DB968A7C235C57C9E3A071A9C3689F34C47E578C23C70DB4BD6BDCA2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.locale.en-US.yaml
+++ b/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ToolsMonk.ToolsMonk
+PackageVersion: 1.1.12
+PackageLocale: en-US
+Publisher: ToolsMonk
+PublisherUrl: https://toolsmonk.com
+PublisherSupportUrl: https://toolsmonk.com/contact
+PrivacyUrl: https://toolsmonk.com/privacy-policy
+Author: ToolsMonk
+PackageName: ToolsMonk
+PackageUrl: https://toolsmonk.com
+License: Proprietary
+LicenseUrl: https://toolsmonk.com/terms-of-service
+Copyright: Copyright (c) 2026 ToolsMonk
+ShortDescription: 250+ tools for PDFs, images, text, SEO and everyday calculations, in one desktop app.
+Description: |-
+  ToolsMonk is a Windows desktop app that puts a large, practical toolbox in one window: PDFs, images, text, SEO checks and everyday calculations.
+
+  Most tools run entirely on your device. You pick a file, it is processed locally, and it never leaves your computer. A smaller number genuinely need a server, such as the AI features and the tools that fetch a page from the web. The app says which is which on the tool itself, and the full list is published at https://toolsmonk.com/where-your-files-are-processed
+
+  PDF: edit, merge, split, compress, sign, redact, fill forms, and convert to and from Word, Excel, PowerPoint, images and plain text. Images: resize, crop, compress, convert, upscale, remove backgrounds, and a layered photo editor. Plus text, developer, SEO and calculator tools.
+
+  The app installs into your own user profile and needs no administrator rights.
+Moniker: toolsmonk
+Tags:
+- calculator
+- converter
+- image-editor
+- pdf
+- pdf-editor
+- productivity
+- seo
+- text
+ReleaseNotesUrl: https://github.com/vksingh5995/toolsmonk-releases/releases/tag/v1.1.12
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.yaml
+++ b/manifests/t/ToolsMonk/ToolsMonk/1.1.12/ToolsMonk.ToolsMonk.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ToolsMonk.ToolsMonk
+PackageVersion: 1.1.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **ToolsMonk.ToolsMonk** version **1.1.12**.

ToolsMonk is a Windows desktop app (Electron) with 250+ tools for PDFs, images, text, SEO checks and everyday calculations. Most tools run entirely on the user's device; the ones that use a server are listed publicly at https://toolsmonk.com/where-your-files-are-processed

- Publisher site: https://toolsmonk.com
- Installer: NSIS, x64, **per-user** (`Scope: user`, installs under `%LOCALAPPDATA%\Programs`, no elevation)
- Installer URL is the GitHub release asset that the publisher's own site redirects to from https://toolsmonk.com/download/windows

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (result: `Manifest validation succeeded.`, winget v1.29.290)
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Notes on the unchecked boxes

- **CLA:** not yet signed at the time of opening. Will sign when the policy bot prompts.
- **`winget install --manifest`:** not run, so this is stated rather than claimed. `winget validate` passed, and the `InstallerSha256` was verified by downloading the release asset and hashing it (`83A6AEC9DB968A7C235C57C9E3A071A9C3689F34C47E578C23C70DB4BD6BDCA2`, 111,651,910 bytes).
- The installer is **not code signed**. It is a per-user NSIS installer and supports `/S`, so silent install works.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430042)