### PR TITLE
New version: Materializr.Materializr version 1.6.4

### DIFF
--- a/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.installer.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.4
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: Materializr
+ReleaseDate: 2026-09-05
+AppsAndFeaturesEntries:
+- ProductCode: Materializr
+  DisplayVersion: v1.6.4
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Materializr'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/materializr-cad/materializr/releases/download/v1.6.4/Materializr-Setup.exe
+  InstallerSha256: ABD2B35222C20C3C59183601F8EB6D276B87EB5E07AD33F0FD0F58C2A522DD80
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.locale.en-US.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.4
+PackageLocale: en-US
+Publisher: Materializr
+PublisherUrl: https://github.com/materializr-cad
+PublisherSupportUrl: https://github.com/materializr-cad/materializr/issues
+Author: Steve Bushwa
+PackageName: Materializr
+PackageUrl: https://github.com/materializr-cad/materializr
+License: GPL-3.0
+LicenseUrl: https://github.com/materializr-cad/materializr/blob/HEAD/LICENSE
+Copyright: Copyright (C) Steve Bushwa
+ShortDescription: Maker 3D CAD — the middle ground between Tinkercad and FreeCAD.
+Description: |-
+  Materializr is open-source 3D CAD for makers — the middle ground between
+  dead-simple tools like Tinkercad and full professional suites like FreeCAD.
+  Sketch on a plane, pull it into a solid (extrude, revolve, loft, sweep),
+  fillet and chamfer, run booleans, cut threads, and edit any step of the
+  history later. Sketches export to SVG and DXF at 1:1 mm for laser cutters and
+  2.5D CNC; it imports STEP, IGES, BREP, STL, SVG and DXF, and exports STEP,
+  STL, IGES, BREP, glTF, OBJ, 3MF, SVG and DXF. Real B-rep solids on the
+  OpenCASCADE kernel.
+Moniker: materializr
+Tags:
+- 3d
+- 3d-printing
+- cad
+- engineering
+- laser
+- modeling
+- opencascade
+- svg
+ReleaseNotes: |-
+  Materializr 1.6.4
+  Added
+  - Repair tools grouped in one place: Patch (fit a surface across picked edges, optionally tangent or curvature-continuous), Sew (join loose surfaces into a solid and report how many edges are still open), Merge Faces, and Remove Feature (formerly "Repair Geometry" — the old name promised a general fixer and only ever deleted a face and healed the gap)
+  - Move Face > Rotate can rebuild only the faces that touch the moved one instead of shearing the whole body, so a bore keeps its axis
+  - Aerofoil import: Selig and Lednicer coordinate files become sketch splines, placed by leading edge, quarter chord or centre
+  - Offset a sketch chain at a fixed distance, including splines
+  - Corner guides in sketching (bisector and smooth tangent at a vertex)
+  - Reference images attach to any construction plane from the plane dialog, with live preview, stepper offset and absolute X/Y/Z rotation
+  Fixed
+  - Opening a large project on a modest machine no longer stops answering the desktop: a 52-step project went from 24.4s to 14.6s, with the longest unresponsive stretch down from 24.5s to 1.4s
+  - Orbit and pan could stay dead for the rest of the session after tilting a face and switching projects
+  - Recovered in-progress sketches return to the tab they were drawn in; two running copies no longer overwrite each other's draft
+  - A malformed length in a shared project file could hang the loader and grow without bound; every length-prefixed field is now bounded and over-budget input is refused
+  - A startup failure with no usable OpenGL driver now reports the reason instead of exiting silently (exit 0xE06D7363 on Windows)
+ReleaseNotesUrl: https://github.com/materializr-cad/materializr/releases/tag/v1.6.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.yaml
+++ b/manifests/m/Materializr/Materializr/1.6.4/Materializr.Materializr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Materializr.Materializr
+PackageVersion: 1.6.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

Update of Materializr.Materializr from 1.6.0 to 1.6.4.

To be accurate about the two unchecked boxes: all three manifests were validated against the published 1.12.0 JSON schemas, but not with the `winget` CLI itself, and the installer was not run through `winget install --manifest` on a Windows machine. The `InstallerSha256` is of the exact `Materializr-Setup.exe` attached to the v1.6.4 GitHub release.

**Note on prior validation for this package:** the automatic validation of 1.6.0 (#411696) reported `Executable ... materializr.exe returned exit code: -529697949` (`0xE06D7363`, an unhandled C++ exception). The cause is fixed in this version. The application requires OpenGL 3.3, which the headless validation sandbox does not provide; it previously died with no diagnostic at all, because the exceptions thrown on that path do not derive from `std::exception` and so escaped the handler around `main`.

Measured on a VM with no 3D driver, comparing the two released binaries directly:

- 1.6.3 (current behaviour): exit `-529697949`, no output.
- 1.6.4: exit `1`, after printing that OpenGL 3.3 is required and suggesting a driver update.

With a software OpenGL implementation present, 1.6.4 launches normally on the same VM and reports `GL 4.6 (Core Profile)`.

The exit code in the sandbox will still be non-zero, since no OpenGL 3.3 is available there, but it is now a reported failure rather than a crash.
