### PR TITLE
New version: nobu121.win3drag version 1.0.1

### DIFF
--- a/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.installer.yaml
+++ b/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: nobu121.win3drag
+PackageVersion: 1.0.1
+InstallerType: portable
+ReleaseDate: 2026-09-07
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/nobu121/win3drag/releases/download/v1.0.1/3drag.exe
+    InstallerSha256: 30614237F4959589DDF856DB8193D4065EECEF2A1A8A33BDDA38B70F9CCF62CE
+    Commands:
+      - 3drag
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.installer.yaml
+++ b/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.installer.yaml
@@ -7,7 +7,7 @@ ReleaseDate: 2026-09-07
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/nobu121/win3drag/releases/download/v1.0.1/3drag.exe
-    InstallerSha256: 30614237F4959589DDF856DB8193D4065EECEF2A1A8A33BDDA38B70F9CCF62CE
+    InstallerSha256: 1F7B210113266D593F3F4E0939E58AF73788D07C537DBE9E99ECFAFE3AB09525
     Commands:
       - 3drag
 ManifestType: installer

--- a/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.locale.en-US.yaml
+++ b/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: nobu121.win3drag
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: nobu121
+PublisherUrl: https://github.com/nobu121
+PublisherSupportUrl: https://github.com/nobu121/win3drag/issues
+PackageName: win3drag
+PackageUrl: https://github.com/nobu121/win3drag
+License: MIT
+LicenseUrl: https://github.com/nobu121/win3drag/blob/main/LICENSE
+ShortDescription: Three-finger drag on Windows Precision Touchpad
+Description: |-
+  win3drag (3drag.exe) turns a three-finger press-and-drag on a Precision Touchpad
+  into a left-button mouse drag. CLI-only, runs in the background.
+
+  Requires Windows 10+ with a Precision Touchpad. Disable Windows built-in
+  three-finger gestures before use.
+Moniker: win3drag
+Tags:
+  - touchpad
+  - mouse
+  - utility
+  - drag
+ReleaseNotes: |-
+  Three-finger drag now starts OLE/shell drags (taskbar icon reorder, Windows
+  Terminal text/file drop). New CLI: 3drag autostart enabled|disabled.
+ReleaseNotesUrl: https://github.com/nobu121/win3drag/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.locale.zh-CN.yaml
+++ b/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.locale.zh-CN.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: nobu121.win3drag
+PackageVersion: 1.0.1
+PackageLocale: zh-CN
+Publisher: nobu121
+PublisherUrl: https://github.com/nobu121
+PublisherSupportUrl: https://github.com/nobu121/win3drag/issues
+PackageName: win3drag
+PackageUrl: https://github.com/nobu121/win3drag
+License: MIT
+LicenseUrl: https://github.com/nobu121/win3drag/blob/main/LICENSE
+ShortDescription: Windows 精确触摸板三指拖拽工具
+Description: |-
+  win3drag（3drag.exe）在精确触摸板（PTP）上通过三指按压并移动实现鼠标左键拖拽。
+  纯命令行，后台运行。
+
+  需要 Windows 10+ 与 PTP 触摸板。使用前请关闭系统自带三指手势。
+Tags:
+  - touchpad
+  - mouse
+  - utility
+ReleaseNotes: |-
+  三指拖拽现在可以触发 OLE/Shell 拖放（任务栏图标排序、Windows Terminal 文本/文件拖放）。
+  新增命令：3drag autostart enabled|disabled。
+ReleaseNotesUrl: https://github.com/nobu121/win3drag/releases/tag/v1.0.1
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.yaml
+++ b/manifests/n/nobu121/win3drag/1.0.1/nobu121.win3drag.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: nobu121.win3drag
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Package submission

- [x] Package manifest validated locally (`winget validate`)
- [x] Installer URL points to GitHub Release asset
- [x] SHA256 matches release asset (`30614237F4959589DDF856DB8193D4065EECEF2A1A8A33BDDA38B70F9CCF62CE`)

### Package

- **PackageIdentifier:** nobu121.win3drag
- **PackageVersion:** 1.0.1
- **Installer:** portable x64 (`3drag.exe`)
- **Command:** `3drag` (added to PATH via WinGet Links)

### Project

- **Repository:** https://github.com/nobu121/win3drag
- **Release:** https://github.com/nobu121/win3drag/releases/tag/v1.0.1

Fixes three-finger drag for taskbar icon reorder and Windows Terminal / OLE drag-and-drop. Adds `3drag autostart enabled|disabled`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/430929)