### PR TITLE
New package: WeiyiShi.Folio version 0.4.0

### DIFF
--- a/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.installer.yaml
+++ b/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WeiyiShi.Folio
+PackageVersion: 0.2.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: folio-0.2.2\folio.exe
+  PortableCommandAlias: folio
+ArchiveBinariesDependOnPath: true
+UpgradeBehavior: install
+ReleaseDate: 2026-09-06
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lulu-loopp/folio-terminal/releases/download/v0.2.2-preview/folio-0.2.2-windows-x64.zip
+  InstallerSha256: 5510BDE154972B927A6590D0A29DB111B69126F6604A854D43EF369C2AFB4F74
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.locale.en-US.yaml
+++ b/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WeiyiShi.Folio
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Weiyi Shi
+PublisherUrl: https://github.com/lulu-loopp
+PublisherSupportUrl: https://github.com/lulu-loopp/folio-terminal/issues
+PrivacyUrl: https://github.com/lulu-loopp/folio-terminal/blob/v0.2.2-preview/docs/PRIVACY.md
+PackageName: Folio
+PackageUrl: https://github.com/lulu-loopp/folio-terminal
+License: Apache-2.0 OR MIT
+LicenseUrl: https://raw.githubusercontent.com/lulu-loopp/folio-terminal/v0.2.2-preview/LICENSE-APACHE
+Copyright: Copyright (c) Weiyi Shi
+ShortDescription: 'A Windows terminal: formulas are typeset where a command prints them, files preview beside the prompt, and an agent that is waiting for you says so.'
+Description: |-
+  Folio is a terminal for Windows. The LaTeX a command prints is typeset where it
+  was printed, above the next prompt. A file a command names opens in a pane beside
+  the shell, rendered rather than paged: Markdown, images, PDF and, where the
+  WebView2 Runtime is installed, a web page. A tab says so when Claude Code, Codex
+  or Copilot CLI has stopped and is waiting on an answer, so a window left in the
+  background is not read late.
+
+  It starts PowerShell 7, Windows PowerShell, WSL, Git Bash and Command Prompt
+  through ConPTY, and draws on the GPU. There is no installer and nothing is
+  written outside the install folder until it is run. That folder is the unit:
+  folio.exe will not start a shell without conpty.dll and OpenConsole.exe beside
+  it, and folio.msix names the same folder as the program it grants an identity
+  to, which is why this package puts its own directory on PATH rather than
+  linking the one file somewhere else. Needs Windows 10 1809 or newer, 64-bit.
+
+  0.2.2 is a preview build; folio.exe and folio.msix in it are signed by Weiyi Shi.
+Moniker: folio
+Tags:
+- agent
+- claude-code
+- cli
+- codex
+- command-line
+- conpty
+- console
+- copilot
+- latex
+- markdown
+- math
+- powershell
+- preview
+- terminal
+- wsl
+ReleaseNotesUrl: https://github.com/lulu-loopp/folio-terminal/releases/tag/v0.2.2-preview
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.yaml
+++ b/manifests/w/WeiyiShi/Folio/0.2.2/WeiyiShi.Folio.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WeiyiShi.Folio
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: Folio 0.4.0, a terminal for Windows and macOS, shipped for Windows as a portable zip. This pull request replaces the 0.2.2 manifests it opened with: 0.4.0 is the current release and the earlier archive is superseded.

`InstallerType: zip` with `NestedInstallerType: portable` and `ArchiveBinariesDependOnPath: true`, because `folio.exe` loads `conpty.dll` and `OpenConsole.exe` from its own directory and `folio.msix` names that directory as its external content location; a symlink in the Links folder would break both. `folio.exe` and `folio.msix` are Authenticode-signed (Microsoft Artifact Signing, `CN=Weiyi Shi`) with a time stamp. The hash is the one `SHA256SUMS.txt` on the release page carries for the archive.

## ✅ Checklist
- [x] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>` (0.2.2 was tested on a clean Windows 10 machine; 0.4.0 has the same layout and will be tested the same way)
- [x] Tested that the installer runs and the application launches from the extracted folder on this machine
