### PR TITLE
New package: PDFMarin.PDFMarin version 0.1.2

### DIFF
--- a/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.installer.yaml
+++ b/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: PDFMarin.PDFMarin
+PackageVersion: 0.1.2
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-05
+ProductCode: c047670e-e7e7-506a-9ff5-19d3318f6c22
+AppsAndFeaturesEntries:
+- DisplayName: PDF MARIN
+  DisplayVersion: 0.1.2
+  ProductCode: c047670e-e7e7-506a-9ff5-19d3318f6c22
+  InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/pdf-marin/pdf-marin.github.io/releases/download/v0.1.2/PDF-MARIN-Setup-0.1.2.exe
+  InstallerSha256: 145C57914DB4368A060BC3B632DFC793B191046B33B8E066EE764345FAD6D7D7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.locale.en-US.yaml
+++ b/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: PDFMarin.PDFMarin
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: PDF MARIN
+PublisherUrl: https://pdf-marin.github.io/
+PublisherSupportUrl: https://pdf-marin.github.io/#report
+PackageName: PDF MARIN
+PackageUrl: https://pdf-marin.github.io/
+License: Proprietary
+LicenseUrl: https://pdf-marin.github.io/terms.html
+PrivacyUrl: https://pdf-marin.github.io/terms.html
+Copyright: PDF MARIN
+ShortDescription: A free PDF editor for Windows with true redaction that removes the pixels, plus page editing, drawing measurement, watermarks, page numbers, passwords and compression.
+Description: |-
+  PDF MARIN is a free desktop PDF editor for Windows. It redacts text and images by
+  removing the underlying content rather than drawing a black box over it, and it can
+  extract, reorder, rotate and merge pages, measure dimensions on drawings with a
+  calibrated scale, add watermarks and page numbers, set or remove passwords, and
+  compress files. The user interface is in Japanese.
+Moniker: pdf-marin
+Tags:
+- pdf
+- pdf-editor
+- redaction
+- redact
+- merge
+- split
+- watermark
+- page-numbers
+- password
+- viewer
+- editor
+- japanese
+ReleaseNotesUrl: https://github.com/pdf-marin/pdf-marin.github.io/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.locale.ja-JP.yaml
+++ b/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.locale.ja-JP.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: PDFMarin.PDFMarin
+PackageVersion: 0.1.2
+PackageLocale: ja-JP
+Publisher: PDF MARIN
+PublisherUrl: https://pdf-marin.github.io/
+PublisherSupportUrl: https://pdf-marin.github.io/#report
+PackageName: PDF MARIN
+PackageUrl: https://pdf-marin.github.io/
+License: プロプライエタリ（著作権者による使用許諾）
+LicenseUrl: https://pdf-marin.github.io/terms.html
+PrivacyUrl: https://pdf-marin.github.io/terms.html
+ShortDescription: 文字も画像の中身も本当に取り除く墨消しに加え、ページの編集・図面の寸法測定・透かし・ページ番号・パスワード・圧縮ができる無料の PDF 編集ソフト。
+Description: |-
+  PDF MARIN は Windows 向けの無料 PDF 編集ソフトです。墨消しは黒い四角を
+  上から描くのではなく、文字も画像の中身（画素）も本当に取り除きます。
+  ページの抽出・並べ替え・回転・結合、図面の縮尺を合わせた寸法測定、
+  透かしとページ番号の挿入、パスワードの設定と解除、ファイルの圧縮ができます。
+Tags:
+- pdf
+- 墨消し
+- 図面
+- 寸法
+- 透かし
+- ページ番号
+- パスワード
+- 圧縮
+ReleaseNotesUrl: https://github.com/pdf-marin/pdf-marin.github.io/releases/tag/v0.1.2
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.yaml
+++ b/manifests/p/PDFMarin/PDFMarin/0.1.2/PDFMarin.PDFMarin.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: PDFMarin.PDFMarin
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package: PDFMarin.PDFMarin version 0.1.2

PDF MARIN is a free PDF editor for Windows (Japanese UI). NSIS installer (user scope), published on GitHub Releases.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Notes:
- InstallerType is `nullsoft` (electron-builder NSIS, per-user install, silent `/S`).
- ProductCode `c047670e-e7e7-506a-9ff5-19d3318f6c22` is the Uninstall registry key written by the installer.
- Installer SHA256 verified against the GitHub Release asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430072)