### PR TITLE
Update Haruna installer URLs and SHA256 hashes

### DIFF
--- a/manifests/k/KDE/Haruna/1.8.1/KDE.Haruna.installer.yaml
+++ b/manifests/k/KDE/Haruna/1.8.1/KDE.Haruna.installer.yaml
@@ -9,14 +9,14 @@ ProductCode: Haruna
 Installers:
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://cdn.kde.org/ci-builds/multimedia/haruna/master/windows/haruna-master-1815-windows-gcc-x86_64.exe
-  InstallerSha256: 31207C5A752CE513AD43A8C7A0A1BE3B09218DB0E736E786135727220CA3EE1E
+  InstallerUrl: https://download.kde.org/stable/haruna/1.8.1/haruna-1.8.1-windows-gcc-x86_64.exe
+  InstallerSha256: 88760894F9EC8214A9AF20AEFC6BEB4443D61C25DDDB0373FD62642A7C0CC225
   InstallerSwitches:
     Custom: /CurrentUser
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://cdn.kde.org/ci-builds/multimedia/haruna/master/windows/haruna-master-1815-windows-gcc-x86_64.exe
-  InstallerSha256: 31207C5A752CE513AD43A8C7A0A1BE3B09218DB0E736E786135727220CA3EE1E
+  InstallerUrl: https://download.kde.org/stable/haruna/1.8.1/haruna-1.8.1-windows-gcc-x86_64.exe
+  InstallerSha256: 88760894F9EC8214A9AF20AEFC6BEB4443D61C25DDDB0373FD62642A7C0CC225
   InstallerSwitches:
     Custom: /AllUsers
 ManifestType: installer


### PR DESCRIPTION
## 📖 Description

Package: KDE.Haruna 1.8.1

The current installer URL points to a KDE CI build artifact that returns HTTP 404.

Updated the manifest to use the official KDE 1.8.1 stable release installer and updated the SHA256 hash accordingly.

Related discussion regarding the broken URL:
https://github.com/microsoft/winget-pkgs/pull/409959

## ✅ Checklist

- [ ] Signed the Contributor License Agreement
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [X] Checked that there aren't other open pull requests for the same manifest update/change
- [X] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [X] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431113)