### PR TITLE
New package: kjanat.actionlint version 1.14.0

### DIFF
--- a/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.installer.yaml
+++ b/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: kjanat.actionlint
+PackageVersion: 1.14.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: actionlint.exe
+  PortableCommandAlias: actionlint
+Commands:
+- actionlint
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/kjanat/actionlint/releases/download/v1.14.0/actionlint_1.14.0_windows_386.zip
+  InstallerSha256: 895B71406FEDFBD0965A9FE4DAFEAA2CB7C28820F1421C104F2E94C20D1D74CF
+- Architecture: x64
+  InstallerUrl: https://github.com/kjanat/actionlint/releases/download/v1.14.0/actionlint_1.14.0_windows_amd64.zip
+  InstallerSha256: 286509D927BDCF96CF245033F489D79D71D748E88E9443B63B2B40CD083E07C1
+- Architecture: arm64
+  InstallerUrl: https://github.com/kjanat/actionlint/releases/download/v1.14.0/actionlint_1.14.0_windows_arm64.zip
+  InstallerSha256: EE2A5476589366D42B8F3E8A91A4642EB092B50FF04199F2601F668A8C61BF39
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.locale.en-US.yaml
+++ b/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: kjanat.actionlint
+PackageVersion: 1.14.0
+PackageLocale: en-US
+Publisher: kjanat
+PublisherUrl: https://github.com/kjanat
+PublisherSupportUrl: https://github.com/kjanat/actionlint/issues
+Author: Kaj Kowalski
+PackageName: actionlint
+PackageUrl: https://actionlint.kjanat.dev
+License: MIT
+LicenseUrl: https://github.com/kjanat/actionlint/blob/v1.14.0/LICENSE.txt
+Copyright: Copyright (c) 2026 Kaj Kowalski, Copyright (c) 2021 rhysd
+CopyrightUrl: https://github.com/kjanat/actionlint/blob/v1.14.0/LICENSE.txt
+ShortDescription: Static checker for GitHub Actions workflow files
+Description: |-
+  actionlint is a static checker for GitHub Actions workflow files. It checks workflow syntax,
+  expression placeholders, shell scripts in run steps, and other mistakes that otherwise only
+  surface when a workflow runs. This is the kjanat fork, published separately from rhysd.actionlint.
+Tags:
+- actionlint
+- ci
+- github-actions
+- linter
+- static-analysis
+- workflow
+- yaml
+ReleaseNotesUrl: https://github.com/kjanat/actionlint/releases/tag/v1.14.0
+InstallationNotes: ShellCheck and pyflakes are optional. When installed, actionlint can use them to check shell and Python scripts in workflow run steps.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.yaml
+++ b/manifests/k/kjanat/actionlint/1.14.0/kjanat.actionlint.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: kjanat.actionlint
+PackageVersion: 1.14.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Add `kjanat.actionlint` 1.14.0 for Windows x86, x64, and ARM64 using the existing release ZIP archives. This maintained fork has its own package identifier and does not update `rhysd.actionlint`.

Downloaded all three archives, verified their SHA-256 hashes against the release asset digests, and checked the executable PE architectures. The extracted x86 and x64 binaries both report version 1.14.0. `winget validate` succeeds with WinGet 1.29.290.

An actual `winget install --manifest` was not run because LocalManifestFiles is disabled on the host. ARM64 execution was not tested on the x64 host.

- Refs kjanat/actionlint#98.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — pending the CLA check
- [x] Linked to an issue (if applicable) — not applicable; first package submission

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests/k/kjanat/actionlint/1.14.0`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430563)