### PR TITLE
CryptographicTriangles.TrianglesQt version 6.2.6.6

### DIFF
--- a/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.installer.yaml
+++ b/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: CryptographicTriangles.TrianglesQt
+PackageVersion: 6.2.6.6
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerType: exe
+    InstallerUrl: https://github.com/SamiAhmed7777/triangles_v5/releases/download/v6.2.6.6/Cryptographic-Triangles-6.2.6.6-win-x64-setup.exe
+    InstallerSha256: 9fba566bde69bdfd0d0ac885d59a19b4493b0bb56508d13a431062466bbd760a
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.locale.en-US.yaml
+++ b/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: CryptographicTriangles.TrianglesQt
+PackageVersion: 6.2.6.6
+PackageLocale: en-US
+Publisher: Cryptographic Triangles
+PublisherUrl: https://cryptographic-triangles.org
+PackageName: Cryptographic Triangles Qt Wallet
+License: MIT
+ShortDescription: Privacy-focused cryptocurrency wallet with PoS staking, Tor v3, and encrypted messaging.
+Description: |-
+  Cryptographic Triangles (TRI) is a privacy-focused cryptocurrency
+  featuring Proof-of-Stake consensus with 33% annual staking rewards,
+  Tor v3 onion routing, and built-in encrypted peer-to-peer messaging.
+  Originally launched in July 2014, featuring the unique Hash9 algorithm
+  (13-step hash cascade).
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.yaml
+++ b/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: CryptographicTriangles.TrianglesQt
+PackageVersion: 6.2.6.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Automated update of CryptographicTriangles.TrianglesQt to v6.2.6.6. Artifacts at https://github.com/SamiAhmed7777/triangles_v5/releases/download/v6.2.6.6/Cryptographic-Triangles-6.2.6.6-win-x64-setup.exe (SHA256: 9fba566bde69bdfd0d0ac885d59a19b4493b0bb56508d13a431062466bbd760a).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430608)