### PR TITLE
New version: derrod.legendary version 0.21.0

### DIFF
--- a/manifests/d/derrod/legendary/0.21.0/derrod.legendary.installer.yaml
+++ b/manifests/d/derrod/legendary/0.21.0/derrod.legendary.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: derrod.legendary
+PackageVersion: 0.21.0
+InstallerType: portable
+Commands:
+- legendary
+ReleaseDate: 2026-08-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/legendary-gl/legendary/releases/download/0.21.0/legendary_windows_x64.exe
+  InstallerSha256: 4C01A14C0ACB0C46069B197AE7212EA4EA6B861661126CA0593CDAC31658FB01
+- Architecture: arm64
+  InstallerUrl: https://github.com/legendary-gl/legendary/releases/download/0.21.0/legendary_windows_arm64.exe
+  InstallerSha256: 839E0D2298F9126608B0C851B9231055E8FA907C624A8BCE0A58278EFB221068
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/derrod/legendary/0.21.0/derrod.legendary.locale.en-US.yaml
+++ b/manifests/d/derrod/legendary/0.21.0/derrod.legendary.locale.en-US.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: derrod.legendary
+PackageVersion: 0.21.0
+PackageLocale: en-US
+Publisher: derrod
+PublisherUrl: https://rodney.io
+PublisherSupportUrl: https://github.com/legendary-gl/legendary/issues
+PackageName: legendary
+PackageUrl: https://github.com/legendary-gl/legendary
+License: GPL-3.0
+LicenseUrl: https://github.com/legendary-gl/legendary/blob/master/LICENSE
+ShortDescription: an open-source game launcher that can download and install games from the Epic Games platform.
+ReleaseNotes: |-
+  After years of slumber legendary-gl upstream is back with new 0.21.0 release, with some highlights like:
+  - ChunksV5 manifests, including encryption support
+  - Ubisoft games launch with uplay protocol support
+  - Legendary now requiring at least Python 3.10 (pypi, zipapp)
+  Together with multitude of improvements and bug fixes.
+  What's Changed
+  - Detect games specifying "the EA app" for their ThirdPartyManagedApp as Origin games (#632)
+  - Skip library items with no appName (#649)
+  - fix: add required arg name for FileLock >=3.15.3 (#656)
+  - Update Ubisoft game instructions (#591)
+  - fix: update graphql host (#713)
+  - [utils/cli] Accept empty string as a falsey value in strtobool (#701)
+  - fix: prevent .netrc credentials from being injected into api calls (#736)
+  - ci: update actions (#739)
+  - feat: support encrypted manifests and chunks (#738)
+  - Move to pyproject.toml and the uv build system (#741)
+  - Handle file tasks case-insensitively (#690)
+  - [core] check for STEAM_COMPAT_DATA_PATH in default.env too when resolving save paths (#714)
+  - tech: make python 3.10 a minimum required version (#746)
+  - fix: add 3rd param to setexchangecode callback (#745)
+  - fix: save-sync chunk read crash (#747)
+  - feat: support launching games with uplay protocol (#750)
+  - tech: ensure boolean types are always returned (#752)
+  - Bump urllib3 from 2.6.3 to 2.7.0 (#754)
+  - fix: support non-encrypted variants of v5 manifests (#756)
+  - [cli/core]: report grant date information with info (#748)
+  - Add achievement handling (#729)
+  - Display UAC prompt for games which requires admin rights (#668)
+  - cli: remove redundant if statement (#762)
+  - fix: unset old_manifest for all types of repair (#697)
+  - ci: automate pypi and releases drafting (#761)
+  - Bump idna from 3.11 to 3.15 (#755)
+  - Add Ruff (#743)
+  - release: 0.21.0 Lowlife (#765)
+  - fix: avoid KeyError when game metadata is missing id/namespace (#769)
+  - Make case_insensitive_file_search a no-op on Windows (#772)
+  - chore: fix typo (#771)
+  - ci: add id-token permission (#773)
+ReleaseNotesUrl: https://github.com/legendary-gl/legendary/releases/tag/0.21.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/derrod/legendary/0.21.0/derrod.legendary.yaml
+++ b/manifests/d/derrod/legendary/0.21.0/derrod.legendary.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: derrod.legendary
+PackageVersion: 0.21.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version: derrod.legendary 0.21.0.

The release assets were renamed: `legendary.exe` is now `legendary_windows_x64.exe`, and there is a new `legendary_windows_arm64.exe`, so the old URL pattern no longer exists. The project also moved to the legendary-gl organisation, so the URLs point at github.com/legendary-gl/legendary (github.com/derrod/legendary redirects there).

Both files were downloaded and checked: the hashes match the SHA256 digests GitHub reports for the assets, the x64 file is an AMD64 executable and the arm64 file an ARM64 executable.

Resolves #430044.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schema; hashes and executable types were read from the downloaded files.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430534)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tJRe9cFgvtMR7dB7kE14Q

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430534)