### PR TITLE
Update version: Jellyfin.FFmpeg version 8.1.2-4

### DIFF
--- a/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.installer.yaml
+++ b/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Jellyfin.FFmpeg
+PackageVersion: 8.1.2-4
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ffmpeg.exe
+  PortableCommandAlias: ffmpeg
+- RelativeFilePath: ffprobe.exe
+  PortableCommandAlias: ffprobe
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-09-06
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v8.1.2-4/jellyfin-ffmpeg_8.1.2-4_portable_win64-clang-gpl.zip
+  InstallerSha256: A6821D72985EE6D5A8AF16925B468D1C4EC1F652B582A0A2A5039282C26FFCA5
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+- Architecture: arm64
+  InstallerUrl: https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v8.1.2-4/jellyfin-ffmpeg_8.1.2-4_portable_winarm64-clang-gpl.zip
+  InstallerSha256: F77E3D0B2DCB4BB7EEC51E7240CCEAEE9071F715AB7D7EFB4B6E263B04F75F0D
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.arm64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.locale.en-US.yaml
+++ b/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Jellyfin.FFmpeg
+PackageVersion: 8.1.2-4
+PackageLocale: en-US
+Publisher: The Jellyfin Project
+PublisherUrl: https://jellyfin.org/contact
+PublisherSupportUrl: https://github.com/jellyfin/jellyfin-ffmpeg/issues
+PackageName: Jellyfin FFmpeg
+PackageUrl: https://github.com/jellyfin/jellyfin-ffmpeg
+License: LGPL-2.1
+LicenseUrl: https://github.com/jellyfin/jellyfin-ffmpeg/blob/HEAD/LICENSE.md
+Copyright: © Jellyfin Contributors
+ShortDescription: FFmpeg for Jellyfin with custom extensions and enhancements.
+Tags:
+- ffmpeg
+- ffprobe
+- jellyfin-ffmpeg
+ReleaseNotes: "## What's Changed\r\n• Fix AMD hevc_vaapi encoder extradata with overrides by @nyanmisaka in https://github.com/jellyfin/jellyfin-ffmpeg/pull/755\r\n• Drop support for EOL Debian Bullseye (old old stable) by @nyanmisaka in https://github.com/jellyfin/jellyfin-ffmpeg/pull/756\r\n\r\n\r\n**Full Changelog**：https://github.com/jellyfin/jellyfin-ffmpeg/compare/v8.1.2-3...v8.1.2-4"
+ReleaseNotesUrl: https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v8.1.2-4
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/jellyfin/jellyfin-ffmpeg/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.yaml
+++ b/manifests/j/Jellyfin/FFmpeg/8.1.2-4/Jellyfin.FFmpeg.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Jellyfin.FFmpeg
+PackageVersion: 8.1.2-4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Jellyfin.FFmpeg to version 8.1.2-4.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430351)