### PR TITLE
Update version: Intermedia.Unite version 2.32.143.0

### DIFF
--- a/manifests/i/Intermedia/Unite/2.32.143.0/Intermedia.Unite.installer.yaml
+++ b/manifests/i/Intermedia/Unite/2.32.143.0/Intermedia.Unite.installer.yaml
@@ -17,5 +17,15 @@ Installers:
   ProductCode: '{C2ED64BD-1CF9-447A-9B2C-C185D622F5E2}'
   AppsAndFeaturesEntries:
   - UpgradeCode: '{809A6B87-78EB-4ABA-98DE-19BE959BA7A9}'
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://cp.intermedia.net/voice/pbx/softphonereleases/default/latest-win/intermedia-unite-x64.msi
+  InstallerSha256: 97E5107F3DF06D881CF1630FF69B1DF228DE647176FB782EDF4928FAA4FCDEAF
+  InstallerSwitches:
+    InstallLocation: APPLICATIONFOLDER="<INSTALLPATH>"
+  ProductCode: '{57397122-1DBA-4F28-99C5-F948CC331CC6}'
+  AppsAndFeaturesEntries:
+  - UpgradeCode: '{809A6B87-78EB-4ABA-98DE-19BE959BA7A9}'
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Add the x64 installer to Intermedia.Unite 2.32.143.0.

The bot update to 2.32.143.0 (#425405) kept only the x86 MSI. The x64 MSI at the vendor's latest-win URL is the same version. Values read from the downloaded file:
- SHA256: 97E5107F3DF06D881CF1630FF69B1DF228DE647176FB782EDF4928FAA4FCDEAF
- ProductVersion 2.32.143.0, ProductCode {57397122-1DBA-4F28-99C5-F948CC331CC6}, UpgradeCode {809A6B87-78EB-4ABA-98DE-19BE959BA7A9}, x64 package

The entry has the same shape as the x64 entry of 2.32.60.0. The x86 file at its URL still matches the hash in the manifest.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schema; hash and MSI properties were read from the downloaded installer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430528)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tJRe9cFgvtMR7dB7kE14Q

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430528)