### PR TITLE
New package: Weita.AitNative version 1.1.3

### DIFF
--- a/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.installer.yaml
+++ b/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.installer.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: "Weita.AitNative"
+PackageVersion: "1.1.3"
+InstallerType: zip
+Installers:
+  - Architecture: arm64
+    InstallerUrl: "https://github.com/weita2026/ait-native/releases/download/v1.1.3/ait-native-1.1.3-aarch64-pc-windows-msvc.zip"
+    InstallerSha256: 1575F3BBDD2B9905257F64E62A5EAB328D6EDCBC71DB81E02BC2F05A694AEDCB
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+    - RelativeFilePath: ait.exe
+      PortableCommandAlias: ait
+    - RelativeFilePath: ait-server.exe
+      PortableCommandAlias: ait-server
+    - RelativeFilePath: ait-runner.exe
+      PortableCommandAlias: ait-runner
+    InstallationMetadata:
+      Files:
+      - RelativeFilePath: ait.exe
+        FileType: launch
+        InvocationParameter: --help
+      - RelativeFilePath: ait-server.exe
+        FileType: launch
+        InvocationParameter: --help
+      - RelativeFilePath: ait-runner.exe
+        FileType: launch
+        InvocationParameter: --help
+    ArchiveBinariesDependOnPath: false
+  - Architecture: x64
+    InstallerUrl: "https://github.com/weita2026/ait-native/releases/download/v1.1.3/ait-native-1.1.3-x86_64-pc-windows-msvc.zip"
+    InstallerSha256: D5042515BAD93E4E7054DB2C401B2BD0F61388BEF0879E8BF5414E02837A276F
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+    - RelativeFilePath: ait.exe
+      PortableCommandAlias: ait
+    - RelativeFilePath: ait-server.exe
+      PortableCommandAlias: ait-server
+    - RelativeFilePath: ait-runner.exe
+      PortableCommandAlias: ait-runner
+    InstallationMetadata:
+      Files:
+      - RelativeFilePath: ait.exe
+        FileType: launch
+        InvocationParameter: --help
+      - RelativeFilePath: ait-server.exe
+        FileType: launch
+        InvocationParameter: --help
+      - RelativeFilePath: ait-runner.exe
+        FileType: launch
+        InvocationParameter: --help
+    ArchiveBinariesDependOnPath: false
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.locale.en-US.yaml
+++ b/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: "Weita.AitNative"
+PackageVersion: "1.1.3"
+PackageLocale: en-US
+Publisher: Weita
+PublisherUrl: https://github.com/weita2026
+PackageName: ait-native
+PackageUrl: "https://github.com/weita2026/ait-native"
+License: "AGPL-3.0-only AND Apache-2.0"
+LicenseUrl: "https://github.com/weita2026/ait-native/blob/v1.1.3/docs/distribution.md#license-and-source-publication-gate"
+ShortDescription: Language-neutral native AIT CLI and runner with an inactive self-hosted server
+Tags:
+  - ai
+  - cli
+  - developer-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.yaml
+++ b/manifests/w/Weita/AitNative/1.1.3/Weita.AitNative.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: "Weita.AitNative"
+PackageVersion: "1.1.3"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the frozen Weita.AitNative 1.1.3 portable manifests for x64 and arm64. The installer hashes are bound to the immutable v1.1.3 release assets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430868)