### PR TITLE
Update: Elinesoft.XTester to 0.0.91

### DIFF
--- a/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.installer.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.91
+InstallerLocale: ru-RU
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/79231232393/XTester-releases/releases/download/v.0.0.91/XTester-Installer-0.0.91.exe
+    InstallerSha256: D1264EC7164B4A7254BEFFF6C803E6A48BA72E1640A16CCBE87C97177BD0130E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.locale.en-US.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.91
+PackageLocale: en-US
+Publisher: Elinesoft
+PublisherUrl: https://xtester.pw
+PublisherSupportUrl: https://github.com/79231232393/XTester-releases/issues
+PackageName: XTester
+PackageUrl: https://xtester.pw
+License: Freeware
+ShortDescription: Desktop cryptocurrency trading strategy simulator and backtester with an AI strategy builder.
+Description: |-
+  XTester is a Windows desktop application for designing, backtesting and simulating
+  cryptocurrency trading strategies on historical market data from major exchanges.
+  Includes a C# strategy editor with IntelliSense, an AI-assisted strategy builder,
+  interactive charts, portfolio statistics and automatic updates.
+Moniker: xtester
+Tags:
+  - trading
+  - backtesting
+  - cryptocurrency
+  - strategy
+  - simulator
+ReleaseNotesUrl: https://github.com/79231232393/XTester-releases/releases/tag/v.0.0.91
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.yaml
+++ b/manifests/e/Elinesoft/XTester/0.0.91/Elinesoft.XTester.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Elinesoft.XTester
+PackageVersion: 0.0.91
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Updates Elinesoft.XTester (the legacy Windows XTester application, not XTester Studio) to 0.0.91.

Official release: https://github.com/79231232393/XTester-releases/releases/tag/v.0.0.91

The public installer was independently downloaded after publication and its size (620183975 bytes) and SHA-256 were verified against the locally built file:
D1264EC7164B4A7254BEFFF6C803E6A48BA72E1640A16CCBE87C97177BD0130E

Installer metadata: XTester / Elinesoft / ProductVersion 0.0.91. The release application, Launcher, and isolated MCP host passed their local release gates. No related issue is required for this routine version update.

## ✅ Checklist

- [ ] Signed the Contributor License Agreement (not asserted on behalf of the account owner; automated CLA check may confirm existing coverage)
- [x] Checked that there are no other open pull requests for this update
- [x] This PR modifies only one package version (three manifest files)
- [x] Validated locally with `winget validate --manifest manifests/e/Elinesoft/XTester/0.0.91`
- [ ] Tested locally with `winget install --manifest <path>`
- [x] Manifests conform to schema 1.12.0

Installation was not run on the active workstation to avoid replacing its existing XTester installation. The public download, checksum, installer metadata and manifest validation were checked; isolated installation validation remains with the upstream pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431024)