### PR TITLE
New package: hclivess.summoner version 1.2

### DIFF
--- a/manifests/h/hclivess/summoner/1.2/hclivess.summoner.installer.yaml
+++ b/manifests/h/hclivess/summoner/1.2/hclivess.summoner.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: hclivess.summoner
+PackageVersion: "1.2"
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: summoner-1.2-windows-x64\summoner.exe
+  PortableCommandAlias: summoner
+ReleaseDate: 2026-09-07
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hclivess/summoner/releases/download/v1.2/summoner-1.2-windows-x64.zip
+  InstallerSha256: B24A4E85828FA1989B784F28FC914CAC6957ED5D948E44F95B2643128C29F225
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hclivess/summoner/1.2/hclivess.summoner.locale.en-US.yaml
+++ b/manifests/h/hclivess/summoner/1.2/hclivess.summoner.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: hclivess.summoner
+PackageVersion: "1.2"
+PackageLocale: en-US
+Publisher: hclivess
+PublisherUrl: https://github.com/hclivess
+PublisherSupportUrl: https://github.com/hclivess/summoner/issues
+PackageName: summoner
+PackageUrl: https://github.com/hclivess/summoner
+License: MIT
+LicenseUrl: https://github.com/hclivess/summoner/blob/main/LICENSE
+ShortDescription: Photo developer - drop raws or JPEGs in, press Start, get developed photos
+Description: |-
+  A digital photo developer with no catalogue and no import step. Drop camera raw files
+  (CR2/CR3, NEF, ARW, DNG, ORF, RW2, RAF and more) or JPEG/PNG/TIFF into the queue, press
+  Start, and developed photos land in a "developed" folder next to the originals. Auto
+  develop analyses every photo separately - white balance from plausibly-grey pixels,
+  highlight-protected exposure, local tone mapping for backlit subjects - with six profiles
+  and twelve manual sliders on top, and a live before/after preview. Outputs JPEG (EXIF
+  preserved), PNG or 16-bit TIFF. Originals are never modified.
+Moniker: summoner
+Tags:
+- photography
+- raw
+- photo-editing
+- image-processing
+- batch-processing
+- photo-developer
+ReleaseNotesUrl: https://github.com/hclivess/summoner/releases/tag/v1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hclivess/summoner/1.2/hclivess.summoner.yaml
+++ b/manifests/h/hclivess/summoner/1.2/hclivess.summoner.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: hclivess.summoner
+PackageVersion: "1.2"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **hclivess.summoner** version 1.2 — a photo developer (drop raws/JPEGs in, press Start, developed photos land next to the originals; auto develop + profiles, no catalogue). MIT-licensed, portable zip build; I am the author.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?