### PR TITLE
Additional version: Microsoft.SQLServer.OLEDBDriver version 18.7.4.0

### DIFF
--- a/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.installer.yaml
+++ b/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.installer.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SQLServer.OLEDBDriver
+PackageVersion: 18.7.4.0
+ReleaseDate: 2024-07-09
+InstallerType: wix
+InstallerSwitches:
+  Silent: /qn IACCEPTMSOLEDBSQLLICENSETERMS=YES
+  SilentWithProgress: /qb IACCEPTMSOLEDBSQLLICENSETERMS=YES
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+    MinimumVersion: 14.51.36247.0
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+    MinimumVersion: 14.51.36247.0
+Installers:
+- Architecture: x64
+  InstallerLocale: en-US
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/en-US/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 81B3D934B81D855EBEB6D8402C2798AF897BEFFE69F608EC2529CF4FFC7DFDB0
+  ProductCode: '{76EB75D2-CCF6-41A9-90B6-922DE9146276}'
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x86
+  InstallerLocale: en-US
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/en-US/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: F488AB31BDF32CB2EA828D1922C0E31714C7B93537FF4417B7B9FEBE92FFA336
+  ProductCode: '{2A1CFEDA-1DD7-479B-A6FA-EAF26D3E44E5}'
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x64
+  InstallerLocale: de-DE
+  ProductCode: '{6C6CC193-CAD1-46CD-B50D-9A5BB62D294E}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/de-DE/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 014996F585FA2572608509A0290AEABE45C3F9A0197529A3B151886D2BDC0397
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB-Treiber für SQL Server'
+- Architecture: x86
+  InstallerLocale: de-DE
+  ProductCode: '{4E87DE28-625E-4956-8D7A-8CCE848A87CE}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/de-DE/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: 75E556F48678646B20F9861880790955CDEEA9E25B130D34ADEAF7C8BE6B346B
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB-Treiber für SQL Server'
+- Architecture: x64
+  InstallerLocale: es-ES
+  ProductCode: '{476C77EF-90E6-4B04-A59A-83CC4749B4F5}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/es-ES/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 3C0E73BA23142F31488BD8CC693C1F2A0BAD624186E529F4DE46C75D44B501EB
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x86
+  InstallerLocale: es-ES
+  ProductCode: '{A8ECFDE9-ABDB-4CF8-A81F-84815F9EB736}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/es-ES/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: BFD00448F801CF6B6D71DBAD4B83F91617317E82B712E04415E9690498373997
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x64
+  InstallerLocale: fr-FR
+  ProductCode: '{AB18F190-38D2-415B-88CA-608E6F62124A}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/fr-FR/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 20A94BC9C01046CA16A8E46B6944AE8745E027A9BC56C94ADC88F33BAB0F5A6D
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver pour SQL Server'
+- Architecture: x86
+  InstallerLocale: fr-FR
+  ProductCode: '{D259C733-243C-4879-BC4A-EEE2C11209E5}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/fr-FR/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: E07B5AF35E61D0A1146AD5F591D0EA9A9E9CC3B4E9DE367E412A1D0101C64FBC
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver pour SQL Server'
+- Architecture: x64
+  InstallerLocale: it-IT
+  ProductCode: '{C70017D9-C725-4FFA-A7DB-CCF374118F2E}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/it-IT/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 796C5A37D898AA9278A473EB681BAF4C6BFA2BCC2AAFA9701B5EB4A0A35EC302
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver per SQL Server'
+- Architecture: x86
+  InstallerLocale: it-IT
+  ProductCode: '{4187CF30-04D9-41F1-A662-73A6E87D1F2D}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/it-IT/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: 8769A9D28B0341687A724F12650201D2BB0A9BE71DEE4123EABF53B1589CB81B
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver per SQL Server'
+- Architecture: x64
+  InstallerLocale: ja-JP
+  ProductCode: '{D2077315-EBE2-4A98-A41F-55A183F775FE}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/ja-JP/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: B1B042FD113B7BEFB5251A1A8E4E99399B046C613399261325321D894F738FC5
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x86
+  InstallerLocale: ja-JP
+  ProductCode: '{2A0B7D7A-29A3-4698-A3FB-7F2F54212B24}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/ja-JP/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: 592A193029C049405048D8522C48572FE22C795D1EEAB7160F5344656018A909
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x64
+  InstallerLocale: ko-KR
+  ProductCode: '{861C343E-0A89-4217-9816-8199C4B5C1CD}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/ko-KR/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: CBACC3FC5260B26E3A03E23857D982F662F815DFAE07208663253DCA1F072AE2
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x86
+  InstallerLocale: ko-KR
+  ProductCode: '{E8197954-8AE2-45E8-B4A0-427D6527E455}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/ko-KR/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: CA54CB059DCC91FAA5E2B26EBD995FAF0A1116787D984D02C841DF1763F1764E
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x64
+  InstallerLocale: pt-BR
+  ProductCode: '{331567C2-6A4D-44EF-9F99-940438FECB2F}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/pt-BR/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 1843FB784738C273ABA0BED590455C952C57CF5C189FCEBF3CF4C00115B65F66
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Driver do Microsoft OLE DB para SQL Server'
+- Architecture: x86
+  InstallerLocale: pt-BR
+  ProductCode: '{44F06AFB-6914-45AC-8597-C5FCB95427C0}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/pt-BR/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: A8767C9E333EE10BCB362EEEFF2CCEB77483F48E911B0EFA66DE9F017137C7A2
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Driver do Microsoft OLE DB para SQL Server'
+- Architecture: x64
+  InstallerLocale: zh-TW
+  ProductCode: '{D0706BDD-6FBE-4289-97F9-0378A6499C0E}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/zh-TW/18.7.4.0/x64/msoledbsql.msi
+  InstallerSha256: 8A207EFEFA1697F2EFD4736FC7C45EB1E6BBBDD75E379D34C420E7400C175DD4
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+- Architecture: x86
+  InstallerLocale: zh-TW
+  ProductCode: '{41B677BF-308F-43CE-BD30-5BE64364CE1A}'
+  InstallerUrl: https://download.microsoft.com/download/2/6/1/2613c841-cf12-4ba3-b0f8-50dcc195faa4/zh-TW/18.7.4.0/x86/msoledbsql.msi
+  InstallerSha256: 71FEB5D3A5C972A42ECEBF670D89913098668F54EB4A8D24490043A05AAFB2A0
+  AppsAndFeaturesEntries:
+  - DisplayName: 'Microsoft OLE DB Driver for SQL Server'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SQLServer.OLEDBDriver
+PackageVersion: 18.7.4.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Microsoft OLE DB Driver for SQL Server
+PackageUrl: https://learn.microsoft.com/en-us/sql/connect/oledb/release-notes-for-oledb-driver-for-sql-server
+License: Proprietary
+ShortDescription: The OLE DB Driver for SQL Server is a stand-alone data access application programming interface (API), used for OLE Database.
+Moniker: oledbdriver18
+Tags:
+- microsoft-ole-db-driver-for-sql-server
+- microsoftoledbdriverforsqlserver
+- microsoft-ole-db-18-driver
+- microsoftoledb18driverforsqlserver
+- driver-do-microsoft-ole-db-para-sql
+- driverdomicrosoftoledbparasqlserver
+- microsoft-ole-db-driver-pour-sql-server
+- microsoft-ole-db-treiber-für-sql-server
+- microsoftoledbdriverpoursqlserver
+- microsoftoledbtreiberfürsqlserver
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.yaml
+++ b/manifests/m/Microsoft/SQLServer/OLEDBDriver/18.7.4.0/Microsoft.SQLServer.OLEDBDriver.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SQLServer.OLEDBDriver
+PackageVersion: 18.7.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Fairly heavily based on https://github.com/pl4nty/winget-extras/issues/1199#issuecomment-5558391043. If pl4nty is right about this, and with https://github.com/microsoft/winget-pkgs/pull/430790 having added uninstallPrevious to 19.4.1.0, then it is possible after all for Winget to treat the 19.x and 18.x versions of OLE DB Driver as one and the same.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #429350.

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430828)