### PR TITLE
New package: mimaxon1.PCRemote version 1.5.0

### DIFF
--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.installer.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.installer.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: mimaxon1.PCRemote
 PackageVersion: '1.5.0'
 InstallerType: inno
@@ -12,7 +12,7 @@ ProductCode: '{8A5675B9-1F20-4E2B-8BB4-D0C42973F9E4}_is1'
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/mimaxon1/pc-remote/releases/download/v1.5.0/PC-Remote-1.5.0-windows-x64-Setup.exe
-    InstallerSha256: 2A02562532C39FC724750B0D0A1C727B9E139ED9E6A3C04A3E3F012BEB814C63
+    InstallerSha256: 39D106C0FA83BB80DCED1D43CB90E2C3755D2EB8E5E063BAD6299C25444CEA70
     AppsAndFeaturesEntries:
       - DisplayName: PC Remote 1.5.0
         Publisher: mimaxon1
@@ -21,4 +21,4 @@ Installers:
     InstallationMetadata:
       DefaultInstallLocation: '%LocalAppData%\Programs\PC Remote'
 ManifestType: installer
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.installer.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+PackageIdentifier: mimaxon1.PCRemote
+PackageVersion: '1.5.0'
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{8A5675B9-1F20-4E2B-8BB4-D0C42973F9E4}_is1'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mimaxon1/pc-remote/releases/download/v1.5.0/PC-Remote-1.5.0-windows-x64-Setup.exe
+    InstallerSha256: 2A02562532C39FC724750B0D0A1C727B9E139ED9E6A3C04A3E3F012BEB814C63
+    AppsAndFeaturesEntries:
+      - DisplayName: PC Remote 1.5.0
+        Publisher: mimaxon1
+        DisplayVersion: '1.5.0'
+        ProductCode: '{8A5675B9-1F20-4E2B-8BB4-D0C42973F9E4}_is1'
+    InstallationMetadata:
+      DefaultInstallLocation: '%LocalAppData%\Programs\PC Remote'
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.en-US.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.en-US.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: mimaxon1.PCRemote
 PackageVersion: '1.5.0'
 PackageLocale: en-US
@@ -28,4 +28,4 @@ Tags:
   - windows
 ReleaseNotesUrl: https://github.com/mimaxon1/pc-remote/releases/tag/v1.5.0
 ManifestType: defaultLocale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.en-US.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+PackageIdentifier: mimaxon1.PCRemote
+PackageVersion: '1.5.0'
+PackageLocale: en-US
+Publisher: mimaxon1
+PublisherUrl: https://github.com/mimaxon1/pc-remote
+PublisherSupportUrl: https://github.com/mimaxon1/pc-remote/issues
+Author: mimaxon1
+PackageName: PC Remote
+PackageUrl: https://github.com/mimaxon1/pc-remote
+License: Apache-2.0
+LicenseUrl: https://github.com/mimaxon1/pc-remote/blob/main/LICENSE
+Copyright: Copyright 2026 mimaxon1
+ShortDescription: Control a Windows PC from any phone browser over the local network.
+Description: >-
+  PC Remote is an open-source, local-first Windows remote controller.
+  Run it on the PC, pair a phone with a QR code, and control apps,
+  windows, media, audio output, volume, and power actions from a browser.
+  No mobile app, cloud service, or external account is required.
+Moniker: pc-remote
+Tags:
+  - lan
+  - local-first
+  - media-control
+  - phone-remote
+  - remote-control
+  - self-hosted
+  - windows
+ReleaseNotesUrl: https://github.com/mimaxon1/pc-remote/releases/tag/v1.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.ru-RU.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.ru-RU.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.28.0.schema.json
+PackageIdentifier: mimaxon1.PCRemote
+PackageVersion: '1.5.0'
+PackageLocale: ru-RU
+Publisher: mimaxon1
+PackageName: PC Remote
+ShortDescription: Управление Windows-компьютером с телефона через локальную сеть.
+Description: >-
+  PC Remote — локальный open-source пульт для Windows.
+  Запустите приложение на ПК, подключите телефон по QR-коду и управляйте
+  приложениями, окнами, мультимедиа, аудио, громкостью и питанием из браузера.
+  Мобильное приложение, облако и внешний аккаунт не требуются.
+ManifestType: locale
+ManifestVersion: 1.28.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.ru-RU.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.locale.ru-RU.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 PackageIdentifier: mimaxon1.PCRemote
 PackageVersion: '1.5.0'
 PackageLocale: ru-RU
@@ -11,4 +11,4 @@ Description: >-
   приложениями, окнами, мультимедиа, аудио, громкостью и питанием из браузера.
   Мобильное приложение, облако и внешний аккаунт не требуются.
 ManifestType: locale
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: mimaxon1.PCRemote
 PackageVersion: '1.5.0'
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.28.0
+ManifestVersion: 1.12.0

--- a/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.yaml
+++ b/manifests/m/mimaxon1/PCRemote/1.5.0/mimaxon1.PCRemote.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+PackageIdentifier: mimaxon1.PCRemote
+PackageVersion: '1.5.0'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
## Summary
- add PC Remote version 1.5.0
- publish the per-user Inno Setup installer from the official GitHub release
- include English and Russian locale metadata

## Validation
- Installer URL points to the immutable v1.5.0 release asset
- Installer SHA-256 was generated by the release workflow
- ProductCode and ARP metadata match the installer
- Release workflow passed tests, silent install/uninstall, and metadata generation

Release: https://github.com/mimaxon1/pc-remote/releases/tag/v1.5.0
Workflow: https://github.com/mimaxon1/pc-remote/actions/runs/34115176506
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430873)