### PR TITLE
Add machine scope support to Lucen Timeline 15.1.0

### DIFF
--- a/manifests/l/Lucen/LucenTimeline/15.1.0/Lucen.LucenTimeline.installer.yaml
+++ b/manifests/l/Lucen/LucenTimeline/15.1.0/Lucen.LucenTimeline.installer.yaml
@@ -7,8 +7,6 @@ InstallerType: zip
 NestedInstallerType: wix
 NestedInstallerFiles:
 - RelativeFilePath: LucenTimeline.msi
-InstallerSwitches:
-  InstallLocation: ADDININSTALLDIR="<INSTALLPATH>"
 UpgradeBehavior: install
 Dependencies:
   PackageDependencies:
@@ -19,10 +17,34 @@ AppsAndFeaturesEntries:
 - UpgradeCode: '{8E493579-8C4D-4530-8A2E-B338DB490784}'
 Installers:
 - Architecture: x86
+  Scope: user
   InstallerUrl: https://www.lucensoftware.com/website/content/download/install/latest/LucenTimelinePreExtracted.zip
   InstallerSha256: 93948C711D53E2090BE0C34838EC5BC926E607D516A594292CA3872D7356200C
+  InstallerSwitches:
+    InstallLocation: ADDININSTALLDIR="<INSTALLPATH>"
+
 - Architecture: x64
+  Scope: user
   InstallerUrl: https://www.lucensoftware.com/website/content/download/install/latest/LucenTimelinePreExtracted.zip
   InstallerSha256: 93948C711D53E2090BE0C34838EC5BC926E607D516A594292CA3872D7356200C
+  InstallerSwitches:
+    InstallLocation: ADDININSTALLDIR="<INSTALLPATH>"
+
+- Architecture: x86
+  Scope: machine
+  InstallerUrl: https://www.lucensoftware.com/website/content/download/install/latest/LucenTimelinePreExtracted.zip
+  InstallerSha256: 93948C711D53E2090BE0C34838EC5BC926E607D516A594292CA3872D7356200C
+  InstallerSwitches:
+    InstallLocation: ADDININSTALLDIR="<INSTALLPATH>"
+    Custom: ALLUSERS=1
+
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://www.lucensoftware.com/website/content/download/install/latest/LucenTimelinePreExtracted.zip
+  InstallerSha256: 93948C711D53E2090BE0C34838EC5BC926E607D516A594292CA3872D7356200C
+  InstallerSwitches:
+    InstallLocation: ADDININSTALLDIR="<INSTALLPATH>"
+    Custom: ALLUSERS=1
+
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds machine-scope support for Lucen Timeline 15.1.0.

Lucen Timeline supports per-machine installation using ALLUSERS=1.

This update adds separate user and machine installer entries for x86 and x64. The machine-scoped installers explicitly pass ALLUSERS=1 to the MSI.

This allows:

winget install -e --id Lucen.LucenTimeline --scope machine

The manifest was validated with winget validate, and the machine-scope installation was tested locally. The test successfully installed Lucen Timeline 15.1.0 and registered the application under HKLM.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431112)