### PR TITLE
New version: NirSoft.InsideClipboard version 1.30

### DIFF
--- a/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.installer.yaml
+++ b/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NirSoft.InsideClipboard
+PackageVersion: '1.30'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: InsideClipboard.exe
+ReleaseDate: 2026-02-09
+Installers:
+- Architecture: neutral
+  UnsupportedOSArchitectures:
+  - arm
+  - arm64
+  InstallerUrl: https://www.nirsoft.net/utils/insideclipboard.zip
+  InstallerSha256: 13E71984F63C0C50E7710B92505D0B5BF422CA5214B61EAF51E02CB8A4B63B7E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.locale.en-US.yaml
+++ b/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NirSoft.InsideClipboard
+PackageVersion: '1.30'
+PackageLocale: en-US
+Publisher: NirSoft
+PackageName: InsideClipboard
+License: Freeware
+Copyright: Copyright (c) 2007 - 2026 Nir Sofer
+CopyrightUrl: https://www.nirsoft.net/utils/inside_clipboard.html
+ShortDescription: |-
+  Small utility that displays the binary content of all formats that are currently stored in the
+  clipboard.
+ReleaseNotes: |-
+  - Version 1.30:
+    - Added 'UTF-8' Display Mode.
+ReleaseNotesUrl: https://www.nirsoft.net/utils/inside_clipboard.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.yaml
+++ b/manifests/n/NirSoft/InsideClipboard/1.30/NirSoft.InsideClipboard.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NirSoft.InsideClipboard
+PackageVersion: '1.30'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New version: NirSoft.InsideClipboard 1.30.

NirSoft serves this tool from a fixed URL with no version in it. The zip there now holds version 1.30 (the exe inside reports FileVersion 1.30 and is dated 2026-02-09), so the 1.27 manifest with the old hash can no longer install. This adds 1.30 with the current hash. 1.27 can be removed once this is in.

Resolves #427898.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Validation note: `winget validate` and `winget install` were not run (no Windows machine available). The manifest set was checked locally against the 1.12.0 JSON schema; the hash and the exe version were read from the downloaded zip.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430535)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tJRe9cFgvtMR7dB7kE14Q

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430535)