### PR TITLE
New version: agavra.tuicr version 0.25.0

### DIFF
--- a/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.installer.yaml
+++ b/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: agavra.tuicr
+PackageVersion: 0.25.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-09-02
+NestedInstallerFiles:
+- RelativeFilePath: tuicr.exe
+  PortableCommandAlias: tuicr
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/agavra/tuicr/releases/download/v0.25.0/tuicr-0.25.0-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 2943F15BAF6C0B498BD5535726C481678621FCCCB939A57AB1C35FDD1C2C0EB2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.locale.en-US.yaml
+++ b/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: agavra.tuicr
+PackageVersion: 0.25.0
+PackageLocale: en-US
+Publisher: Almog Gavra
+PublisherUrl: https://github.com/agavra
+PublisherSupportUrl: https://github.com/agavra/tuicr/issues
+Author: Almog Gavra
+PackageName: tuicr
+PackageUrl: https://tuicr.dev
+License: MIT
+LicenseUrl: https://github.com/agavra/tuicr/blob/main/LICENSE
+Copyright: Copyright (c) 2025 tuicr contributors
+CopyrightUrl: https://github.com/agavra/tuicr/blob/main/LICENSE
+ShortDescription: A code review TUI with vim keybindings. Export to GitHub, GitLab, Bitbucket, or clipboard.
+Description: |-
+  tuicr is a terminal code review tool with vim keybindings. It shows a GitHub-style continuous diff
+  so you can scroll through every changed file in one stream, and supports pull request style comments
+  at the line, range, file, and review level. Review progress is tracked at file or hunk granularity and
+  persisted across sessions. Finished reviews can be pushed to GitHub, GitLab, or Bitbucket, copied to
+  the clipboard as structured markdown, or piped to stdout. It works with git, jj, and mercurial, and can
+  review uncommitted changes, commit ranges, or an existing GitHub PR, GitLab MR, or Bitbucket PR.
+Moniker: tuicr
+Tags:
+- cli
+- code-review
+- diff
+- git
+- review
+- rust
+- terminal
+- tui
+- vim
+ReleaseNotesUrl: https://github.com/agavra/tuicr/releases/tag/v0.25.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.yaml
+++ b/manifests/a/agavra/tuicr/0.25.0/agavra.tuicr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: agavra.tuicr
+PackageVersion: 0.25.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: agavra.tuicr version 0.25.0.

Upstream release: https://github.com/agavra/tuicr/releases/tag/v0.25.0 (published 2026-09-02). The Windows release remains an x64 portable zip, and the existing Microsoft.VCRedist.2015+.x64 dependency is retained because tuicr.exe imports VCRUNTIME140.dll.

## ✅ Checklist

- [x] Signed the Contributor License Agreement

## 📦 Manifest Checklist

- [x] Checked that there are not other open pull requests for the same manifest update
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430585)