### PR TITLE
Add Antybrowser CLI v1.0.0

### DIFF
--- a/manifests/a/Antybrowser/CLI/1.0.0/Antybrowser.CLI.yaml
+++ b/manifests/a/Antybrowser/CLI/1.0.0/Antybrowser.CLI.yaml
@@ -1,0 +1,76 @@
+PackageIdentifier: Antybrowser.CLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Antybrowser.com
+PublisherUrl: https://antybrowser.com
+PublisherSupportUrl: https://antybrowser.com/support
+Author: Antybrowser.com
+PackageName: Antybrowser CLI
+PackageUrl: https://github.com/antybrowser/antybrowser-cli
+License: MIT
+LicenseUrl: https://antybrowser.com/license
+ShortDescription: CLI for Antybrowser anti-detect browser - manage profiles, proxies, extensions, and automations
+Description: |
+  Antybrowser CLI is a command-line interface for Antybrowser, the anti-detect browser for multi-account management, affiliate marketing, web scraping, and online privacy.
+
+  Manage browser profiles with unique fingerprints, proxy configurations (HTTP, SOCKS4, SOCKS5), browser extensions, profile groups, and browser automations directly from your terminal.
+
+  Features:
+  - Create, list, start, stop, duplicate, and delete browser profiles
+  - Manage proxies with bulk connectivity checking
+  - Organize profiles into groups with custom colors
+  - Run browser automations from the command line
+  - JSON output for scripting and CI/CD pipelines
+  - Persistent configuration for API URL and authentication key
+  - Cross-platform: macOS (ARM/Intel), Linux (ARM/x64), Windows (ARM/x64)
+
+  Requires the Antybrowser desktop app to be running. The CLI connects to the local API server on port 5173.
+Homepage: https://antybrowser.com
+Documentations:
+  - DocumentUrl: https://docs.antybrowser.com
+    DocumentName: Documentation
+Tags:
+  - antybrowser
+  - cli
+  - browser
+  - automation
+  - proxy
+  - fingerprint
+  - multi-account
+  - anti-detect
+  - scraping
+  - privacy
+  - profiles
+  - command-line
+  - terminal
+ReleaseNotes: |
+  Antybrowser CLI v1.0.0 - Initial release
+
+  Features:
+  - Profile management (create, list, start, stop, duplicate, delete)
+  - Proxy management (list, create, check, delete)
+  - Extension management (list, delete)
+  - Group management (list, create, update, delete)
+  - Automation execution
+  - Configuration management
+  - JSON output for scripting
+ReleaseNotesUrl: https://github.com/antybrowser/antybrowser-cli/releases/tag/cli-v1.0.0
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/antybrowser/antybrowser-cli/releases/download/cli-v1.0.0/antybrowser-windows-amd64.zip
+    InstallerSha256: 656a6401b20ba7541d90f986942816c703e6bb98d966469fd7a6f45e6b36525b
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: antybrowser.exe
+        PortableCommandAlias: antybrowser
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://github.com/antybrowser/antybrowser-cli/releases/download/cli-v1.0.0/antybrowser-windows-arm64.zip
+    InstallerSha256: c0ade56a0f58752276716423020b516e08bb8a4ae64094522bfc6e9cbdee5412
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: antybrowser.exe
+        PortableCommandAlias: antybrowser
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Antybrowser CLI v1.0.0

CLI for Antybrowser anti-detect browser - manage profiles, proxies, extensions, and automations from the terminal.

### Links
- Homepage: https://antybrowser.com
- Documentation: https://docs.antybrowser.com
- GitHub: https://github.com/antybrowser/antybrowser-cli
- License: MIT

### Platforms
- Windows x64
- Windows ARM64

### Install
```
winget install Antybrowser.CLI
antybrowser profiles list
antybrowser profiles create --name "My Profile"
antybrowser profiles start <id>
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430835)