### PR TITLE
New package: DanielKreutz.MRCPDFKompressor version 4.1.0

### DIFF
--- a/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.installer.yaml
+++ b/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: DanielKreutz.MRCPDFKompressor
+PackageVersion: 4.1.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: mrc-pdf-kompressor\MrcCompressor.exe
+  PortableCommandAlias: mrc-pdf-kompressor
+# Die EXE braucht ihre DLLs (Magick.NET, SkiaSharp, iTextSharp, jbig2.exe ...)
+# im selben Ordner -> winget legt den Ordner in den PATH statt nur die EXE zu verlinken.
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  # Feste, versionierte Datei-URL (winget akzeptiert keine Skript-URLs wie download.php).
+  # SHA256 aus mrc-pdf-kompressor-4.1.0.zip.sha256 (build-release.ps1 mit pack-release.py, 2026-09-07).
+  InstallerUrl: https://kreutzweb.de/dl/mrc-pdf-kompressor-4.1.0.zip
+  InstallerSha256: FC92BBD0975021844325A000568D7838C0059FDA162C1838C5111C1D933FB22D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.locale.en-US.yaml
+++ b/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: DanielKreutz.MRCPDFKompressor
+PackageVersion: 4.1.0
+PackageLocale: en-US
+Publisher: Daniel Kreutz
+PublisherUrl: https://kreutzweb.de
+PublisherSupportUrl: https://kreutzweb.de/kontakt.html
+PackageName: MRC PDF Kompressor
+PackageUrl: https://kreutzweb.de/en/tool-mrc-pdf-kompressor.html
+License: PolyForm Small Business License 1.0.0
+LicenseUrl: https://polyformproject.org/licenses/small-business/1.0.0
+Copyright: Copyright Daniel Kreutz (https://kreutzweb.de)
+ShortDescription: Turns scanned documents (TIFF, JPEG, PNG) into very small, sharp PDF files using Mixed Raster Content - GUI and command line.
+Description: |-
+  MRC PDF Kompressor converts scanned images into compact PDF files using
+  Mixed Raster Content (MRC): the page is split into a high-resolution text
+  mask (JBIG2, pattern-safe without character substitution), separate colour
+  text layers for stamps and headings, and a smoothed, downscaled background
+  (JPEG 2000 or JPEG). Typical results are 90-95 % smaller than the original
+  scan while the text stays crisp. Supports PDF/A-1b output, multi-page TIFF,
+  batch processing of folders, and a split-view GUI with live preview. The
+  command line is fully scriptable (exit codes, progress, profiles). Free for
+  private individuals and small businesses (PolyForm Small Business License).
+Moniker: mrc-pdf-kompressor
+Tags:
+- pdf
+- compression
+- mrc
+- scan
+- scanner
+- tiff
+- jbig2
+- jpeg2000
+- pdfa
+- archiving
+- document
+ReleaseNotesUrl: https://kreutzweb.de/en/tool-mrc-pdf-kompressor.html
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.yaml
+++ b/manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/DanielKreutz.MRCPDFKompressor.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# winget-Versionsmanifest - einreichen als Pull Request an
+# https://github.com/microsoft/winget-pkgs unter
+# manifests/d/DanielKreutz/MRCPDFKompressor/4.1.0/
+# InstallerUrl + InstallerSha256 stehen in der .installer.yaml; die Datei
+# muss unter der festen URL live sein, BEVOR der PR eroeffnet wird.
+# Bei neuer Version: Hash aus mrc-pdf-kompressor-<Version>.zip.sha256
+# (erzeugt build-release.ps1) uebernehmen, alte Datei im dl/-Ordner liegen lassen.
+PackageIdentifier: DanielKreutz.MRCPDFKompressor
+PackageVersion: 4.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds **DanielKreutz.MRCPDFKompressor** version **4.1.0** (new package).

MRC PDF Kompressor is a free Windows tool (portable zip) that compresses scanned
documents (TIFF/JPEG/PNG) into very small, sharp PDF files using Mixed Raster
Content: a JBIG2 text mask (generic encoding, pattern-safe – no symbol
substitution), separate colour text layers and a JPEG 2000 background. GUI with
live preview plus a fully scriptable command line; PDF/A-1b output. The
application binary is Authenticode-signed (Certum, CN=Daniel Kreutz).
Website: https://kreutzweb.de/en/tool-mrc-pdf-kompressor.html

`ArchiveBinariesDependOnPath` is set because the executable loads its native
libraries (Magick.NET, SkiaSharp, PDFium, jbig2) from its own folder.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430892)