### PR TITLE
New version: TheJonaz.Moraine version 0.3.0

### DIFF
--- a/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.installer.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: moraine-windows-x86_64\moraine.exe
+    PortableCommandAlias: moraine
+Commands:
+  - moraine
+ReleaseDate: 2026-07-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TheJonaz/moraine-backup/releases/download/v0.3.0/moraine-windows-x86_64.zip
+    InstallerSha256: 0F3049226BA159504758912F29DD04B5FA3C0DD420BA996DA3B0E4A9DE0A6676
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.locale.en-US.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Jonaz Thern
+PublisherUrl: https://www.thern.io
+PublisherSupportUrl: https://github.com/TheJonaz/moraine-backup/issues
+Author: Jonaz Thern
+PackageName: Moraine
+PackageUrl: https://moraine.thern.io
+License: MIT
+LicenseUrl: https://github.com/TheJonaz/moraine-backup/blob/main/LICENSE
+Copyright: Copyright (c) Jonaz Thern
+ShortDescription: Snapshot-based backup over SSH/rsync and rclone — command-line client.
+Description: |-
+  Moraine is a small, fast backup client written in Rust. Hard-linked snapshots
+  over SSH make every run look like a complete tree while only changed files take
+  new space; restore anything from any snapshot. It also supports an rclone
+  backend for cloud/object storage and FTP.
+
+  This Windows package ships the `moraine` command-line client. The GTK desktop
+  app is Linux-only.
+Moniker: moraine
+Tags:
+  - backup
+  - snapshot
+  - rsync
+  - rclone
+  - ssh
+  - cli
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.0/TheJonaz.Moraine.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been manually reviewed

Moraine 0.3.0 — snapshot-based backup over SSH/rsync and rclone (CLI + GTK desktop app).

- Installer: `moraine-windows-x86_64.zip` from the [v0.3.0 release](https://github.com/TheJonaz/moraine-backup/releases/tag/v0.3.0)
- `InstallerSha256` matches the `SHA256SUMS` published with the release.
- Submitted by the upstream maintainer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430115)