### PR TITLE
Update: WardianApp.Wardian to 0.6.0

### DIFF
--- a/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.installer.yaml
+++ b/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WardianApp.Wardian
+PackageVersion: 0.6.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wardian-app/Wardian/releases/download/v0.6.0/Wardian_0.6.0_x64-setup.exe
+  InstallerSha256: CEEA2B0C6764B421D7BD9A4CFA1D2AE111FBB384B06E81AE2EBBD05ED0E9AFF9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.locale.en-US.yaml
+++ b/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WardianApp.Wardian
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: Wardian App
+PublisherUrl: https://wardian.org
+PublisherSupportUrl: https://github.com/wardian-app/Wardian/issues
+Author: Wardian App
+PackageName: Wardian
+PackageUrl: https://wardian.org
+License: MIT
+ShortDescription: Where local agent work becomes visible, durable, and malleable.
+Description: Wardian runs CLI agents across all your workspaces, keeps their sessions and evidence visible, and turns successful work into reusable prompts, skills, classes, automations, and project context.
+Tags:
+- ai
+- agents
+- cli
+- tauri
+ReleaseNotesUrl: https://github.com/wardian-app/Wardian/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.yaml
+++ b/manifests/w/WardianApp/Wardian/0.6.0/WardianApp.Wardian.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WardianApp.Wardian
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds `WardianApp.Wardian` version 0.6.0.

Wardian 0.6.0 was published as a stable GitHub Release on 2026-09-05:
https://github.com/wardian-app/Wardian/releases/tag/v0.6.0

- Installer: `Wardian_0.6.0_x64-setup.exe` (NSIS, x64), served from the tagged release asset URL.
- `InstallerSha256` was verified against a fresh download of the published asset.
- Manifests were moved from schema 1.10.0 to 1.12.0 to match the current schema version.
- `ShortDescription` and `Description` were refreshed to the project's current wording, and `ReleaseNotesUrl` / `ReleaseDate` were added. Installer type, install modes, silent switches, and upgrade behavior are unchanged from 0.5.3.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430063)