### PR TITLE
New package: BURSUsofts.BURSUcm version 3.5.1

### DIFF
--- a/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.installer.yaml
+++ b/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.installer.yaml
@@ -1,0 +1,32 @@
+# Created manually for BURSUsofts on 2026-09-07 (komac 2.16 cannot read Inno Setup 7 headers)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BURSUsofts.BURSUcm
+PackageVersion: 3.5.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART
+  Log: /LOG="<LOGPATH>"
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+ProductCode: '{8E9C2A14-7B3D-4F6E-9A21-0C1D2E3F4A5B}_is1'
+AppsAndFeaturesEntries:
+- DisplayName: BURSU Connection Manager 3.5.1
+  Publisher: BURSUsofts
+  DisplayVersion: 3.5.1
+  ProductCode: '{8E9C2A14-7B3D-4F6E-9A21-0C1D2E3F4A5B}_is1'
+  InstallerType: inno
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://bursucm.com/downloads/BURSUcm-Setup-3.5.1.exe
+  InstallerSha256: FED889D7C0C62F00F61A011C1ADC4D122F2CAC22EE15D3BCABF1EAE6724CA7F2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.locale.en-US.yaml
+++ b/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# Created manually for BURSUsofts on 2026-09-07 (komac 2.16 cannot read Inno Setup 7 headers)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BURSUsofts.BURSUcm
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: BURSUsofts
+PublisherUrl: https://bursucm.com
+PublisherSupportUrl: https://bursucm.com/docs/en/
+PrivacyUrl: https://bursucm.com/privacy
+Author: BURSUsofts
+PackageName: BURSU Connection Manager
+PackageUrl: https://bursucm.com
+License: Freeware
+LicenseUrl: https://bursucm.com/terms
+Copyright: Copyright (C) 2026 BURSUsofts
+CopyrightUrl: https://bursucm.com/terms
+ShortDescription: SSH, RDP, VNC, Telnet, WinRM, SFTP and FTP connection manager with a zero-knowledge cloud catalog
+Description: |-
+  BURSU Connection Manager keeps every server you work with in one catalog: SSH, Telnet and Serial terminals, RDP and VNC desktops, WinRM sessions, SFTP and FTP file transfers and Web tabs. Connections, credentials and SSH keys live in a local vault or in a zero-knowledge cloud catalog that the desktop, Android and iOS clients share; the master password never leaves the device. Terminals can run inside tmux, tunnel through SOCKS5 or a jump host, and an optional AI assistant proposes commands from what is on the screen.
+Moniker: bursucm
+Tags:
+- connection-manager
+- ftp
+- rdp
+- remote-desktop
+- sftp
+- ssh
+- telnet
+- terminal
+- vnc
+- winrm
+Documentations:
+- DocumentLabel: User guide
+  DocumentUrl: https://bursucm.com/docs/en/
+ReleaseNotesUrl: https://bursucm.com/download#changelog
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.yaml
+++ b/manifests/b/BURSUsofts/BURSUcm/3.5.1/BURSUsofts.BURSUcm.yaml
@@ -1,0 +1,8 @@
+# Created manually for BURSUsofts on 2026-09-07 (komac 2.16 cannot read Inno Setup 7 headers)
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BURSUsofts.BURSUcm
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **BURSUsofts.BURSUcm** version **3.5.1** — BURSU Connection Manager, an SSH / RDP / VNC / Telnet / WinRM / SFTP / FTP connection manager for Windows by BURSUsofts (https://bursucm.com).

- Inno Setup installer, Authenticode-signed (BURSUsofts, Certum), one installer for x64 / x86 / arm64 that installs the build matching the OS, hence a single `neutral` entry.
- Machine scope, `PrivilegesRequired=admin` in the installer, so `ElevationRequirement: elevationRequired`.
- The URL is version-specific and permanent; `https://bursucm.com/downloads/BURSUcm-Setup-<version>.exe` is kept for every released version.
- Submitted by the publisher.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (will sign when the CLA bot asks)
- [ ] Linked to an issue (if applicable) — none

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>` (Windows 11 x64; silent install succeeded, the ARP entry correlates by ProductCode)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430872)