### PR TITLE
New package: BeeswaxPat.Nexus7 version 0.1.3

### DIFF
--- a/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.installer.yaml
+++ b/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.Nexus7
+PackageVersion: 0.1.3
+InstallerType: portable
+Commands:
+- nexus-7
+PortableCommandAlias: nexus-7
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/beeswaxpat/nexus-7/releases/download/v0.1.3/NEXUS-7-0.1.3.exe
+  InstallerSha256: 48E88893CF780C09D070E505F1288069B64C083F32BF1433F1750446E0725181
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.locale.en-US.yaml
+++ b/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.Nexus7
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: beeswaxpat
+PublisherUrl: https://github.com/beeswaxpat
+PublisherSupportUrl: https://github.com/beeswaxpat/nexus-7/issues
+Author: beeswaxpat
+PackageName: NEXUS-7
+PackageUrl: https://github.com/beeswaxpat/nexus-7
+License: MIT
+LicenseUrl: https://github.com/beeswaxpat/nexus-7/blob/main/LICENSE
+Copyright: Copyright (c) 2026 beeswaxpat
+CopyrightUrl: https://github.com/beeswaxpat/nexus-7/blob/main/LICENSE
+ShortDescription: Crypto and stock dashboard with a cyberpunk look.
+Description: |-
+  NEXUS-7 shows live crypto and stock prices, a Bitcoin candlestick chart, a wireframe globe that tracks real satellites and scrolls out to the edge of the universe, an encrypted group chat, free internet radio, public webcams and TV, and an animated synthwave skyline. It uses public APIs only: no account, no API keys, no telemetry.
+Moniker: nexus-7
+Tags:
+- bitcoin
+- crypto
+- cryptocurrency
+- cyberpunk
+- dashboard
+- finance
+- market
+- stocks
+- synthwave
+ReleaseNotes: |-
+  - Night City runs in ULTRA (synthwave) by default.
+  - New profiles start with zero holdings.
+  - Jukebox: Nightride FM is CH 01. Star a station and it is selected on the next open.
+  - Panel moves hold up everywhere.
+ReleaseNotesUrl: https://github.com/beeswaxpat/nexus-7/releases/tag/v0.1.3
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/beeswaxpat/nexus-7#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.yaml
+++ b/manifests/b/BeeswaxPat/Nexus7/0.1.3/BeeswaxPat.Nexus7.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BeeswaxPat.Nexus7
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: BeeswaxPat.Nexus7 version 0.1.3.

NEXUS-7 is an open-source (MIT) crypto and stock dashboard for Windows: live prices, a Bitcoin chart, a globe that tracks real satellites, an encrypted group chat, internet radio, webcams, and an animated skyline. Source and releases: https://github.com/beeswaxpat/nexus-7. The installer is the portable exe attached to the v0.1.3 GitHub release; the SHA-256 matches the digest GitHub shows on the release asset.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>` (local manifest installs need an elevated `winget settings` change on this machine, so not run; the same exe was installed and run by hand)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430256)