### PR TITLE
New version: N0deZ3r0.Win11Privacy version 1.9.2

### DIFF
--- a/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.installer.yaml
+++ b/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.installer.yaml
@@ -1,0 +1,15 @@
+# Создано tools/make_winget.py — правьте генератор, а не этот файл
+PackageIdentifier: N0deZ3r0.Win11Privacy
+PackageVersion: 1.9.2
+InstallerType: portable
+Commands:
+  - Win11Privacy
+# Программа меняет системные настройки и сама запрашивает права администратора
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-09-06
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/N0deZ3r0/Win11Privacy/releases/download/v1.9.2/Win11Privacy.exe
+    InstallerSha256: 705a0ead92dff099ce2fdf9db128877fd576833f8fdf0d9a925bbcd40b6f2012
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.locale.en-US.yaml
+++ b/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Создано tools/make_winget.py — правьте генератор, а не этот файл
+PackageIdentifier: N0deZ3r0.Win11Privacy
+PackageVersion: 1.9.2
+PackageLocale: en-US
+Publisher: N0deZ3r0
+PublisherUrl: https://github.com/N0deZ3r0
+PublisherSupportUrl: https://github.com/N0deZ3r0/Win11Privacy/issues
+PackageName: Windows 11 Privacy
+PackageUrl: https://github.com/N0deZ3r0/Win11Privacy
+License: MIT
+LicenseUrl: https://github.com/N0deZ3r0/Win11Privacy/blob/main/LICENSE
+ShortDescription: Turns off Microsoft data collection, shows what has already been collected and keeps updates from switching it back on.
+Description: |-
+  Applies privacy settings to Windows 10 and 11, then reads the real state of
+  the system back instead of ticking boxes. Shows the telemetry events Windows
+  has actually collected about this computer, which apps used the camera,
+  microphone and location, and what leaves the machine over the network.
+  Every change is journalled and can be reverted one item at a time.
+Tags:
+  - privacy
+  - telemetry
+  - windows
+  - debloat
+ReleaseNotesUrl: https://github.com/N0deZ3r0/Win11Privacy/releases/tag/v1.9.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.yaml
+++ b/manifests/n/N0deZ3r0/Win11Privacy/1.9.2/N0deZ3r0.Win11Privacy.yaml
@@ -1,0 +1,6 @@
+# Создано tools/make_winget.py — правьте генератор, а не этот файл
+PackageIdentifier: N0deZ3r0.Win11Privacy
+PackageVersion: 1.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Publisher and package name

N0deZ3r0 / Windows 11 Privacy (`N0deZ3r0.Win11Privacy`)

### What this package does

Turns off Microsoft data collection on Windows 10 and 11, then reads the real state of the
system back instead of ticking boxes. Every change is journalled and can be reverted.
Open source (MIT): https://github.com/N0deZ3r0/Win11Privacy

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

A single portable executable published in the project's GitHub release; the SHA256 above
matches `SHA256SUMS.txt` of that release. The program changes system settings and asks for
administrator rights itself, hence `ElevationRequirement: elevatesSelf`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430457)