### PR TITLE
Update version: tsouth89.Ceiling version 1.5.37

### DIFF
--- a/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.installer.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.37
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ProductCode: io.github.tsouth89.ceiling_is1
+ReleaseDate: 2026-09-07
+AppsAndFeaturesEntries:
+- DisplayName: Ceiling 1.5.37
+  DisplayVersion: 1.5.37
+  ProductCode: io.github.tsouth89.ceiling_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tsouth89/ceiling/releases/download/v1.5.37/Ceiling-1.5.37-Setup.exe
+  InstallerSha256: 30DE2400D60C01C7B84EA64066AE724A2F2B2A8AAF2A3F2CA1D9509866D4F20A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.locale.en-US.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.37
+PackageLocale: en-US
+Publisher: Brandon South
+PublisherUrl: https://github.com/tsouth89
+PublisherSupportUrl: https://github.com/tsouth89/ceiling/issues
+Author: Brandon South
+PackageName: Ceiling
+PackageUrl: https://ceiling.win
+License: MIT
+LicenseUrl: https://github.com/tsouth89/ceiling/blob/v1.5.29/LICENSE
+Copyright: Copyright (c) Ceiling contributors
+ShortDescription: Desktop capacity and quota monitor for coding assistants.
+Description: Ceiling is a local-first Windows app for monitoring provider-reported capacity and quota usage across AI coding platforms.
+Moniker: ceiling
+Tags:
+- claude
+- codex
+- cursor
+- desktop
+- gemini
+- grok
+- usage
+- windows
+ReleaseNotes: |-
+  Ceiling 1.5.37 is a maintenance release focused on pricing accuracy and honest failure states.
+
+  ## Highlights
+
+  - Codex usage on GPT-6 Astra is priced correctly, so an active Astra day no longer reads as $0.00 on Charts.
+  - A failed usage fetch now reports an error instead of a healthy 0% (Vertex AI, Amp, Kiro, MiniMax).
+  - A 429 on one Claude seat no longer pauses other seats sharing the same login email.
+  - Capacity baselines keep Codex directory seats separate, so one seat's drop no longer reads as the other's reset.
+  - An unreadable settings.json is quarantined instead of overwritten by the next save.
+  - Timed-out Kiro, Augment, and Vertex CLI fetches no longer leave orphaned processes.
+  - MCP get_status ranks Cursor the way the desktop strip does, and get_usage exposes cursor-api and on-demand windows.
+
+  ## MCP compatibility
+
+  get_status.remaining_percent now matches the desktop strip for Cursor, and usage.extra_rate_windows is included in get_usage and get_status output.
+ReleaseNotesUrl: https://github.com/tsouth89/ceiling/releases/tag/v1.5.37
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.yaml
+++ b/manifests/t/tsouth89/Ceiling/1.5.37/tsouth89.Ceiling.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: tsouth89.Ceiling
+PackageVersion: 1.5.37
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Pull request created via the manifest update workflow.

 * Have you verified that this PR is able to be merged into the winget-pkgs repository? Yes
 * Have you validated your manifest locally with `winget validate --manifest <path>`? No, winget is only available on Windows and this was prepared from a Linux environment; schema and fields follow the approved 1.5.36 manifests.
 * Have you followed the [manifest authoring guidelines](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md)? Yes

Changes:
- Copies the approved 1.5.36 manifest folder and changes only version-specific fields: PackageVersion, InstallerUrl, InstallerSha256, DisplayName, DisplayVersion, ReleaseDate, ReleaseNotes, and ReleaseNotesUrl.
- InstallerUrl resolves and the SHA-256 was recomputed from the downloaded asset: 30DE2400D60C01C7B84EA64066AE724A2F2B2A8AAF2A3F2CA1D9509866D4F20A (matches the release sidecar).
- Stable package identity unchanged: PackageIdentifier tsouth89.Ceiling, InstallerType inno, Scope user, ProductCode io.github.tsouth89.ceiling_is1, Publisher, silent install behavior.

Linked release: https://github.com/tsouth89/ceiling/releases/tag/v1.5.37
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431068)