### PR TITLE
Update version: KeeperSecurity.KeeperForcefield version 1.2.1.195

### DIFF
--- a/manifests/k/KeeperSecurity/KeeperForcefield/1.2.1.195/KeeperSecurity.KeeperForcefield.installer.yaml
+++ b/manifests/k/KeeperSecurity/KeeperForcefield/1.2.1.195/KeeperSecurity.KeeperForcefield.installer.yaml
@@ -11,5 +11,9 @@ Installers:
   InstallerUrl: https://download.keepersecurity.com/forcefield/keeperforcefield.msi
   InstallerSha256: E468308D4689F16C4FA7EDD0D3B20F3E52855963E35C4E002A3617B9A724C95F
   ProductCode: '{0D2C3D9B-5449-4794-B660-C1115B861FC5}'
+- Architecture: arm64
+  InstallerUrl: https://download.keepersecurity.com/forcefield/arm64/keeperforcefield.msi
+  InstallerSha256: 9D31D61C61E840ECB2AF902E4199D096805012E5FF99DAD4BF1E9DACB6F5A8A4
+  ProductCode: '{BBECEC1F-2A02-4905-BF55-D83AC042E488}'
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Add the arm64 installer to KeeperSecurity.KeeperForcefield 1.2.1.195.

The bot update to 1.2.1.195 (#429127) dropped the arm64 entry that 1.2.0.183 had. The arm64 download URL now serves 1.2.1.195 as well. Values read from the downloaded file:
- SHA256: 9D31D61C61E840ECB2AF902E4199D096805012E5FF99DAD4BF1E9DACB6F5A8A4
- ProductVersion 1.2.1.195, ProductCode {BBECEC1F-2A02-4905-BF55-D83AC042E488}, Arm64 package

The x64 file at its URL still matches the hash in the manifest.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schema; hash and MSI properties were read from the downloaded installer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430526)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tJRe9cFgvtMR7dB7kE14Q

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430526)