### PR TITLE
New package: SimplestBOT.translate-for-developers version 1.7.0

### DIFF
--- a/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.installer.yaml
+++ b/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: SimplestBOT.translate-for-developers
+PackageVersion: 1.7.0
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: scripts\bridge\translator-ui.exe
+    PortableCommandAlias: translator
+  InstallerUrl: https://github.com/SimplestBOT/translate-for-developers/releases/download/v1.7.0/translate-for-developers-v1.7.0-portable.zip
+  InstallerSha256: 0a8b44aa9a076786cfeeda7bbcbc2cb7e1b6357ae4a83d0d5b2135f611497525
+  ArchiveBinariesDependOnPath: true
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.locale.zh-CN.yaml
+++ b/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: SimplestBOT.translate-for-developers
+PackageVersion: 1.7.0
+PackageLocale: zh-CN
+Publisher: SimplestBOT
+PublisherUrl: https://github.com/SimplestBOT
+PublisherSupportUrl: https://github.com/SimplestBOT/translate-for-developers/issues
+PackageName: translate-for-developers
+PackageUrl: https://github.com/SimplestBOT/translate-for-developers
+License: MIT
+LicenseUrl: https://github.com/SimplestBOT/translate-for-developers/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SimplestBOT
+ShortDescription: 面向开发者的划词翻译（划词 / 截图 OCR / 输入翻译）
+Description: |-
+  任意软件中选中文本按热键即弹出译文；支持截图 OCR 翻译（Windows 内置
+  Windows.Media.Ocr，免费离线）与多行输入翻译；WebView2 渲染深色 UI；
+  翻译服务可选 MyMemory / 百度 / DeepL / OpenAI 兼容大模型；密钥 DPAPI
+  加密落盘；绿色便携，无安装器无注册表。
+Tags:
+- translate
+- translation
+- ocr
+- developer
+- chinese
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.yaml
+++ b/manifests/s/SimplestBOT/translate-for-developers/1.7.0/SimplestBOT.translate-for-developers.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: SimplestBOT.translate-for-developers
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: SimplestBOT
+PublisherUrl: https://github.com/SimplestBOT
+PublisherSupportUrl: https://github.com/SimplestBOT/translate-for-developers/issues
+PackageName: translate-for-developers
+PackageUrl: https://github.com/SimplestBOT/translate-for-developers
+License: MIT
+LicenseUrl: https://github.com/SimplestBOT/translate-for-developers/blob/main/LICENSE
+Copyright: Copyright (c) 2026 SimplestBOT
+ShortDescription: Hotkey translation for developers (selection / screenshot OCR / typed input)
+Description: |-
+  Select text in any app, press the hotkey, get the translation instantly.
+  Includes screenshot OCR translation (built-in Windows.Media.Ocr, free and
+  offline) and a multi-line input mode. Dark WebView2 UI; translation backends
+  MyMemory / Baidu / DeepL / OpenAI-compatible LLMs; API keys are DPAPI-
+  encrypted at rest; fully portable, no installer, no registry.
+Tags:
+- translate
+- translation
+- ocr
+- developer
+- chinese
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package

- Package: **SimplestBOT.translate-for-developers** v1.7.0
- Publisher: SimplestBOT (account owner of the package repo)
- Installer: portable zip (NestedInstallerType: portable, alias `translator`), x64, 889,109 bytes
- InstallerSha256: `0a8b44aa9a076786cfeeda7bbcbc2cb7e1b6357ae4a83d0d5b2135f611497525` (downloaded from the official GitHub Release: https://github.com/SimplestBOT/translate-for-developers/releases/tag/v1.7.0)
- License: MIT
- Manifests: defaultLocale (en-US) + locale zh-CN + installer, schema 1.6.0

### Description

Translate for Developers is an MIT-licensed Windows hotkey translation tool for developers: selection capture via clipboard + UIA TextPattern dual channel (works in MATLAB and terminal-class windows where classic highlight-based tools fail; terminals get Ctrl+Insert instead of Ctrl+C so running tasks are never interrupted), backends MyMemory / Baidu / DeepL / any OpenAI-compatible LLM with code/path/URL identifier masking, plus built-in Windows OCR screenshot translation and a typed-input mode. Fully portable, no installer, keys encrypted via DPAPI.

This is my own open-source project (I own the SimplestBOT account and the release); submitting on behalf of the project per the contribution guidelines.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430390)