### PR TITLE
New package: Flockbay.Flockbay version 0.1.79

### DIFF
--- a/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.installer.yaml
+++ b/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.installer.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Flockbay.Flockbay
+PackageVersion: 0.1.79
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Protocols:
+- flockbay
+ReleaseDate: 2026-09-05
+InstallationMetadata:
+  DefaultInstallLocation: '%LOCALAPPDATA%\Flockbay'
+  Files:
+  - RelativeFilePath: flockbay-desktop.exe
+    FileType: launch
+    DisplayName: Flockbay
+Installers:
+- Architecture: x64
+  InstallerUrl: https://api.flockbay.com/bootstrap/plan672/windows/stable-x86_64-v1/0.1.79/i-ae50cfc29e265eea10cdc211dc4495c94dbc9d89b00bfd67200cc9fcdd68a17b/Flockbay_0.1.79_x64-setup.exe
+  InstallerSha256: AE50CFC29E265EEA10CDC211DC4495C94DBC9D89B00BFD67200CC9FCDD68A17B
+  ProductCode: Flockbay
+  AppsAndFeaturesEntries:
+  - DisplayName: Flockbay
+    Publisher: flockbay
+    ProductCode: Flockbay
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.locale.en-US.yaml
+++ b/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Flockbay.Flockbay
+PackageVersion: 0.1.79
+PackageLocale: en-US
+Publisher: Flockbay
+PublisherUrl: https://flockbay.com/
+PrivacyUrl: https://flockbay.com/privacy/
+Author: 9560-9970 Québec inc.
+PackageName: Flockbay
+PackageUrl: https://flockbay.com/
+License: Proprietary
+LicenseUrl: https://flockbay.com/terms/
+Copyright: © 2026 Flockbay
+ShortDescription: Free AI game maker. Build your dream game idea with AI. No code, no game engine to learn.
+Description: |-
+  Flockbay is the free AI game maker for Mac and Windows. Describe the game you want, play what it builds on the bundled Godot engine, and change anything by asking. Make levels, combat, enemies and sound, then export a real PC game. No code and no game engine to learn.
+  Building a game needs an internet connection and a Flockbay account (free plan available). The game you make runs locally on your PC.
+Moniker: flockbay
+Tags:
+- ai
+- game-maker
+- game-engine
+- godot
+- no-code
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.yaml
+++ b/manifests/f/Flockbay/Flockbay/0.1.79/Flockbay.Flockbay.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Flockbay.Flockbay
+PackageVersion: 0.1.79
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Flockbay is a free AI game maker for Windows (and Mac). This is a first submission of `Flockbay.Flockbay` 0.1.79.

- Installer: Tauri NSIS per-user (`InstallerType: nullsoft`, `/S`), Authenticode signed (9560-9970 Québec inc.).
- `InstallerUrl` is the immutable versioned file on `api.flockbay.com` (same registrable domain as `PublisherUrl` https://flockbay.com/). SHA-256 matches `winget hash` on Windows 11.
- `winget validate --manifest` succeeded on Windows 11 (winget 1.29) against these three files.
- Not tested in this PR with `winget install --manifest` on a clean VM (the publisher's own machine already has a newer in-place install). Happy to run SandboxTest if a reviewer wants it.
- Silent install creates a desktop shortcut, matching the vendor installer.

Checklist:
- [x] Have you signed the Microsoft CLA?
- [x] Have you checked that there aren't other open pull requests for the same manifest update?
- [x] Have you validated your manifest locally with `winget validate --manifest`?
- [ ] Have you tested your manifest locally with `winget install --manifest`?
- [x] Have you checked that your installer is not blocked by Windows Defender SmartScreen?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430715)