### PR TITLE
Fix: ScooterSoftware.BeyondCompare.4 version 4.4.7.28397 - declare en-US on the English installers

### DIFF
--- a/manifests/s/ScooterSoftware/BeyondCompare/4/4.4.7.28397/ScooterSoftware.BeyondCompare.4.installer.yaml
+++ b/manifests/s/ScooterSoftware/BeyondCompare/4/4.4.7.28397/ScooterSoftware.BeyondCompare.4.installer.yaml
@@ -12,11 +12,13 @@ FileExtensions:
 - bcss
 ReleaseDate: 2023-10-19
 Installers:
-- Architecture: x86
+- InstallerLocale: en-US
+  Architecture: x86
   InstallerUrl: https://www.scootersoftware.com/files/BCompare-4.4.7.28397.exe
   InstallerSha256: 5B14F35BF4219FDCC138A4A6ED8F20605D455027A94A50AB37DB64E53153D141
   ProductCode: BeyondCompare4_is1
-- Architecture: x64
+- InstallerLocale: en-US
+  Architecture: x64
   InstallerUrl: https://www.scootersoftware.com/files/BCompare-4.4.7.28397.exe
   InstallerSha256: 5B14F35BF4219FDCC138A4A6ED8F20605D455027A94A50AB37DB64E53153D141
   ProductCode: BeyondCompare4_is1


### PR DESCRIPTION
## 📖 Description

`winget install ScooterSoftware.BeyondCompare.4 --locale en-US` fails with **"No applicable installer found."**

The two English installers in this manifest don't declare a locale at all:

```yaml
- Architecture: x86
  InstallerUrl: https://www.scootersoftware.com/files/BCompare-4.4.7.28397.exe
```

Every other installer in the same file does — `de-DE`, `fr-FR`, `ja-JP`, `zh-CN`. When `--locale` is passed, winget only considers installers whose locale matches the request, so the two English entries are never candidates and the install fails.

The fix adds `InstallerLocale: en-US` to those two entries. Nothing else changes — same URLs, same SHA256 hashes, same product codes, 4 lines added and 2 removed.

I used `en-US` rather than bare `en` to match the region-qualified style already used by every other locale in this file.

This is the same fix that was applied to **BeyondCompare 5** after #207619 — that manifest declares an explicit English locale, which is why v5 works and v4 doesn't.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - Resolves #428343

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — `Manifest validation succeeded.` on winget v1.29.290
- [ ] Tested manifest locally with `winget install --manifest <path>` — not done; `--manifest` needs `LocalManifestFiles` enabled as administrator on my machine. Happy to have this verified in validation.
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) — this manifest is on schema 1.6.0; I left the schema version alone to keep the change to the reported bug. Glad to bump it if you'd prefer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430771)