### PR TITLE
New version: Aleckstygit.WayCoder version 0.96.67

### DIFF
--- a/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.installer.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.67
+InstallerLocale: zh-CN
+InstallerType: portable
+Commands:
+  - waycoder
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.67/waycoder-v0.96.67-win-x64.zip
+    InstallerSha256: 0333abdfd693d37290d05dfd6fd6ced8a90af0ff54ee58090e7a63b24d4c5545
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.locale.zh-CN.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.67
+PackageLocale: zh-CN
+Publisher: Aleckstygit
+PublisherUrl: https://gitee.com/aleckstygit/way-coder
+PublisherSupportUrl: https://gitee.com/aleckstygit/way-coder/issues
+PackageName: WayCoder
+PackageUrl: https://gitee.com/aleckstygit/way-coder
+License: MIT
+ShortDescription: 中文编程智能体 CLI Coding Agent
+Tags:
+  - coding
+  - agent
+  - ai
+  - cli
+  - programmer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.67/Aleckstygit.WayCoder.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.67
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
更新 WayCoder 到 0.96.67（多端斜杠命令收敛到单一 SlashCommandRegistry + GUI/Web/MAUI 补齐）。下载源 GitHub Release（跨平台 NativeAOT）。
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430722)