### PR TITLE
New package: DJsluxx.ScribeDrop version 0.1.0

### DIFF
--- a/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.installer.yaml
+++ b/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: DJsluxx.ScribeDrop
+PackageVersion: 0.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ScribeDrop\ScribeDrop.exe
+  PortableCommandAlias: ScribeDrop
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DJsluxx/scribedrop/releases/download/v0.1.0/ScribeDrop-0.1.0-win64-cpu.zip
+  InstallerSha256: 9F1B80A75507FCF996474A2E7C3E01E611548702F32DA68BC9AE562C949BD7F5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.locale.en-US.yaml
+++ b/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: DJsluxx.ScribeDrop
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: DJsluxx
+PublisherUrl: https://github.com/DJsluxx
+PublisherSupportUrl: https://github.com/DJsluxx/scribedrop/issues
+Author: Daniel Salama
+PackageName: ScribeDrop
+PackageUrl: https://github.com/DJsluxx/scribedrop
+License: MIT
+LicenseUrl: https://github.com/DJsluxx/scribedrop/blob/v0.1.0/LICENSE
+ShortDescription: Free offline Whisper transcription GUI for Windows - drag in audio or video, get .txt/.srt/.vtt back
+Description: >-
+  ScribeDrop is a free, open-source Windows GUI for offline speech-to-text transcription, built on
+  faster-whisper. Drag an audio or video file, or a whole folder, onto the window (or use Add
+  files) to get .txt, .srt and .vtt output in any combination, written next to the source file or
+  into a folder you choose. It includes a model picker (tiny/base/small/medium/large-v3), language
+  auto-detect or one of 28 explicit languages, GPU/CPU device detection, and a queue with per-file
+  progress and a working Cancel button. Transcription runs entirely on the local machine; the only
+  network access is a one-time download of Whisper model weights from Hugging Face the first time
+  a given model size is used. The standalone download in this manifest is a CPU-only build with no
+  installer and no uninstaller - it is a portable executable with its supporting files alongside
+  it, and it writes nothing to the registry.
+Moniker: scribedrop
+Tags:
+- whisper
+- transcription
+- speech-to-text
+- subtitles
+- srt
+- vtt
+- audio
+- video
+- offline
+- open-source
+- free
+- gui
+- drag-and-drop
+ReleaseNotesUrl: https://github.com/DJsluxx/scribedrop/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.yaml
+++ b/manifests/d/DJsluxx/ScribeDrop/0.1.0/DJsluxx.ScribeDrop.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: DJsluxx.ScribeDrop
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## Description

Adds a new package: `DJsluxx.ScribeDrop` version `0.1.0`.

ScribeDrop is a free, open-source Windows GUI for offline Whisper speech-to-text transcription
(drag a file in, get `.txt`/`.srt`/`.vtt` back). Repo: https://github.com/DJsluxx/scribedrop,
release: https://github.com/DJsluxx/scribedrop/releases/tag/v0.1.0.

**Disclosure: I am the publisher/author of this package** (GitHub account DJsluxx = Daniel Salama,
same account opening this PR). Submitting it myself since it has no existing distribution.

Notes for reviewers:
- The installer is a `zip` containing a PyInstaller "onedir" portable build (`ScribeDrop.exe` plus
  a companion `_internal\` folder) - no installer/uninstaller, nothing written to the registry, so
  `InstallerType: zip` + `NestedInstallerType: portable` was used, matching precedent (e.g.
  `junegunn.fzf`, `sharkdp.fd`).
- `RelativeFilePath` is `ScribeDrop\ScribeDrop.exe` because that is the literal path stored inside
  the archive (verified by listing the zip's entries, and by extracting it and confirming the exe
  resolves and is a valid PE at that path).
- The `.exe` is **not code-signed** (a known, documented limitation in the project's own README -
  SmartScreen will warn on first run). This is disclosed here for transparency; nothing in the
  repository policy requires code-signing for `zip`/`portable` installer types (only MSIX/APPX
  require a signature per `doc/manifest/schema/1.12.0/installer.md`).
- License is MIT for ScribeDrop's own code (`LicenseUrl` points at the tagged `LICENSE` file). The
  standalone zip also bundles GPLv2 FFmpeg-derived libraries (via the PyAV wheel) with full GPL
  notices and corresponding source attached to the same GitHub release; this doesn't change the
  `License: MIT` field, which reflects ScribeDrop's own licensing per the schema's intent.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note on the two unchecked boxes, in the interest of accuracy:**
> - *CLA*: not yet signed. This is the account's first contribution to a Microsoft repository: the
>   CLA bot will comment with a link on this PR once it validates; I will need a human
>   (account owner) to click through and accept it, since agreeing to a legal agreement isn't
>   something I do on the account owner's behalf.
> - *`winget install --manifest` local test*: `winget settings --enable LocalManifestFiles`
>   requires an elevated (administrator) shell, which wasn't available in the environment this PR
>   was prepared in, and Windows Sandbox is not installed on that machine. In its place I validated
>   the manifest with `winget validate --manifest` (passed: "Manifest validation succeeded."), and
>   independently confirmed the archive layout by extracting the release zip and verifying
>   `ScribeDrop\ScribeDrop.exe` resolves at the exact `RelativeFilePath` declared in the manifest
>   and is a valid Windows PE (`MZ` header). Happy to run the full local-install test if a reviewer
>   would rather see that before merge.

> **Note:** `<path>` is the directory containing the manifest you're submitting.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430090)