### PR TITLE
New package: roblillack.tdoc version 0.12.3

### DIFF
--- a/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.installer.yaml
+++ b/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: roblillack.tdoc
+PackageVersion: 0.12.3
+InstallerType: portable
+Commands:
+- tdoc
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/roblillack/tdoc/releases/download/v0.12.3/tdoc-windows-x86_64.exe
+  InstallerSha256: D1E9E9924BC3C11A3B0B0A5E9740CACC8BAC3947714D0776D1FB87A28FBCB6A3
+- Architecture: arm64
+  InstallerUrl: https://github.com/roblillack/tdoc/releases/download/v0.12.3/tdoc-windows-aarch64.exe
+  InstallerSha256: 342537F13DF8F2C02912A61E1E96A28B4399777EB67E48F5C3C412D14F235F19
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.locale.en-US.yaml
+++ b/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: roblillack.tdoc
+PackageVersion: 0.12.3
+PackageLocale: en-US
+Publisher: Rob Lillack
+PublisherUrl: https://github.com/roblillack
+PublisherSupportUrl: https://github.com/roblillack/tdoc/issues
+Author: Rob Lillack
+PackageName: tdoc
+PackageUrl: https://github.com/roblillack/tdoc
+License: MIT
+LicenseUrl: https://github.com/roblillack/tdoc/blob/main/LICENSE
+Copyright: Copyright (c) 2025-2026 Robert Lillack
+CopyrightUrl: https://github.com/roblillack/tdoc/blob/main/LICENSE
+ShortDescription: Command-line tool for reading, rendering, and converting text documents across Markdown, HTML, Gemini, and FTML.
+Description: |-
+  tdoc is a single binary for viewing and converting Markdown, HTML, Gemini, and FTML documents.
+  Point it at a file, a URL, or stdin and it renders the content as richly styled terminal output
+  with a built-in pager, or converts it from one format into another. Every supported format is
+  parsed into a single in-memory document tree, so anything tdoc can read it can also render and
+  re-emit in any other format it knows. A --watch mode re-renders or regenerates output whenever
+  the input file changes.
+Moniker: tdoc
+Tags:
+- cli
+- converter
+- ftml
+- gemini
+- gemtext
+- html
+- markdown
+- pager
+- rust
+- terminal
+ReleaseNotes: |-
+  - Windows: Ensure to statically link MSVC C runtime
+ReleaseNotesUrl: https://github.com/roblillack/tdoc/releases/tag/v0.12.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.yaml
+++ b/manifests/r/roblillack/tdoc/0.12.3/roblillack.tdoc.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: roblillack.tdoc
+PackageVersion: 0.12.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
This adds support for `tdoc`, a CLI text document viewer, pager, and converter: https://github.com/roblillack/tdoc

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430405)