### PR TITLE
New package: jvonscheidt.ibkr-etaxstatement version 0.3.1

### DIFF
--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.installer.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.1
+InstallerType: portable
+Commands:
+  - ibkr-etaxstatement
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/releases/download/v0.3.1/ibkr-etaxstatement.exe
+    InstallerSha256: 9051EA1DE57352F863D6DEABA05E638ADABAAF33DE566C5669AB4CC2C6D0B0D6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.locale.en-US.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Johannes von Scheidt
+PublisherUrl: https://github.com/jvonscheidt
+PublisherSupportUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/issues
+PackageName: IBKR eTax Statement
+PackageUrl: https://github.com/jvonscheidt/ibkr-etaxstatement
+License: Apache-2.0
+LicenseUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/blob/v0.3.1/LICENSE
+ShortDescription: Convert IBKR FlexQuery XML to a Swiss e-tax statement.
+Description: >-
+  Converts Interactive Brokers FlexQuery XML exports into eCH-0196 XML and
+  eCH-0270 barcode PDFs for import into Swiss cantonal tax software.
+Tags:
+  - ech-0196
+  - ech-0270
+  - ibkr
+  - swiss-tax
+ReleaseNotesUrl: https://github.com/jvonscheidt/ibkr-etaxstatement/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.yaml
+++ b/manifests/j/jvonscheidt/ibkr-etaxstatement/0.3.1/jvonscheidt.ibkr-etaxstatement.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: jvonscheidt.ibkr-etaxstatement
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds jvonscheidt.ibkr-etaxstatement version 0.3.1.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only adds one package version (three manifest files)
- [x] Validated generated manifests in the release workflow with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The CLA check passed. The published manifest was installed locally in user scope; the installed executable reported 0.3.1, and the temporary installation was removed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430352)
