### PR TITLE
New package: havurgiray.aht version 0.9.0

### DIFF
--- a/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.installer.yaml
+++ b/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: havurgiray.aht
+PackageVersion: 0.9.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: aht.exe
+    PortableCommandAlias: aht
+  - RelativeFilePath: aht-tray.exe
+    PortableCommandAlias: aht-tray
+ReleaseDate: 2026-09-06
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/havurgiray/agent-history-tether/releases/download/v0.9.0/aht-0.9.0-windows-x64.zip
+    InstallerSha256: A97423D17ABB6FB7F4F94FA47BB72FD62C0F501AA564761F86217B114BB68C3B
+  - Architecture: arm64
+    InstallerUrl: https://github.com/havurgiray/agent-history-tether/releases/download/v0.9.0/aht-0.9.0-windows-arm64.zip
+    InstallerSha256: 0151F93CFC981ED4FAF6BABE2BCAAA6DD7C065B19CD6CE9BA5BFC85B6886894C
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.locale.en-US.yaml
+++ b/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: havurgiray.aht
+PackageVersion: 0.9.0
+PackageLocale: en-US
+Publisher: Giray Havur
+PublisherUrl: https://github.com/havurgiray
+PublisherSupportUrl: https://github.com/havurgiray/agent-history-tether/issues
+PackageName: agent-history-tether
+PackageUrl: https://github.com/havurgiray/agent-history-tether
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/havurgiray/agent-history-tether/blob/master/LICENSE
+Copyright: Copyright (C) 2026 Giray Havur
+ShortDescription: Keeps AI coding agents' per-project histories tethered to their folders
+Description: Claude Code, Codex, Gemini, Cursor, OpenCode, Copilot and Kimi keep per-project conversation history keyed to the folder's absolute path, so moving, renaming, nesting or copying a project folder orphans it. aht drops one identity marker in each folder, watches for moves and copies, and re-links every agent's history (asking first). It also backs histories up, restores them wherever a folder ends up, and badges managed folders.
+Moniker: aht
+Tags:
+  - ai
+  - claude-code
+  - codex
+  - gemini-cli
+  - cli
+  - developer-tools
+  - history
+ReleaseNotesUrl: https://github.com/havurgiray/agent-history-tether/releases/tag/v0.9.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.yaml
+++ b/manifests/h/havurgiray/aht/0.9.0/havurgiray.aht.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: havurgiray.aht
+PackageVersion: 0.9.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package: havurgiray.aht 0.9.0 (agent-history-tether)

- Portable zip installers for x64 and arm64, both built and smoke-tested on GitHub-hosted Windows runners: https://github.com/havurgiray/agent-history-tether/releases/tag/v0.9.0
- Command aliases: `aht` (CLI) and `aht-tray` (system tray companion)
- License: AGPL-3.0-or-later
- The exes are unsigned (individual developer, no code-signing certificate yet); the SHA256 sums in the release's `SHA256SUMS.txt` match the manifest.

Checklist notes: the manifest was written by hand against schema 1.6.0 from macOS, so `winget validate` and `winget install --manifest` were not run locally; the identical zips were installed and exercised by the release smoke suites on x64 and arm64 runners. Happy to adjust anything the validation pipeline flags.

- [ ] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.6 schema?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430244)