### PR TITLE
Update: VisoDyne.BatteryMonitor to 1.1

### DIFF
--- a/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.installer.yaml
+++ b/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.installer.yaml
@@ -1,0 +1,40 @@
+# Created with the VisoDyne release process
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VisoDyne.BatteryMonitor
+PackageVersion: "1.1"
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: exe
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-07
+AppsAndFeaturesEntries:
+- DisplayName: VisoDyne Battery Monitor
+  Publisher: VisoDyne
+  ProductCode: VisoDyneBatteryMonitor
+  InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/VisoDyne/VisoDyneBatteryMonitor/releases/download/Setup/VisoDyneBatteryMonitorSetup-1.1-win64.exe
+  InstallerSha256: C6A28AF76BBFC4201FB8F90B61F234AB9F1A9CF271D525CD3B0EA7D23F94C92E
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+    Custom: /CURRENTUSER /STARTMINIMIZED
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevationRequired
+  InstallerUrl: https://github.com/VisoDyne/VisoDyneBatteryMonitor/releases/download/Setup/VisoDyneBatteryMonitorSetup-1.1-win64.exe
+  InstallerSha256: C6A28AF76BBFC4201FB8F90B61F234AB9F1A9CF271D525CD3B0EA7D23F94C92E
+  InstallerSwitches:
+    Silent: /S
+    SilentWithProgress: /S
+    Custom: /ALLUSERS /STARTMINIMIZED
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.locale.en-US.yaml
+++ b/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# Created with the VisoDyne release process
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VisoDyne.BatteryMonitor
+PackageVersion: "1.1"
+PackageLocale: en-US
+Publisher: VisoDyne
+PublisherUrl: https://visodyne.com
+PublisherSupportUrl: https://visodyne.com/battery-monitor
+Author: VisoDyne
+PackageName: VisoDyne Battery Monitor
+PackageUrl: https://visodyne.com/battery-monitor
+License: Proprietary
+LicenseUrl: https://visodyne.com/terms-of-service
+PrivacyUrl: https://visodyne.com/privacy-policy
+Copyright: Copyright (c) VisoDyne
+ShortDescription: System tray battery monitor for wireless devices on Windows 10 and 11.
+Description: |-
+  VisoDyne Battery Monitor is a Windows 10 and 11 system tray app that shows live battery levels for wireless devices, including headphones, earbuds, AirPods, mice, keyboards, game controllers, and speakers. It offers per-device tray icons, configurable icon styles and battery color thresholds, low battery notifications, and battery time estimates for devices that report charge in coarse steps.
+
+  A free Community version is available and does not expire.
+
+  This package is the setup program. It downloads the current application release, verifies its SHA-256 checksum, and then installs it.
+Moniker: visodyne-battery-monitor
+Tags:
+- airpods
+- battery
+- bluetooth
+- earbuds
+- headphones
+- keyboard
+- monitor
+- mouse
+- notification
+- system-tray
+- tray
+- wireless
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.yaml
+++ b/manifests/v/VisoDyne/BatteryMonitor/1.1/VisoDyne.BatteryMonitor.yaml
@@ -1,0 +1,8 @@
+# Created with the VisoDyne release process
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VisoDyne.BatteryMonitor
+PackageVersion: "1.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Updates VisoDyne Battery Monitor to version 1.1 using the versioned bootstrap installer. Both install scopes pass `/STARTMINIMIZED` so the app opens minimized after installation.

## Checklist

- [x] Signed the Contributor License Agreement
- [x] Checked that there are no other open pull requests for this manifest update
- [x] This PR only modifies one manifest version
- [x] Validated locally with `winget validate --manifest manifests/v/VisoDyne/BatteryMonitor/1.1`
- [x] Tested locally with `winget install --manifest manifests/v/VisoDyne/BatteryMonitor/1.1`
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430733)