### PR TITLE
New version: Luoyuctl.AgentTrace version 0.8.1

### DIFF
--- a/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.installer.yaml
+++ b/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: Luoyuctl.AgentTrace
+PackageVersion: 0.8.1
+InstallerType: portable
+Commands:
+  - agenttrace
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/luoyuctl/agenttrace/releases/download/v0.8.1/agenttrace-windows-amd64.exe
+    InstallerSha256: 46dd84ef8d0af4c7794693baa7f4653816dce900207612ca1c0046c57444aa2c
+    PortableCommandAlias: agenttrace
+  - Architecture: arm64
+    InstallerUrl: https://github.com/luoyuctl/agenttrace/releases/download/v0.8.1/agenttrace-windows-arm64.exe
+    InstallerSha256: 500cf18c178f2e733aad957bbf7a2d83297c2462ddb602f145bbf042cf3ce9a5
+    PortableCommandAlias: agenttrace
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.locale.en-US.yaml
+++ b/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: Luoyuctl.AgentTrace
+PackageVersion: 0.8.1
+PackageLocale: en-US
+Publisher: Luoyuctl
+PublisherUrl: https://github.com/luoyuctl
+PublisherSupportUrl: https://github.com/luoyuctl/agenttrace/issues
+PackageName: AgentTrace
+PackageUrl: https://github.com/luoyuctl/agenttrace
+License: MIT
+LicenseUrl: https://github.com/luoyuctl/agenttrace/blob/master/LICENSE
+ShortDescription: Local-first TUI and reports for AI coding-agent session history, cost, tokens, time, and slow-run diagnosis.
+Description: AgentTrace is a local-first terminal TUI and report generator for AI coding-agent session history, cost, tokens, time, and slow-run diagnosis.
+Moniker: agenttrace
+Tags:
+  - agent
+  - ai
+  - cli
+  - observability
+  - tui
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.yaml
+++ b/manifests/l/Luoyuctl/AgentTrace/0.8.1/Luoyuctl.AgentTrace.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Luoyuctl.AgentTrace
+PackageVersion: 0.8.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Update Luoyuctl.AgentTrace to 0.8.1.

Manifests were generated by the upstream release channel renderer using the published v0.8.1 checksums. Both x64 and ARM64 portable Windows assets are included.

Release: https://github.com/luoyuctl/agenttrace/releases/tag/v0.8.1

Native Windows installation validation was not run locally; please use the repository validation checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430449)