### PR TITLE
New package: dixieflatline76.NachoFlow version 1.0.2

### DIFF
--- a/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.installer.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 1.0.2
+Commands:
+  - nacho-flow
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/dixieflatline76/nacho-flow/releases/download/v1.0.2/nacho-flow-1.0.2-windows-amd64.exe
+    InstallerSha256: 76EFFB957CA998AFC34D6ABCD4F74C89D45DD1DC30E2D28E968B887A202525B5
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.locale.en-US.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.locale.en-US.yaml
@@ -1,0 +1,25 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 1.0.2
+PackageLocale: en-US
+Publisher: dixieflatline76
+PublisherUrl: https://spicebox.dev
+PublisherSupportUrl: https://github.com/dixieflatline76/nacho-flow/issues
+PackageName: Nacho Flow
+PackageUrl: https://spicebox.dev/nacho-flow/
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/dixieflatline76/nacho-flow/blob/main/LICENSE
+Copyright: Copyright (c) 2026 dixieflatline76
+ShortDescription: Agent Supervisor & Model Dispatcher for coding agents (spicebox.dev/nacho-flow).
+Description: High-performance, zero-dependency agent supervisor and model dispatcher in Go. Sits locally between autonomous coding agents (Cline, Zoo Code, OpenCode, Aider) and LLMs to route routine turns to local GPUs for $0.00, kill runaway loops, and escalate complex reasoning to cloud APIs.
+Moniker: nacho-flow
+Tags:
+  - ai
+  - llm
+  - proxy
+  - gateway
+  - ollama
+  - openrouter
+  - agents
+  - local-llm
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.yaml
+++ b/manifests/d/dixieflatline76/NachoFlow/1.0.2/dixieflatline76.NachoFlow.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: dixieflatline76.NachoFlow
+PackageVersion: 1.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0


### PR DESCRIPTION
## 📖 Description

Adds initial manifest for `dixieflatline76.NachoFlow` version `1.0.2`.

**Nacho Flow** is an **Agent Supervisor & Model Dispatcher** built in pure Go. It sits between autonomous coding agents (Cline, Zoo Code, OpenCode, Aider, Cursor, Continue) and LLM backends, dynamically evaluating each prompt turn to route between local GPUs (Ollama, vLLM, LM Studio, llama.cpp) and cloud endpoints (OpenRouter, DeepSeek, Langdock, Azure OpenAI).

It runs routine turns on your local GPU for $0.00, terminates runaway repetition loops, resuscitates stalled agents, and escalates complex reasoning to cloud models when implementation gets hard. Includes an official VS Code companion extension with real-time telemetry and visual route inspection.

- **Publisher**: dixieflatline76
- **Package Name**: Nacho Flow
- **Package Identifier**: `dixieflatline76.NachoFlow`
- **Version**: `1.0.2`
- **License**: GNU AGPL-3.0-or-later
- **Project URL**: https://spicebox.dev/nacho-flow/
- **Release URL**: https://github.com/dixieflatline76/nacho-flow/releases/tag/v1.0.2
- **Installer Type**: Portable (`nacho-flow-1.0.2-windows-amd64.exe`)

---

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema
