### PR TITLE
New package: JiesiMa.WaveSubs version 1.0.1

### DIFF
--- a/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.installer.yaml
+++ b/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JiesiMa.WaveSubs
+PackageVersion: 1.0.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ProductCode: bb1695ad-ec2d-5152-85db-62c64de0e280
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jason-jm/wavesubs/releases/download/v1.0.1/Wave.Subs.Setup.1.0.1.exe
+  InstallerSha256: A19F718B4C12B8D6873D8E40CAB75477C0BB2853C6F2279365A43F9592B92789
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.locale.en-US.yaml
+++ b/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JiesiMa.WaveSubs
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Jiesi Ma
+PublisherUrl: https://wavesubs.com/
+PublisherSupportUrl: https://github.com/jason-jm/wavesubs/issues
+PrivacyUrl: https://wavesubs.com/en/privacy.html
+Author: Jiesi Ma
+PackageName: Wave Subs
+PackageUrl: https://wavesubs.com/
+License: MIT
+LicenseUrl: https://github.com/jason-jm/wavesubs/blob/main/LICENSE
+Copyright: Copyright © 2026 Jiesi Ma
+ShortDescription: Generate SRT/ASS subtitles from any video with local AI and auto-translate them, offline.
+Description: |-
+  Can't find subtitles for a video? Wave Subs recognizes the dialogue with whisper.cpp, refines the timing, and translates the result into your language with a local Qwen3 model (or any OpenAI-compatible API). Exports SRT / ASS next to the video, batch-processes a whole season, and includes a subtitle editor with video preview. Everything runs on your own computer: no account, no upload, no internet needed after the one-time model download. Free and open source (MIT).
+Moniker: wavesubs
+Tags:
+- ai
+- ass
+- offline
+- speech-to-text
+- srt
+- subtitle
+- subtitles
+- transcription
+- translation
+- video
+- whisper
+ReleaseNotesUrl: https://github.com/jason-jm/wavesubs/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.locale.zh-CN.yaml
+++ b/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.locale.zh-CN.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: JiesiMa.WaveSubs
+PackageVersion: 1.0.1
+PackageLocale: zh-CN
+Publisher: Jiesi Ma
+PackageName: Wave Subs
+ShortDescription: 用本地 AI 从影片生成 SRT/ASS 字幕并自动翻译，无需联网。
+Description: |-
+  看片找不到字幕？Wave Subs 用 whisper.cpp 识别对白、精修时间轴，再用本地 Qwen3 模型（或任何 OpenAI 兼容接口）翻译成你的语言。导出 SRT / ASS 到影片旁边，整季批量处理，自带带视频预览的字幕编辑器。全部在你自己的电脑上完成：没有账号、不上传、模型下载后无需联网。免费开源（MIT）。
+Tags:
+- 字幕
+- 翻译
+- 语音识别
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.yaml
+++ b/manifests/j/JiesiMa/WaveSubs/1.0.1/JiesiMa.WaveSubs.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JiesiMa.WaveSubs
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`? (not possible on macOS; manifests follow schema 1.12.0 and mirror existing electron-builder NSIS packages)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (relies on the pipeline sandbox)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Wave Subs generates SRT/ASS subtitles from any video with local AI (whisper.cpp) and auto-translates them; open source (MIT). Installer is electron-builder NSIS (assisted, per-user), silent with `/S`. ProductCode is electron-builder's deterministic GUID for `com.wavesubs.desktop`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430387)