### PR TITLE
New version: gohide.gohide version 5.2.1

### DIFF
--- a/manifests/g/gohide/gohide/5.2.1/gohide.gohide.installer.yaml
+++ b/manifests/g/gohide/gohide/5.2.1/gohide.gohide.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.19041.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gohide/GoHide/releases/download/v5.2.1/gohide-5.2.1-win-Setup.exe
+  InstallerSha256: 0BD48B835E3590D5489D18ADE764C4ADFBBF4911292E52C7AD65943A299640AC
+  AppsAndFeaturesEntries:
+  - DisplayName: gohide
+    Publisher: Xianwei Zhu
+    DisplayVersion: 5.2.1
+    ProductCode: gohide
+    InstallerType: exe
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gohide/gohide/5.2.1/gohide.gohide.locale.en-US.yaml
+++ b/manifests/g/gohide/gohide/5.2.1/gohide.gohide.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.1
+PackageLocale: en-US
+Publisher: Xianwei Zhu
+PublisherUrl: https://gohide.net
+PublisherSupportUrl: https://gohide.net/en/docs/troubleshooting
+PrivacyUrl: https://gohide.net/en/legal/privacy
+Author: Xianwei Zhu
+PackageName: gohide
+PackageUrl: https://gohide.net
+License: Proprietary
+LicenseUrl: https://gohide.net/en/legal/terms
+Copyright: Copyright (c) 2026 Xianwei Zhu
+ShortDescription: Hide app windows, taskbar buttons and tray icons on Windows with one hotkey.
+Description: |-
+  gohide hides the running applications you choose - their windows, taskbar buttons and even their
+  system-tray icons - with a single global hotkey, then restores everything exactly where it was.
+  Most classic window hiders stopped working on the redesigned Windows 11 notification area; gohide
+  still hides tray icons there. It can also mute an app while hidden, or suspend it entirely so a
+  hidden game stops using CPU and GPU. Everything is fully reversible, works offline, and needs no
+  account and no telemetry. Free for up to 5 managed apps; an optional Pro tier is a one-time
+  perpetual purchase with no subscription.
+Moniker: gohide
+Tags:
+- boss-key
+- desktop
+- focus
+- hide
+- hotkey
+- privacy
+- productivity
+- system-tray
+- taskbar
+- window-management
+ReleaseNotesUrl: https://github.com/gohide/GoHide/releases/tag/v5.2.1
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://gohide.net/en/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gohide/gohide/5.2.1/gohide.gohide.yaml
+++ b/manifests/g/gohide/gohide/5.2.1/gohide.gohide.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been manually validated?

- [ ] Yes

### Have you validated the manifest locally with `winget validate --manifest <path>`?

- [x] Yes

### Have you tested the manifest locally with `winget install --manifest <path>`?

- [ ] No

---

New version of an existing package. The previously published version (1.1.17) is several
releases behind, so `winget install gohide.gohide` has been serving a stale build.

- Installer: `https://github.com/gohide/GoHide/releases/download/v5.2.1/gohide-5.2.1-win-Setup.exe`
- SHA256 matches the `.sha256` asset published alongside the installer in the same release.
- Release notes: https://github.com/gohide/GoHide/releases/tag/v5.2.1

Also corrected one stale line in the locale manifest: the free tier covers 5 managed apps,
not 3.

Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?repo=winget-pkgs&pullRequest=0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430452)