### PR TITLE
Update: AdrienCros.Avash to 0.9.2

### DIFF
--- a/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.installer.yaml
+++ b/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: AdrienCros.Avash
+PackageVersion: 0.9.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AdrienAvalon/avash/releases/download/v0.9.2/Avash_0.9.2_x64-setup.exe
+  InstallerSha256: D8A698C5B3ECA49B56199CB39CE6718A707464BFD83BA4E1917A3FBC17993BAF
+  ProductCode: Avash
+  AppsAndFeaturesEntries:
+  - DisplayName: Avash
+    Publisher: Adrien Cros
+    DisplayVersion: 0.9.2
+    ProductCode: Avash
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.locale.en-US.yaml
+++ b/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: AdrienCros.Avash
+PackageVersion: 0.9.2
+PackageLocale: en-US
+Publisher: Adrien Cros
+PublisherUrl: https://github.com/AdrienAvalon
+PublisherSupportUrl: https://github.com/AdrienAvalon/avash/issues
+PackageName: Avash
+PackageUrl: https://github.com/AdrienAvalon/avash
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/AdrienAvalon/avash/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Adrien Cros
+CopyrightUrl: https://github.com/AdrienAvalon/avash/blob/main/LICENSE
+ShortDescription: Native, fast and secure SSH, RDP and VNC connection manager
+Description: |-
+  Avash brings your SSH terminals, your Windows remote desktops (RDP), your VNC desktops, your serial consoles and your file transfers (SFTP) into a single native application. It reads and writes your ~/.ssh/config as it is, keeps passwords in the system credential store, verifies host keys for SSH and RDP before any credential leaves, shares a local folder as a drive on the remote desktop, and imports PuTTY and MobaXterm sessions. Built with Tauri 2 and Rust; requires the WebView2 runtime, shipped with Windows 10 and 11.
+Moniker: avash
+Tags:
+- ssh
+- rdp
+- vnc
+- sftp
+- terminal
+- remote-desktop
+- ssh-client
+- rdp-client
+- vnc-client
+- putty
+- mobaxterm
+- tauri
+- rust
+ReleaseNotesUrl: https://github.com/AdrienAvalon/avash/releases/tag/v0.9.2
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/AdrienAvalon/avash/blob/main/README.en.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.locale.fr-FR.yaml
+++ b/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.locale.fr-FR.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: AdrienCros.Avash
+PackageVersion: 0.9.2
+PackageLocale: fr-FR
+Publisher: Adrien Cros
+PublisherUrl: https://github.com/AdrienAvalon
+PublisherSupportUrl: https://github.com/AdrienAvalon/avash/issues
+PackageName: Avash
+PackageUrl: https://github.com/AdrienAvalon/avash
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/AdrienAvalon/avash/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Adrien Cros
+ShortDescription: Gestionnaire de connexions SSH, RDP et VNC, natif, rapide, sécurisé
+Description: |-
+  Avash réunit vos terminaux SSH, vos bureaux distants Windows (RDP), vos bureaux VNC, vos consoles série et vos transferts de fichiers (SFTP) dans une seule application native. Il lit et écrit votre ~/.ssh/config tel quel, garde les mots de passe dans le gestionnaire d'identifiants du système, vérifie les clés d'hôte en SSH et en RDP avant le moindre identifiant, partage un dossier du poste comme lecteur sur le bureau distant, et importe les sessions PuTTY et MobaXterm. Construit avec Tauri 2 et Rust ; requiert le moteur WebView2, livré avec Windows 10 et 11.
+Tags:
+- ssh
+- rdp
+- vnc
+- sftp
+- terminal
+- bureau-distant
+ReleaseNotesUrl: https://github.com/AdrienAvalon/avash/releases/tag/v0.9.2
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/AdrienAvalon/avash/blob/main/README.md
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.yaml
+++ b/manifests/a/AdrienCros/Avash/0.9.2/AdrienCros.Avash.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: AdrienCros.Avash
+PackageVersion: 0.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **AdrienCros.Avash** to version 0.9.2: Avash, a native SSH, RDP and VNC connection manager (Tauri 2 + Rust, AGPL-3.0-or-later), published at https://github.com/AdrienAvalon/avash. Previous version in the repository: 0.9.1 (#429575).

- Installer: NSIS (`nullsoft`), per-user scope, x64, from the GitHub release `v0.9.2`; SHA256 taken from the release's `SHA256SUMS`, which is also covered by a Sigstore build-provenance attestation (`gh attestation verify Avash_0.9.2_x64-setup.exe --repo AdrienAvalon/avash`, bundle `avash-v0.9.2.intoto.jsonl` attached to the release for offline verification).
- Same installer layout and `ProductCode: Avash` as 0.9.1, which the pipeline installed and validated.
- Default locale `en-US`, plus `fr-FR`.
- Requires the WebView2 runtime, shipped with Windows 10 and 11.

The manifests are generated by the script kept in the upstream repository (`scripts/winget-manifeste.sh`).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (authored on Linux, where winget is not available; the manifests only differ from the validated 0.9.1 ones by version, date, hash and descriptions; I rely on the pipeline validation here and will fix anything it reports)
- [ ] Tested manifest locally with `winget install --manifest <path>` (same reason)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430406)