### PR TITLE
New package: Canact.Canact version 0.1.1

### DIFF
--- a/manifests/c/Canact/Canact/0.1.1/Canact.Canact.installer.yaml
+++ b/manifests/c/Canact/Canact/0.1.1/Canact.Canact.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Canact.Canact
+PackageVersion: 0.1.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: canact.exe
+  PortableCommandAlias: canact
+Commands:
+- canact
+UpgradeBehavior: install
+ReleaseDate: 2026-09-07
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/canact/canact/releases/download/v0.1.1/canact-x86_64-pc-windows-msvc.zip
+  InstallerSha256: B89C82617AC92477A83AF60E2C89D223A54257207DB4941EB0F0FBB2A3DCCDF9
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Canact/Canact/0.1.1/Canact.Canact.locale.en-US.yaml
+++ b/manifests/c/Canact/Canact/0.1.1/Canact.Canact.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Canact.Canact
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: canact
+PublisherUrl: https://github.com/canact
+PublisherSupportUrl: https://github.com/canact/canact/issues
+Author: canact
+PackageName: canact
+PackageUrl: https://github.com/canact/canact
+License: Apache-2.0
+LicenseUrl: https://github.com/canact/canact/blob/HEAD/LICENSE
+Copyright: Copyright (c) canact contributors
+ShortDescription: Probe an LLM and return host policy
+Description: |-
+  canact probes an LLM against this host's tools and returns a capability
+  card: how many tools to send, which edit format to pick, whether to enable
+  XML fallback, and whether to wrap JSON in a repair layer.
+Moniker: canact
+Tags:
+- agents
+- cli
+- llm
+- probe
+- rust
+ReleaseNotesUrl: https://github.com/canact/canact/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Canact/Canact/0.1.1/Canact.Canact.yaml
+++ b/manifests/c/Canact/Canact/0.1.1/Canact.Canact.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Canact.Canact
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
This is a first listing of Canact.Canact.

canact is a Rust CLI that probes an LLM and returns host policy
(max tools, edit format, XML fallback, JSON repair).

Installer: portable zip from GitHub Releases. `canact.exe` is at
the zip root (cargo-dist). x64 only for 0.1.1.

```
canact.exe
CHANGELOG.md
LICENSE
README.md
```

SHA256 of
https://github.com/canact/canact/releases/download/v0.1.1/canact-x86_64-pc-windows-msvc.zip
is B89C82617AC92477A83AF60E2C89D223A54257207DB4941EB0F0FBB2A3DCCDF9

This is a portable console CLI, not a GUI app.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431011)