### PR TITLE
New package: HiddenTunes.HiddenTunes version 1.0.1

### DIFF
--- a/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.installer.yaml
+++ b/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.installer.yaml
@@ -1,0 +1,27 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HiddenTunes.HiddenTunes
+PackageVersion: 1.0.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  Custom: /currentuser
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: Hidden Tunes Desktop 1.0.1
+  DisplayVersion: 1.0.1
+  Publisher: Hidden Tunes
+  ProductCode: 7ac3b9d9-a2ab-59e0-9fa4-b8f102a0c89e
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.hiddentunes.com/desktop/windows/1.0.1/Hidden-Tunes-Desktop-1.0.1-win-x64.exe
+  InstallerSha256: 3B8F17048E441EE9CFD9E59B2CAB529A3372D3BEE61D888796B1BA67BE6DF40B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.locale.en-US.yaml
+++ b/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HiddenTunes.HiddenTunes
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Hidden Tunes
+PublisherUrl: https://hiddentunes.com/
+PublisherSupportUrl: https://hiddentunes.com/support
+PrivacyUrl: https://hiddentunes.com/privacy
+PackageName: Hidden Tunes
+PackageUrl: https://hiddentunes.com/
+License: Proprietary
+LicenseUrl: https://hiddentunes.com/legal/desktop-eula
+ShortDescription: Hidden Tunes Desktop offers catalog browsing and media playback.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.yaml
+++ b/manifests/h/HiddenTunes/HiddenTunes/1.0.1/HiddenTunes.HiddenTunes.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HiddenTunes.HiddenTunes
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Hidden Tunes 1.0.1 for Windows x64 using its existing immutable publisher-hosted NSIS installer. The manifest selects per-user installation and references the [proprietary Desktop EULA](https://hiddentunes.com/legal/desktop-eula).

The publisher confirms that the existing Windows Desktop release was previously physically qualified and is working. This submission reuses that released installer unchanged. No additional installer execution or application functional testing was performed for this manifest submission.

## Validation evidence

- Official installer URL and artifact size: 155,130,811 bytes. SHA-256: `3b8f17048e441ee9cfd9e59b2cab529a3372d3bee61d888796b1ba67be6df40b`.
- Microsoft wingetcreate identified the installer as NSIS/nullsoft and calculated the expected hash. The embedded application is x64, with file version `1.0.1` and publisher metadata `Hidden Tunes`.
- Static inspection of the exact public installer's compiled NSIS header established `/currentuser`, quiet uninstall `/S`, version and uninstall-registration metadata, and the existing-install removal command with `/KEEP_APP_DATA`. These are artifact metadata findings, not a new runtime install/uninstall test.
- The three-file manifest set passed official `winget validate --manifest` using schema 1.12.

## Checklist

- [ ] Signed the [Microsoft Contributor License Agreement](https://cla.opensource.microsoft.com) (existing acceptance not yet verified)
- [x] Checked that there are no other open pull requests for this package/version
- [x] This PR only modifies one package/version
- [x] Validated manifest locally with `winget validate --manifest`
- [ ] Tested manifest locally with `winget install --manifest` (not run for this submission; publisher-confirmed existing release qualification reused)
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430553)