### PR TITLE
New package: FiredMosquito831.MyClaudeCode version 7.13.1

### DIFF
--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.installer.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.installer.yaml
@@ -1,0 +1,21 @@
+# Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: FiredMosquito831.MyClaudeCode
+PackageVersion: 6.45.2
+Installers:
+  - Architecture: x64
+    InstallerType: inno
+    Scope: user
+    InstallerUrl: https://github.com/FiredMosquito831/my-claude-code/releases/download/v6.45.2/MyClaudeCode-Setup-windows-x86_64.exe
+    InstallerSha256: FB78D8505AE2659BBBEDEDB81E759A38FE65310CEFFF282236B21C9980DBFF8F
+    ProductCode: '{5FC8D5C3-33F7-4366-AD8D-C844D21BC089}_is1'
+    AppsAndFeaturesEntries:
+      - DisplayName: My Claude Code (desktop app)
+        DisplayVersion: 6.45.2
+        Publisher: My Claude Code
+        ProductCode: '{5FC8D5C3-33F7-4366-AD8D-C844D21BC089}_is1'
+        InstallerType: inno
+    ReleaseDate: 2026-09-04
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.installer.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.installer.yaml
@@ -1,5 +1,5 @@
 # Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: FiredMosquito831.MyClaudeCode
 PackageVersion: 6.45.2
@@ -18,4 +18,4 @@ Installers:
         InstallerType: inno
     ReleaseDate: 2026-09-04
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.locale.en-US.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: FiredMosquito831.MyClaudeCode
+PackageVersion: 6.45.2
+PackageLocale: en-US
+Publisher: FiredMosquito831
+PublisherUrl: https://github.com/FiredMosquito831
+PublisherSupportUrl: https://github.com/FiredMosquito831/my-claude-code/issues
+Author: FiredMosquito831
+PackageName: My Claude Code
+PackageUrl: https://github.com/FiredMosquito831/my-claude-code
+License: AGPL-3.0-or-later AND MIT
+LicenseUrl: https://github.com/FiredMosquito831/my-claude-code/blob/main/LICENSE
+Copyright: Copyright (c) 2026 FiredMosquito831
+CopyrightUrl: https://github.com/FiredMosquito831/my-claude-code/blob/main/LICENSE
+ShortDescription: A desktop window onto the My Claude Code dashboard; it installs and starts the server for you.
+Description: >-
+  My Claude Code is a local proxy that connects coding agents -- Claude Code, Codex, Gemini CLI and
+  a dozen others -- to OpenAI-compatible AI providers, with routing, fallback, rate-limit handling
+  and a web dashboard on 127.0.0.1:8082.
+
+  This package installs the desktop app: a small native window that renders that dashboard and puts
+  an icon in the tray. It carries no Python, no server and no configuration. On first launch, if the
+  server is not installed yet, the window shows you the exact install command and runs it in front
+  of you, then starts the server and loads the dashboard.
+
+  It installs per user, needs no administrator rights, and uninstalling it removes the window and
+  nothing else -- your configuration, your keys and the mcc-server command are left alone.
+Moniker: my-claude-code
+Tags:
+  - ai
+  - claude
+  - coding-agent
+  - dashboard
+  - developer-tools
+  - gateway
+  - llm
+  - openai-compatible
+  - proxy
+ReleaseNotesUrl: https://github.com/FiredMosquito831/my-claude-code/releases/tag/v6.45.2
+Documentations:
+  - DocumentLabel: Usage
+    DocumentUrl: https://github.com/FiredMosquito831/my-claude-code/blob/main/docs/USAGE.md
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.locale.en-US.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: FiredMosquito831.MyClaudeCode
 PackageVersion: 6.45.2
@@ -43,4 +43,4 @@ Documentations:
   - DocumentLabel: Usage
     DocumentUrl: https://github.com/FiredMosquito831/my-claude-code/blob/main/docs/USAGE.md
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.yaml
@@ -1,0 +1,8 @@
+# Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: FiredMosquito831.MyClaudeCode
+PackageVersion: 6.45.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.yaml
+++ b/manifests/f/FiredMosquito831/MyClaudeCode/6.45.2/FiredMosquito831.MyClaudeCode.yaml
@@ -1,8 +1,8 @@
 # Rendered by desktop-shell/installer/winget/render.py -- do not edit by hand.
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: FiredMosquito831.MyClaudeCode
 PackageVersion: 6.45.2
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package

`FiredMosquito831.MyClaudeCode` 6.45.2 — the My Claude Code desktop app, a small native window (~3.5 MB installed) onto the dashboard the project's local server already serves on 127.0.0.1.

Homepage: https://github.com/FiredMosquito831/my-claude-code
Installer: https://github.com/FiredMosquito831/my-claude-code/releases/download/v6.45.2/MyClaudeCode-Setup-windows-x86_64.exe

### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? — **not yet; will sign when the CLA bot posts the link.** Left honestly unchecked rather than pre-ticked.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

### Notes for the reviewer

- **Per-user Inno Setup installer**, `PrivilegesRequired=lowest`. `Scope: user`; there is no machine-scope installer to offer.
- **Silent install and silent uninstall both verified**, using the default Inno switches winget supplies (`/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART`) and the registered `QuietUninstallString`. No `InstallerSwitches` block is present because none is needed.
- **`AppsAndFeaturesEntries` mirrors the registry exactly**: the installer's `AppId` is fixed forever, so the uninstall key is always `{5FC8D5C3-33F7-4366-AD8D-C844D21BC089}_is1`. With the app installed, `winget list` reports the package as `ARP\User\X64\{5FC8D5C3-33F7-4366-AD8D-C844D21BC089}_is1`.
- **Uninstall leaves nothing behind.** `HKCU\…\Uninstall`, `HKCU\…\Run`, both Start Menu Programs trees, `%LOCALAPPDATA%\Programs` and `~/.local/bin` were snapshotted before install and diffed after uninstall; all five diffs were empty.
- **The installer is unsigned and will remain so.** SmartScreen shows its reputation warning on first run; this is documented in the project's README rather than papered over. The package carries no `Commands`, because the installer deliberately puts nothing on `PATH`.
- **`InstallerSha256` re-verified against the live release asset immediately before opening this PR** — `FB78D850…DBFF8F`, matching byte for byte.
- The manifests are generated from the release by [`desktop-shell/installer/winget/render.py`](https://github.com/FiredMosquito831/my-claude-code/blob/main/desktop-shell/installer/winget/render.py) in the source repository, and a test there asserts the committed copies are byte-for-byte what it produces.

Validation environment: winget v1.29.290 on Windows 11 build 26100.
