### PR TITLE
New package: InnovationTrigger.PDFluent version 1.0.0-beta.21

### DIFF
--- a/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.installer.yaml
+++ b/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: InnovationTrigger.PDFluent
+PackageVersion: 1.0.0-beta.21
+InstallerType: wix
+# ALLUSERS=1 stands in the MSI's Property table, so this installs per machine.
+# The manifest said `user`, which is the claim winget acts on when it decides
+# where the package went and whether it may remove it.
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
+UpgradeBehavior: install
+ProductCode: '{AEE448FB-9AC3-4519-956E-60B7A232CDA8}'
+# The MSI's own ProductVersion is 1.0.0 and does not move between betas, so the
+# entry Windows writes into Apps & Features never equals PackageVersion. Without
+# this block winget compares 1.0.0-beta.21 against a DisplayVersion of 1.0.0 and
+# offers the same upgrade forever.
+AppsAndFeaturesEntries:
+  - DisplayName: PDFluent
+    DisplayVersion: 1.0.0
+    Publisher: pdfluent
+    ProductCode: '{AEE448FB-9AC3-4519-956E-60B7A232CDA8}'
+    UpgradeCode: '{8AE94143-984E-5CE4-893C-ED1723406728}'
+    InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://pdfluent.com/releases/1.0.0-beta.21/PDFluent_1.0.0-beta.21_x64_en-US.msi
+    InstallerSha256: F6262AC4EF35920F0B6D2992DD9BF4701A21751309A85B1E938533AF10364F12
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.locale.en-US.yaml
+++ b/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: InnovationTrigger.PDFluent
+PackageVersion: 1.0.0-beta.21
+PackageLocale: en-US
+Publisher: Innovation Trigger B.V.
+PublisherUrl: https://pdfluent.com
+PublisherSupportUrl: https://pdfluent.com/contact/
+PrivacyUrl: https://pdfluent.com/privacy/
+PackageName: PDFluent
+PackageUrl: https://pdfluent.com
+License: Proprietary
+LicenseUrl: https://pdfluent.com/license/
+Copyright: Copyright (c) 2026 Innovation Trigger B.V.
+ShortDescription: A PDF editor that processes documents on your own machine.
+Description: |-
+  PDFluent is a desktop PDF editor. It opens, edits, converts, signs and
+  redacts PDF files, and it does that work on the machine it is installed on
+  rather than on a server.
+
+  The application is free to use, including commercially. There is no account
+  to create and no licence key to enter. Crash reports are off unless you turn
+  them on.
+
+  The PDF engine is written in Rust with no C or C++ dependencies.
+Moniker: pdfluent
+Tags:
+  - pdf
+  - pdf-editor
+  - pdf-converter
+  - editor
+  - office
+  - document
+  - offline
+  - privacy
+ReleaseNotesUrl: https://pdfluent.com/changelog/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.yaml
+++ b/manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/InnovationTrigger.PDFluent.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: InnovationTrigger.PDFluent
+PackageVersion: 1.0.0-beta.21
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" -->

## 📖 Description

New package: **InnovationTrigger.PDFluent** version **1.0.0-beta.21**.

PDFluent is a desktop PDF editor from Innovation Trigger B.V. It opens, edits, converts, signs and redacts PDF files on the machine it is installed on rather than on a server. Installer is the signed x64 MSI served from the publisher's own site, one URL per version.

Publisher-submitted: I am the publisher.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — left unchecked deliberately: I will sign whatever the CLA bot asks for on this PR rather than tick a box for an agreement it has not yet presented.
- [ ] Linked to an issue (if applicable) — no issue; this is a first-time package submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change — searched `PDFluent in:title`, open PRs: none. `InnovationTrigger.PDFluent` does not exist in `manifests/` today.
- [x] This PR only modifies one (1) manifest — three files, one package version, nothing else in the tree.
- [ ] Validated manifest locally with `winget validate --manifest <path>` — **could not run: no Windows machine.** See what was validated instead, below.
- [ ] Tested manifest locally with `winget install --manifest <path>` — **could not run, same reason.**
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) — these are authored against **1.10.0** and validate clean against it. They also validate clean against the 1.12.0 schemas unchanged; say the word and I will push the version bump.

## What was validated, and how

Without Windows, in place of `winget validate`:

| Check | Result |
|---|---|
| All three manifests against the official `1.10.0` JSON schemas | pass |
| Same three against `1.12.0` | pass |
| `PackageIdentifier` / `PackageVersion` against the folder path and file names | `manifests/i/InnovationTrigger/PDFluent/1.0.0-beta.21/`, all three agree |
| `InstallerUrl` reachable | `HTTP/2 200`, `content-type: application/x-msi`, 20 119 552 bytes |
| `InstallerSha256` against the bytes actually served | downloaded and hashed: `F6262AC4…64F12`, matches the manifest |

`ProductCode`, `UpgradeCode`, `Scope` and the `AppsAndFeaturesEntries` block were read out of the MSI itself with `msiinfo export` (msitools) rather than guessed:

- `ALLUSERS=1` stands in the Property table, so `Scope: machine`.
- The MSI's own `ProductVersion` is `1.0.0` and does not move between betas, so without `AppsAndFeaturesEntries` winget would compare `1.0.0-beta.21` against a `DisplayVersion` of `1.0.0` and offer the same upgrade forever.
- The UI sequence that would open a window sits in `InstallUISequence`, which `/quiet` does not run; the one custom action that launches the app hangs off `AUTOLAUNCHAPP`, set only by the checkbox on the final page. So the silent modes are claimed on the MSI's own tables.

**What that leaves open, stated plainly:** the install has not been run on Windows by me. `DownloadAndInvokeBootstrapper` fetches the Edge WebView2 runtime from `go.microsoft.com` when `WVRTINSTALLED` is not already set, so a silent install on a machine without WebView2 needs network. If your validation pipeline finds anything, I will fix it here the same day.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430389)