### PR TITLE
Add HoshimonoDesign.FullyLocalTranscribe version 4.5.3

### DIFF
--- a/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.installer.yaml
+++ b/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: HoshimonoDesign.FullyLocalTranscribe
+PackageVersion: 4.5.3
+InstallerLocale: ja-JP
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: 完全ローカル文字起こしツール.exe
+  PortableCommandAlias: fullylocaltranscribe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://fullylocaltranscribe-dl.fullylocaltranscribe.workers.dev/app/4.5.3/%E5%AE%8C%E5%85%A8%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E6%96%87%E5%AD%97%E8%B5%B7%E3%81%93%E3%81%97%E3%83%84%E3%83%BC%E3%83%AB.zip
+  InstallerSha256: 13C6AF748E94CA43E32AD790C6C0D71BE05F69BD7E977E79CB554AD1D728D321
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.locale.ja-JP.yaml
+++ b/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.locale.ja-JP.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: HoshimonoDesign.FullyLocalTranscribe
+PackageVersion: 4.5.3
+PackageLocale: ja-JP
+Publisher: Hoshimono Design
+PublisherUrl: https://fullylocaltranscribe.com/
+PublisherSupportUrl: https://fullylocaltranscribe.com/
+PackageName: 完全ローカル文字起こし
+PackageUrl: https://fullylocaltranscribe.com/
+License: Proprietary
+LicenseUrl: https://fullylocaltranscribe.com/legal.html
+Copyright: Copyright (c) Hoshimono Design
+ShortDescription: 録音した音声を外部送信せずPC内だけで文字起こし・要約を行うWindows向けソフト
+Description: |-
+  「完全ローカル文字起こし」は、録音した音声をインターネットに一切送信せず、PC内だけで
+  文字起こし・要約を行うWindows向けソフトです。クラウド利用が制限される医療機関・
+  士業事務所・コールセンター・官公庁などの職場でも利用できます。
+  インストール不要でZIPを展開して起動するだけで動作し、話者分離やローカルLLMによる
+  AIチャット・要約機能を搭載しています。誤変換を修正すると自動で単語登録され、
+  次回以降は正しく出力されます。個人利用は無料（機能制限なし）、法人利用は有償ライセンスです。
+Tags:
+- transcription
+- speech-to-text
+- offline
+- privacy
+- japanese
+- meeting
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.yaml
+++ b/manifests/h/HoshimonoDesign/FullyLocalTranscribe/4.5.3/HoshimonoDesign.FullyLocalTranscribe.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: HoshimonoDesign.FullyLocalTranscribe
+PackageVersion: 4.5.3
+DefaultLocale: ja-JP
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Adds version 4.5.3 of HoshimonoDesign.FullyLocalTranscribe.

This supersedes #427019 (version 4.5.2), which I closed: that build has been replaced by 4.5.3 and removed from our CDN, so its declared `InstallerSha256` could no longer be validated.

The manifests are identical in structure to the 4.5.2 submission, which passed all validation checks. Only three values changed:

- `PackageVersion`: 4.5.2 → 4.5.3
- `InstallerUrl`: now points at the `app/4.5.3/` path
- `InstallerSha256`: recomputed from the published artifact (3,252,843,539 bytes)

- [x] Contributor License Agreement signed (via #427019)
- [x] No other open pull requests exist for this manifest

Note: I do not have a Windows environment with the Windows Package Manager Manifest Creator available, so `winget validate` / `winget install` were not run locally. The installer URL is live and the SHA256 was computed from the exact bytes served at that URL. Happy to make any corrections the automated validation flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430287)