### PR TITLE
New package: ShreyamAdhikari.Markpad version 0.14.2 (Quillpane)

### DIFF
--- a/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.installer.yaml
+++ b/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ShreyamAdhikari.Markpad
+PackageVersion: 0.13.3
+ManifestType: installer
+ManifestVersion: 1.6.0
+
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/shreyam1008/markpad/releases/download/v0.13.3/markpad-setup.exe
+    InstallerSha256: 9be26c7fa579fb57bffac37a35dd850b59e03883380f5ba640657a49c99128af

--- a/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.locale.en-US.yaml
+++ b/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ShreyamAdhikari.Markpad
+PackageVersion: 0.13.3
+PackageLocale: en-US
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+
+PackageName: Quillpane
+Publisher: Shreyam Adhikari
+PublisherUrl: https://shreyam1008.com.np/
+PublisherSupportUrl: https://github.com/shreyam1008/markpad/issues
+Author: Shreyam Adhikari
+License: MIT
+LicenseUrl: https://github.com/shreyam1008/markpad/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Shreyam Adhikari
+ShortDescription: Quillpane is a small native Markdown notepad and local-file viewer
+Description: |-
+  Quillpane (formerly Markpad) is a small native Markdown notepad and
+  local-file viewer built with Go, Wails, and the operating system webview.
+  Sessions, drafts, and version history stay local, with no account, sync
+  service, or telemetry.
+
+  Features include Markdown editor, split, and preview modes; bounded local
+  history and recovery drafts; syntax-highlighted source viewing; command
+  palette and keyboard navigation; local image preview; and external PDF
+  handoff to the system viewer.
+Moniker: quillpane
+Tags:
+  - markdown
+  - notepad
+  - editor
+  - note
+  - notes
+  - text-editor
+  - writer
+  - local
+  - offline
+PackageUrl: https://quillpane.shreyam1008.com.np/
+ReleaseNotesUrl: https://github.com/shreyam1008/markpad/releases/tag/v0.13.3

--- a/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.yaml
+++ b/manifests/s/ShreyamAdhikari/Markpad/0.13.3/ShreyamAdhikari.Markpad.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ShreyamAdhikari.Markpad
+PackageVersion: 0.13.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Publishes Quillpane 0.14.2 under the existing ShreyamAdhikari.Markpad package ID. This hotfix restores Ubuntu task-board dragging and improves collapsed columns, card colors, and wrapped-title spacing.

The x64 NSIS installer is from the public v0.14.2 release, with verified SHA256 `9e9a036a83249704edb818b1b20044db519945884363649e0bb2605a0f27f0a9`. Existing machine installation and upgrade behavior are preserved. Linux, Windows, macOS, and Snap release builds passed.

Release: https://github.com/shreyam1008/markpad/releases/tag/v0.14.2
