### PR TITLE
New package: Vortexio.Vortexio version 0.3.64

### DIFF
--- a/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.installer.yaml
+++ b/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Vortexio.Vortexio
+PackageVersion: 0.3.64
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-05
+Installers:
+- Architecture: x64
+  InstallerUrl: https://updates.vortexio.cc/desktop/Vortexio.Setup.0.3.64.exe
+  InstallerSha256: 5A1C62994F138526A516A707C79A960B930FF79D21EA9ED1665C5A238463167A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.locale.en-US.yaml
+++ b/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Vortexio.Vortexio
+PackageVersion: 0.3.64
+PackageLocale: en-US
+Publisher: Vortexio
+PublisherUrl: https://vortexio.cc
+PublisherSupportUrl: https://vortexio.cc
+PackageName: Vortexio
+PackageUrl: https://vortexio.cc
+License: Proprietary
+Copyright: Copyright (c) Vortexio
+ShortDescription: Windows desktop client for the Vortexio VPN subscription service.
+Description: |-
+  Vortexio is the official Windows desktop client for the Vortexio VPN subscription
+  service. It imports your subscription, picks the fastest available server, and
+  routes traffic through modern transports such as Hysteria2 and Reality.
+
+  A Vortexio account is required to connect. You can register inside the app or sign
+  in with an existing account.
+Moniker: vortexio
+Tags:
+- proxy
+- privacy
+- security
+- vpn
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.yaml
+++ b/manifests/v/Vortexio/Vortexio/0.3.64/Vortexio.Vortexio.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Vortexio.Vortexio
+PackageVersion: 0.3.64
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: Vortexio.Vortexio version 0.3.64

Windows desktop client for the Vortexio VPN subscription service.

- **Installer:** NSIS (electron-builder), per-user scope, Authenticode-signed
- **Publisher URL:** https://vortexio.cc
- **Installer URL:** https://updates.vortexio.cc/desktop/Vortexio.Setup.0.3.64.exe

Notes for reviewers:
- The installer URL is the vendor's own release channel and keeps previous versions
  online, so the manifest stays resolvable after future releases.
- The app requires an account to connect; registration and sign-in are both available
  in the client.

Validation done:
- `winget validate --manifest` passes (client v1.29.290).
- `InstallerSha256` computed from the exact file served at the installer URL.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430880)