### PR TITLE
New package: Nasji.Nasjicad version 1.0.10

### DIFF
--- a/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.installer.yaml
+++ b/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Nasji.Nasjicad
+PackageVersion: 1.0.10
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+FileExtensions:
+- dwg
+- dxf
+ReleaseDate: 2026-09-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://nasji.com/downloads/Nasjicad-1.0.10-win-x64.exe
+  InstallerSha256: 5BF5AFED3B14C8814968EDCA7330379B41F2D19CFC50C806643F0CF2839EDB39
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.locale.en-US.yaml
+++ b/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Nasji.Nasjicad
+PackageVersion: 1.0.10
+PackageLocale: en-US
+Publisher: NASJI
+PublisherUrl: https://nasji.com
+PublisherSupportUrl: https://nasji.com/download
+PackageName: Nasjicad
+PackageUrl: https://nasji.com/download
+License: Proprietary
+LicenseUrl: https://nasji.com/download
+Copyright: Copyright (c) NASJI
+ShortDescription: Professional 2D CAD that opens, edits and saves DWG and DXF drawings.
+Description: |-
+  Nasjicad is a free 2D CAD program for Windows and macOS. It opens and saves native DWG and DXF drawings, draws with the usual tools (line, polyline, circle, arc, hatch, dimensions, blocks, layouts), and includes an agent that turns a written description into geometry in the drawing.
+Moniker: nasjicad
+Tags:
+- cad
+- dwg
+- dxf
+- drafting
+- drawing
+ReleaseNotes: Drawing by finger on phones, a focus layout, trackpad and Command-key support on Mac, and the web app installs from the browser.
+ReleaseNotesUrl: https://nasji.com/download
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.yaml
+++ b/manifests/n/Nasji/Nasjicad/1.0.10/Nasji.Nasjicad.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Nasji.Nasjicad
+PackageVersion: 1.0.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (local manifests are disabled on the authoring machine; the installer itself is the one served at nasji.com and was installed and run there)
- [x] Does your manifest conform to the 1.10 schema?

Nasjicad is a 2D CAD for Windows and macOS (native DWG/DXF). The installer is a code-signed NSIS package (Certum, timestamped) published by the same publisher at https://nasji.com/download; silent install with /S, per-user scope.