### PR TITLE
New version: greatgc-flow.Engram version 3.1.1

### DIFF
--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.installer.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: greatgc-flow.Engram
+PackageVersion: 3.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: Engram.exe
+    PortableCommandAlias: engram
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/greatgc-flow/Engram/releases/download/v3.1.1/Engram-v3.1.1-portable-x64.zip
+    InstallerSha256: A8865C4C7FD9B1E5BD78FBD626F06DFAA5D2737E1D3138B8A90F2A3E5F383C10
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.locale.en-US.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: greatgc-flow.Engram
+PackageVersion: 3.1.1
+PackageLocale: en-US
+Publisher: greatgc-flow
+PublisherUrl: https://github.com/greatgc-flow
+PublisherSupportUrl: https://github.com/greatgc-flow/Engram/issues
+PackageName: Engram
+PackageUrl: https://github.com/greatgc-flow/Engram
+License: MIT
+LicenseUrl: https://github.com/greatgc-flow/Engram/blob/main/LICENSE
+Copyright: Copyright (c) 2026 greatgc-flow
+CopyrightUrl: https://github.com/greatgc-flow/Engram/blob/main/LICENSE
+ShortDescription: Portable Developer Runtime & Virtual Environment Engine for Windows
+Description: Engram is a zero-bloat, self-contained Windows portable runtime environment that provides virtual drive management and isolated Python/Node/Git environments. It can optionally install, update, and manage the status of third-party AI CLI tools, but all AI-to-AI collaboration itself is handled by the separate peerhub package.
+Moniker: engram
+Tags:
+  - portable
+  - developer-tools
+  - workflow
+  - automation
+  - windows
+  - virtual-environment
+ReleaseNotes: |-
+  Engram v3.1.1:
+  - Complete separation of Engram core from AI collaboration logic
+  - Native Winget portable package packaging support
+  - Zero-bloat portable developer runtime with isolated virtual environments
+ReleaseNotesUrl: https://github.com/greatgc-flow/Engram/releases/tag/v3.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.locale.ko-KR.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.locale.ko-KR.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: greatgc-flow.Engram
+PackageVersion: 3.1.1
+PackageLocale: ko-KR
+Publisher: greatgc-flow
+PublisherUrl: https://github.com/greatgc-flow
+PublisherSupportUrl: https://github.com/greatgc-flow/Engram/issues
+PackageName: Engram
+PackageUrl: https://github.com/greatgc-flow/Engram
+License: MIT
+LicenseUrl: https://github.com/greatgc-flow/Engram/blob/main/LICENSE
+Copyright: Copyright (c) 2026 greatgc-flow
+CopyrightUrl: https://github.com/greatgc-flow/Engram/blob/main/LICENSE
+ShortDescription: Windows용 무설치 포터블 개발 런타임 및 가상 환경 엔진
+Description: Engram은 가상 드라이브 관리(P:)와 격리된 Python/Node/Git 환경을 제공하는 Windows 전용 독립형 무설치 포터블 런타임 환경입니다. 서드파티 AI CLI 도구의 설치·업데이트·상태 확인을 선택적으로 지원하며, AI 간 협업 자체는 별도의 peerhub 패키지가 담당합니다.
+Tags:
+  - 포터블
+  - 개발도구
+  - 자동화
+  - 윈도우
+  - 가상환경
+  - 워크플로우
+ReleaseNotes: |-
+  Engram v3.1.1 릴리즈:
+  - Engram 코어와 AI 협업 로직의 완전한 분리 완료
+  - 공식 Winget 포터블 패키징 인프라 탑재
+  - 격리된 가상 환경을 갖춘 무설치 포터블 개발 런타임
+ReleaseNotesUrl: https://github.com/greatgc-flow/Engram/releases/tag/v3.1.1
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.version.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.version.yaml
@@ -1,7 +1,0 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
-
-PackageIdentifier: greatgc-flow.Engram
-PackageVersion: 3.1.1
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.12.0

--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.version.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: greatgc-flow.Engram
+PackageVersion: 3.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.yaml
+++ b/manifests/g/greatgc-flow/Engram/3.1.1/greatgc-flow.Engram.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: greatgc-flow.Engram
+PackageVersion: 3.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds greatgc-flow.Engram version 3.1.1 (portable-zip installer, schema 1.12.0). Validated locally via `winget validate --manifest` (success). Supersedes the stale, unmerged #428737 (v3.0.0), which will be closed in favor of this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430265)