### PR TITLE
Update version: OpenJS.Electron.42 version 42.11.2

### DIFF
--- a/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.installer.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.2
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.2/electron-v42.11.2-win32-ia32.zip
+  InstallerSha256: 7551BC5D56F5DBF5AC7CD714F1043B2B79D8ABA45A32EC8BC46B17E8956FFAE1
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.2/electron-v42.11.2-win32-x64.zip
+  InstallerSha256: 4087FA209CDC294624582692823D7E8522B7958C39CB376EF7AFF0C92CE0674E
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.2/electron-v42.11.2-win32-arm64.zip
+  InstallerSha256: 2477FD310512CAD10F899CB3B732612628AFB5078B3B6C822784E8695DEE5AAD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.2
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: "# Release Notes for v42.11.2\n\n## Fixes\n\n• Fixed application crash after a large number of IPC messages from renderers. [#53419](https://github.com/electron/electron/pull/53419) <sup>(Also in [43](https://github.com/electron/electron/pull/53420), [44](https://github.com/electron/electron/pull/53417), [45](https://github.com/electron/electron/pull/53418))</sup>\n• Fixed native addons deriving from `node::ObjectWrap` aborting during garbage collection on Node.js 24.19.0 and later. [#53394](https://github.com/electron/electron/pull/53394) <sup>(Also in [43](https://github.com/electron/electron/pull/53393), [44](https://github.com/electron/electron/pull/53392), [45](https://github.com/electron/electron/pull/53391))</sup>\n## Other Changes\n\n• Backported fixes from upstream ANGLE, Chromium, Skia and V8. [#53480](https://github.com/electron/electron/pull/53480) \n• Backported fixes from upstream Chromium, Dawn, Skia and V8. [#53397](https://github.com/electron/electron/pull/53397) \n• Backported fixes from upstream Chromium, V8, ANGLE, Dawn, Skia, WebRTC and DevTools. [#53367](https://github.com/electron/electron/pull/53367)"
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v42.11.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.2/OpenJS.Electron.42.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.42 to version 42.11.2.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430306)