### PR TITLE
New version: M-Igashi.baken version 3.2.1

### DIFF
--- a/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.installer.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.installer.yaml
@@ -1,0 +1,20 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: baken.exe
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-09-07
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/baken/releases/download/v3.2.1/baken-v3.2.1-windows-x86_64.zip
+    InstallerSha256: 0EC2906DDE2D674365EDB4946DC188EC030444E9F7E3DA4EA544361A8C8F264A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/baken/issues
+Author: M-Igashi
+PackageName: Bake'n Deck
+PackageUrl: https://github.com/M-Igashi/baken
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/baken/blob/main/LICENSE
+ShortDescription: Rekordbox to CDJ prep toolkit - loudness gain, Key+BPM playlist sort, and CDJ-safe MP3 transcode
+Description: |-
+  Bake'n Deck (baken) is a Rekordbox to CDJ prep toolkit, the successor to headroom (renamed at v3.0.0).
+  The headroom subcommand analyzes audio files for loudness (LUFS) and True Peak headroom, then applies lossless gain adjustment. It supports MP3, AAC/M4A, FLAC, AIFF, and WAV files, with batch processing, lossless MP3/AAC gain via mp3rgain, and a scriptable non-interactive CLI mode.
+  The rbsort subcommand sorts every playlist in a Rekordbox collection.xml export by Camelot Key and BPM for harmonic mixing prep, in place and without touching any audio - no ffmpeg required.
+  The cdjsafe subcommand converts every track in a playlist to 320 kbps CBR MP3 at 44.1 kHz for pre-NXS2 CDJs, emitting an updated XML in which converted tracks inherit beatgrids and cue points verbatim.
+Moniker: baken
+Tags:
+  - aac
+  - audio
+  - cdj
+  - cli
+  - dj
+  - ffmpeg
+  - gain
+  - loudness
+  - lufs
+  - mastering
+  - mp3
+  - music
+  - normalize
+  - rekordbox
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/baken/releases/tag/v3.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.yaml
+++ b/manifests/m/M-Igashi/baken/3.2.1/M-Igashi.baken.yaml
@@ -1,0 +1,8 @@
+# Created with manual update
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.baken
+PackageVersion: 3.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Manual update of M-Igashi.baken to 3.2.1. Manifests copied from 3.2.0 with the version, release date, installer URL and SHA256 updated. Release: https://github.com/M-Igashi/baken/releases/tag/v3.2.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430580)