### PR TITLE
New version: cadwal.BookDB version 4.0.1

### DIFF
--- a/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.installer.yaml
+++ b/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 4.0.1
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BookDB.Desktop.exe
+  PortableCommandAlias: bookdb
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.Runtime.10
+  - PackageIdentifier: Microsoft.DotNet.AspNetCore.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v4.0.1/BookDB-v4.0.1-win-x64-fdd.zip
+  InstallerSha256: 0D373F22A45E0245A3629D903895C491CEF0230AB36A5E73B072F6B314240823
+- Architecture: arm64
+  InstallerUrl: https://github.com/cadwal/BookDB/releases/download/v4.0.1/BookDB-v4.0.1-win-arm64-fdd.zip
+  InstallerSha256: AE8455455BCC672F78C7631007273E79C1D7A4FFA09E330DF6996C9DF8B7CE23
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-06

--- a/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.locale.en-US.yaml
+++ b/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 4.0.1
+PackageLocale: en-US
+Publisher: cadwal
+PublisherUrl: https://github.com/cadwal
+PublisherSupportUrl: https://github.com/cadwal/BookDB/issues
+PackageName: BookDB
+PackageUrl: https://github.com/cadwal/BookDB
+License: MIT
+ShortDescription: A personal book catalog for Windows
+Description: A book catalog database for personal collections. Can import data from Readerware 4.
+Tags:
+- books
+- catalog
+- library
+ReleaseNotesUrl: https://github.com/cadwal/BookDB/releases/tag/v4.0.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/cadwal/BookDB/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.yaml
+++ b/manifests/c/cadwal/BookDB/4.0.1/cadwal.BookDB.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: cadwal.BookDB
+PackageVersion: 4.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Version bump of **cadwal.BookDB** to **4.0.1** (x64 + arm64 framework-dependent installers), generated with wingetcreate. Release notes: https://github.com/cadwal/BookDB/releases/tag/v4.0.1

This version also adds `Microsoft.DotNet.AspNetCore.10` to `Dependencies.PackageDependencies`, alongside the existing `Microsoft.DotNet.Runtime.10`. The application has bound the ASP.NET Core shared framework since 4.0.0, but the manifest declared only the base runtime — so a machine without ASP.NET Core installed was left to the .NET runtime's own first-launch prompt instead of having winget install it.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
