### PR TITLE
Update version: LANCommander.Server version 2.1.13

### DIFF
--- a/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.installer.yaml
+++ b/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.13
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.13/LANCommander.Server-2.1.13-x64-Setup.exe
+  InstallerSha256: C124B71D34D26FC11ADF1AE6CFD184E93188A71E9D0D0ECD3D22812FFDEF8A06
+- Architecture: arm64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.13/LANCommander.Server-2.1.13-arm64-Setup.exe
+  InstallerSha256: 549FF486ED2006B14E31B519C81B3C394A400009A9FA0AC793E500C015BDA127
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.locale.en-US.yaml
+++ b/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.13
+PackageLocale: en-US
+Publisher: LANCommander LLC
+PublisherUrl: https://github.com/LANCommander
+PublisherSupportUrl: https://github.com/LANCommander/LANCommander/issues
+Author: Pat Hartl
+PackageName: LANCommander Server
+PackageUrl: https://github.com/LANCommander/LANCommander
+License: MIT
+Copyright: Copyright (c) LANCommander LLC
+ShortDescription: |
+  LANCommander is a self-hosted game distribution platform designed for LAN parties and personal libraries.
+  This server software is your central repository for games, redistributables, saves, and users.
+ReleaseNotes: "View the full release notes over on the official documentation site:\r\nhttps://lancommander.app/Releases/2.1.13"
+ReleaseNotesUrl: https://github.com/LANCommander/LANCommander/releases/tag/v2.1.13
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.lancommander.app
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.yaml
+++ b/manifests/l/LANCommander/Server/2.1.13/LANCommander.Server.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.13
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update LANCommander.Server to version 2.1.13.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430140)