### PR TITLE
New package: Contextify.Contextify version 1.8.0

### DIFF
--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.installer.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.installer.yaml
@@ -1,0 +1,37 @@
+PackageIdentifier: Contextify.Contextify
+PackageVersion: 1.8.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+  Repair: --silent
+UpgradeBehavior: install
+RepairBehavior: installer
+Commands:
+- contextify
+Installers:
+- Architecture: x64
+  InstallerUrl: 'https://github.com/PeterPym/contextify/releases/download/v1.8.0/ContextifyDesktop-win-x64-stable-Setup.exe'
+  InstallerSha256: 1F46668DF3DE4E542D3D31E5D71BB9F5E6A791C67B3FE102E5FC5757EAF678A5
+  ProductCode: ContextifyDesktop
+  AppsAndFeaturesEntries:
+  - DisplayName: Contextify
+    Publisher: Robert Banagale
+    ProductCode: ContextifyDesktop
+    InstallerType: exe
+- Architecture: arm64
+  InstallerUrl: 'https://github.com/PeterPym/contextify/releases/download/v1.8.0/ContextifyDesktop-win-arm64-stable-Setup.exe'
+  InstallerSha256: 445518A70C65D14C1452974B80BD07FC37A6AAE1AF6129BA95CB6AEDC0BA168C
+  ProductCode: ContextifyDesktop
+  AppsAndFeaturesEntries:
+  - DisplayName: Contextify
+    Publisher: Robert Banagale
+    ProductCode: ContextifyDesktop
+    InstallerType: exe
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.installer.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Contextify.Contextify
 PackageVersion: 1.8.0
 InstallerType: exe

--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.locale.en-US.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.locale.en-US.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Contextify.Contextify
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: Robert Banagale
+PublisherUrl: https://contextify.sh/
+PublisherSupportUrl: https://contextify.sh/support/
+PrivacyUrl: https://contextify.sh/privacy/
+PackageName: Contextify
+PackageUrl: https://contextify.sh/download/
+License: Proprietary
+LicenseUrl: https://contextify.sh/terms/
+ShortDescription: Searchable history for Claude Code and Codex.
+Moniker: contextify
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.locale.en-US.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Contextify.Contextify
 PackageVersion: 1.8.0
 PackageLocale: en-US

--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Contextify.Contextify
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.yaml
+++ b/manifests/c/Contextify/Contextify/1.8.0/Contextify.Contextify.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Contextify.Contextify
 PackageVersion: 1.8.0
 DefaultLocale: en-US


### PR DESCRIPTION
### New package: Contextify.Contextify version 1.8.0

Adds `Contextify.Contextify` 1.8.0 (new package). Contextify is searchable history for Claude Code and Codex.

- Installers are the publisher's own signed GitHub release assets on `github.com/PeterPym/contextify` (x64 + arm64), version-specific HTTPS URLs.
- `InstallerType: exe` (Velopack), silent switch `--silent`; the publisher's own install/uninstall proof passes on both architectures.
- `InstallerSha256` computed from the published release bytes.
- Manifest schema `1.12.0`, multi-file set under `manifests/c/Contextify/Contextify/1.8.0/`.

Checklist:
- [x] There are no other open pull requests for this manifest.
- [x] The manifests conform to the 1.12.0 schema (validated with `jsonschema` against the published 1.12.0 version/installer/defaultLocale schemas).
- [ ] Contributor License Agreement: will be signed when the CLA bot prompts.
- [ ] `winget validate` / `winget install` from a Windows host: the authoring host is macOS; the publisher's own Windows install/uninstall proof passes on both architectures, and the Microsoft validation pipeline performs the install/uninstall.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430639)