### PR TITLE
New package: mblua.AgentsCommander version 0.34.0

### DIFF
--- a/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.installer.yaml
+++ b/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: mblua.AgentsCommander
+PackageVersion: 0.30.5
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mblua/AgentsCommander/releases/download/v0.30.5/Agents.Commander_0.30.5_x64-setup.exe
+  InstallerSha256: 429C72004DCBA2343D147BF9E0283C03CC85DDC12EDCF6CC7202759F4CA380DF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.locale.en-US.yaml
+++ b/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: mblua.AgentsCommander
+PackageVersion: 0.30.5
+PackageLocale: en-US
+Publisher: AgentsCommander Contributors
+PublisherUrl: https://github.com/mblua/AgentsCommander
+PublisherSupportUrl: https://github.com/mblua/AgentsCommander/issues
+PackageName: Agents Commander
+PackageUrl: https://github.com/mblua/AgentsCommander
+License: MIT
+LicenseUrl: https://github.com/mblua/AgentsCommander/blob/v0.30.5/LICENSE
+Copyright: Copyright (c) 2026 Mariano Blua
+ShortDescription: Coordinate multiple CLI coding agents in isolated workspaces.
+Description: |-
+  AgentsCommander is a desktop application for running and coordinating multiple CLI coding agents.
+  It provides terminal sessions, teams, isolated room workspaces, and file-based communication between agents.
+Tags:
+- ai
+- coding
+- developer-tools
+- terminal
+ReleaseNotesUrl: https://github.com/mblua/AgentsCommander/releases/tag/v0.30.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.yaml
+++ b/manifests/m/mblua/AgentsCommander/0.30.5/mblua.AgentsCommander.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: mblua.AgentsCommander
+PackageVersion: 0.30.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Add **mblua.AgentsCommander 0.34.0** (Agents Commander), a desktop application for coordinating CLI coding agents. The manifest uses the publisher's stable Windows x64 NSIS installer in user scope.

Official release: https://github.com/mblua/AgentsCommander/releases/tag/v0.34.0. License: MIT.

Validation evidence: https://github.com/mblua/winget-pkgs/actions/runs/35108212200

- Downloaded installer SHA-256 matches both the GitHub release asset digest and `SHASUMS256.txt`.
- The submitted three-file manifest set passes the official 1.12.0 JSON schemas and native `winget validate` with WinGet 1.29.290.
- Direct NSIS installation with `/S` passed on Windows Server 2025. The installed application is x64, reports version 0.34.0, registers the expected name and publisher, and exits successfully for `--help`.
- The installed executable matches the published raw executable after accounting for [Tauri's documented NSIS bundle marker](https://github.com/tauri-apps/tauri/blob/tauri-cli-v2.10.1/crates/tauri-bundler/src/bundle.rs#L21).
- Direct NSIS uninstallation with `/S` passed; the executable and uninstall registry entry were removed.

**End-to-end test limitation:** `winget install --manifest` was attempted in the hosted Windows environment but stalled when launching the downloaded installer. The native NSIS tests above completed using the same checksum-verified installer. This PR was originally opened for 0.30.5, which passed Microsoft's upstream validation checks 01-10; it has been updated to 0.34.0 and upstream validation must run again for the new manifests. The local end-to-end attempt is still recorded as incomplete.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com); `license/cla` is successful.
- Linked issue: not applicable; this is a new package manifest submission.

## 📦 Manifest Checklist

- [x] Checked that there are no existing package entries or other open pull requests for AgentsCommander.
- [x] This PR only modifies one package version represented by its three-file manifest set.
- [x] Validated manifest with `winget validate --manifest <path>` in the isolated Windows runner.
- [ ] Tested manifest end to end with `winget install --manifest <path>` — limitation documented above.
- [x] Manifest conforms to the 1.12 schema.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430604)


