### PR TITLE
New package: jvonscheidt.ibkr-etaxstatement version 0.3.0

### DIFF
--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.installer.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.installer.yaml
@@ -1,0 +1,14 @@
+# Created with WinGet Manifest Creator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.0
+InstallerType: portable
+Commands:
+  - ibkr-etaxstatement
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/releases/download/v0.3.0/ibkr-etaxstatement.exe
+    InstallerSha256: BC1F48499E9EB58922C1953873F5F38B7D3130F16574224F0AEC63FDC8B9D6F1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.locale.en-US.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# Created with WinGet Manifest Creator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.0
+PackageLocale: en-US
+Publisher: Johannes von Scheidt
+PublisherUrl: https://github.com/jvonscheidt
+PublisherSupportUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/issues
+PackageName: IBKR eTax Statement
+PackageUrl: https://github.com/jvonscheidt/ibkr-etaxstatement
+License: Apache-2.0
+LicenseUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/blob/v0.3.0/LICENSE
+ShortDescription: Convert IBKR FlexQuery XML to a Swiss e-tax statement.
+Description: >-
+  Converts Interactive Brokers FlexQuery XML exports into eCH-0196 XML and
+  eCH-0270 barcode PDFs for import into Swiss cantonal tax software.
+Tags:
+  - ech-0196
+  - ech-0270
+  - ibkr
+  - swiss-tax
+ReleaseNotes: >-
+  Corrects withholding-tax classification, refunds and multi-currency income.
+  Uses dividend accrual metadata for historical payment quantities, preserves
+  fractional holdings, and fixes valuation FX overrides and external XSD lookup.
+ReleaseNotesUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/releases/tag/v0.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.0/jvonscheidt.ibkr-etaxstatement.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Manifest Creator
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds jvonscheidt.ibkr-etaxstatement version 0.3.0, a portable Windows x64 converter from IBKR FlexQuery XML to Swiss eCH-0196 XML and eCH-0270 barcode PDFs.

Release: https://github.com/jvonscheidt/ibkr-etaxstatement/releases/tag/v0.3.0

The installer checksum matches the published release asset. Local installation succeeded and the installed executable reported 0.3.0; the temporary installation was then removed.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one manifest (one package version, three YAML files)
- [x] Validated locally with `winget validate --manifest packaging\winget\0.3.0`
- [x] Tested locally with `winget install --manifest packaging\winget\0.3.0 --scope user`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430240)