### PR TITLE
New package: DoubleCouponDay.Stickle version 0.3.4

### DIFF
--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: DoubleCouponDay.Stickle
+PackageVersion: 0.3.4
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+InstallModes:
+- silent
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: stickle.exe
+    PortableCommandAlias: stickle
+  InstallerUrl: https://nightly.link/DoubleCouponDay/stickle/workflows/build-tui/main2/stickle-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 48BDAC72748B080A5E4B437A2B80630A58B18C7D9F56152708B54CA72AFBF83B
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
@@ -13,7 +13,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: stickle.exe
     PortableCommandAlias: stickle
-  InstallerUrl: https://github.com/DoubleCouponDay/stickle/actions/runs/34094329093/artifacts/10008022745
-  InstallerSha256: 21DAC4C19A35659C468698DEFB2BAE507AB3FE5D5BBE25B5EBE019464B869007
+  InstallerUrl: https://github.com/DoubleCouponDay/stickle/releases/download/0.3.4/stickle-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 21dac4c19a35659c468698defb2bae507ab3fe5d5bbe25b5ebe019464b869007
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
@@ -12,6 +12,6 @@ Installers:
   - RelativeFilePath: stickle.exe
     PortableCommandAlias: stickle
   InstallerUrl: https://nightly.link/DoubleCouponDay/stickle/workflows/build-tui/main2/stickle-x86_64-pc-windows-msvc.zip
-  InstallerSha256: 48BDAC72748B080A5E4B437A2B80630A58B18C7D9F56152708B54CA72AFBF83B
+  InstallerSha256: 21DAC4C19A35659C468698DEFB2BAE507AB3FE5D5BBE25B5EBE019464B869007
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: DoubleCouponDay.Stickle
 PackageVersion: 0.3.4
 MinimumOSVersion: 10.0.17763.0
@@ -14,4 +16,4 @@ Installers:
   InstallerUrl: https://nightly.link/DoubleCouponDay/stickle/workflows/build-tui/main2/stickle-x86_64-pc-windows-msvc.zip
   InstallerSha256: 21DAC4C19A35659C468698DEFB2BAE507AB3FE5D5BBE25B5EBE019464B869007
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.installer.yaml
@@ -13,7 +13,7 @@ Installers:
   NestedInstallerFiles:
   - RelativeFilePath: stickle.exe
     PortableCommandAlias: stickle
-  InstallerUrl: https://nightly.link/DoubleCouponDay/stickle/workflows/build-tui/main2/stickle-x86_64-pc-windows-msvc.zip
+  InstallerUrl: https://github.com/DoubleCouponDay/stickle/actions/runs/34094329093/artifacts/10008022745
   InstallerSha256: 21DAC4C19A35659C468698DEFB2BAE507AB3FE5D5BBE25B5EBE019464B869007
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.locale.en-US.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: DoubleCouponDay.Stickle
 PackageVersion: 0.3.4
 PackageLocale: en-US
@@ -21,4 +23,4 @@ Tags:
 - tui
 ReleaseNotesUrl: https://github.com/DoubleCouponDay/stickle/releases
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.locale.en-US.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.locale.en-US.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: DoubleCouponDay.Stickle
+PackageVersion: 0.3.4
+PackageLocale: en-US
+Publisher: DoubleCouponDay
+PublisherUrl: https://github.com/DoubleCouponDay
+PublisherSupportUrl: https://github.com/DoubleCouponDay/stickle/issues
+Author: DoubleCouponDay
+PackageName: Stickle
+PackageUrl: https://github.com/DoubleCouponDay/stickle
+License: LGPL-3.0-only
+LicenseUrl: https://github.com/DoubleCouponDay/stickle/blob/main2/LICENSE
+ShortDescription: TUI for a streamlined Rusty PLC Compiler workflow
+Description: The Stickle Workflow provides a Terminal User Interface and example Structured Text project for the Rusty PLC compiler, unlocking plain-text source control and unit testing for automation projects without coupling to a manufacturer ecosystem.
+Moniker: stickle
+Tags:
+- automation
+- compiler
+- plc
+- rust
+- structured-text
+- tui
+ReleaseNotesUrl: https://github.com/DoubleCouponDay/stickle/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: DoubleCouponDay.Stickle
+PackageVersion: 0.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.yaml
+++ b/manifests/d/DoubleCouponDay/Stickle/0.3.4/DoubleCouponDay.Stickle.yaml
@@ -1,5 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: DoubleCouponDay.Stickle
 PackageVersion: 0.3.4
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds version 0.3.4 of the Stickle TUI to Winget. 

## ✅ Checklist

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [X] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [X] This PR only modifies one (1) manifest
- [X] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [X] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430818)