### PR TITLE
New version: TechyGeeksHome.TranscribeGeek version 1.1.2

### DIFF
--- a/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.installer.yaml
+++ b/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.installer.yaml
@@ -1,0 +1,18 @@
+# Created with the TechyGeeksHome release process
+PackageIdentifier: TechyGeeksHome.TranscribeGeek
+PackageVersion: 1.1.2
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-01
+ProductCode: '{483F9381-1276-442B-A840-E9443D4C3938}_is1'
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/techygeekshome/TranscribeGeek/releases/download/v1.1.2/TranscribeGeekSetup.exe
+  InstallerSha256: 2480DEBB256F141AC3060689859573914F88C6EB049261AE4DB92D14A3E0DE84
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.locale.en-US.yaml
+++ b/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with the TechyGeeksHome release process
+PackageIdentifier: TechyGeeksHome.TranscribeGeek
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: TechyGeeksHome
+PublisherUrl: https://techygeekshome.info
+PublisherSupportUrl: https://github.com/techygeekshome/TranscribeGeek/issues
+Author: TechyGeeksHome
+PackageName: TranscribeGeek
+PackageUrl: https://techygeekshome.info/transcribegeek/
+License: GPL-3.0
+LicenseUrl: https://github.com/techygeekshome/TranscribeGeek/blob/main/LICENSE
+Copyright: Copyright (c) 2026 TechyGeeksHome
+ShortDescription: Turns audio and video into text on your own machine, with no upload and no length limit.
+Description: |-
+  TranscribeGeek runs OpenAI's Whisper speech models locally through whisper.cpp, so a recording
+  is transcribed on the machine it is already on. There is no account, no server and no
+  per minute charge, and a two hour recording costs the same as a two minute one.
+
+  It writes a plain text transcript beside the source file, with or without timestamps, and an
+  optional SubRip .srt subtitle file. Files are queued and worked through one at a time. Twenty
+  two languages are supported, or it can detect the language itself.
+
+  Speech models are not bundled. You pick one on the Models screen and it is fetched once and
+  kept, from Tiny at 78 MB up to Medium at 1.5 GB.
+
+  Compressed formats such as MP3 and MP4 need ffmpeg present to decode. Plain 16 kHz mono WAV
+  works either way, and the app says plainly which case it is in rather than failing quietly.
+Moniker: transcribegeek
+Tags:
+- audio
+- speech-to-text
+- subtitles
+- transcription
+- whisper
+- offline
+- windows
+ReleaseNotesUrl: https://github.com/techygeekshome/TranscribeGeek/releases/tag/v1.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.yaml
+++ b/manifests/t/TechyGeeksHome/TranscribeGeek/1.1.2/TechyGeeksHome.TranscribeGeek.yaml
@@ -1,0 +1,6 @@
+# Created with the TechyGeeksHome release process
+PackageIdentifier: TechyGeeksHome.TranscribeGeek
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

TechyGeeksHome.TranscribeGeek 1.1.2.

This replaces #426513, which was opened for 1.0.1 and has now been closed. 1.1.0, 1.1.1 and 1.1.2 have been released since, so this keeps one current manifest per package.

1.1.2 fixes a fault that stopped transcription working on every earlier release. The speech library was packed inside the single file executable and the loader could not find it at runtime. It is now written to the user profile and loaded from there, verified by size and SHA-256.

ProductCode is unchanged from earlier versions. The Inno Setup AppId is fixed across versions by design.

## Checklist

- [ ] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`

The last two are unticked deliberately rather than overlooked. This manifest was prepared without a Windows host to run winget validate on. What was done instead: the installer was downloaded from the release and its SHA-256 computed and compared against the release's own SHA256SUMS.txt, the three files were checked against the 1.6.0 manifest shape, and the ProductCode was read from the Inno Setup script in the source repository rather than guessed. Happy to correct anything the validation pipeline flags.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431082)