### PR TITLE
New package: hclivess.diskmaster version 1.1

### DIFF
--- a/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.installer.yaml
+++ b/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: hclivess.diskmaster
+PackageVersion: "1.1"
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: diskmaster-1.1-windows-x64\diskmaster.exe
+  PortableCommandAlias: diskmaster
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/hclivess/diskmaster/releases/download/v1.1/diskmaster-1.1-windows-x64.zip
+  InstallerSha256: C69DC66FA9817C5275AC378F25039865A52B34D841A7B66B20AB78F1D50ECE42
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.locale.en-US.yaml
+++ b/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: hclivess.diskmaster
+PackageVersion: "1.1"
+PackageLocale: en-US
+Publisher: hclivess
+PublisherUrl: https://github.com/hclivess
+PublisherSupportUrl: https://github.com/hclivess/diskmaster/issues
+PackageName: diskmaster
+PackageUrl: https://github.com/hclivess/diskmaster
+License: MIT
+LicenseUrl: https://github.com/hclivess/diskmaster/blob/main/LICENSE
+ShortDescription: Drive health monitor with native SMART, an explained health score and surface scans
+Description: |-
+  Drive health monitor for Windows, Linux and macOS. Reads SMART natively, turns the raw
+  attributes into an explained health score, runs surface scans that name the files sitting
+  on bad sectors, confirms every unreadable sector with a second read, and keeps history
+  with configurable alerts.
+Moniker: diskmaster
+Tags:
+- smart
+- disk-health
+- hard-drive
+- hdd
+- ssd
+- monitoring
+ReleaseNotesUrl: https://github.com/hclivess/diskmaster/releases/tag/v1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.yaml
+++ b/manifests/h/hclivess/diskmaster/1.1/hclivess.diskmaster.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: hclivess.diskmaster
+PackageVersion: "1.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: **hclivess.diskmaster** version 1.1 — a drive health monitor (native SMART, explained health score, surface scans that name files on bad sectors). MIT-licensed, portable zip build; I am the author.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430825)