### PR TITLE
Update version: Datadog.dd-trace-dotnet version 3.53.0

### DIFF
--- a/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.installer.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.53.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Custom: ALLUSERS="1" PATHSHORTCUT="1"
+UpgradeBehavior: install
+ProductCode: "{814E61E0-BA5A-4E37-9F83-DD890E95BEAE}"
+ReleaseDate: 2026-09-07
+AppsAndFeaturesEntries:
+- DisplayName: Datadog .NET Tracer 64-bit
+  ProductCode: "{814E61E0-BA5A-4E37-9F83-DD890E95BEAE}"
+  UpgradeCode: "{FC228E86-EAE2-4C2A-AE82-135B718C269E}"
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%/Datadog/.NET Tracer"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/DataDog/dd-trace-dotnet/releases/download/v3.53.0/datadog-dotnet-apm-3.53.0-x64.msi
+  InstallerSha256: 4CFAF65EDF080E1EAFFCB25D5FB9030D6C7A0C6EDB2D495F1D0E4ECE70D133FA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.53.0
+PackageLocale: en-US
+Publisher: Datadog, Inc.
+PublisherUrl: https://docs.datadoghq.com/
+PublisherSupportUrl: https://www.datadoghq.com/support
+PrivacyUrl: https://www.datadoghq.com/legal/privacy
+Author: Datadog
+PackageName: Datadog .NET Tracer
+PackageUrl: https://docs.datadoghq.com/tracing
+License: Apache-2.0
+LicenseUrl: https://github.com/DataDog/dd-trace-dotnet/blob/HEAD/LICENSE
+Copyright: Copyright 2017 Datadog, Inc.
+CopyrightUrl: https://github.com/DataDog/dd-trace-dotnet/blob/master/NOTICE
+ShortDescription: Automatic instrumentation for .NET applications
+Moniker: dd-trace-dotnet
+Tags:
+- apm
+- tracing
+ReleaseNotes: "## Summary\r\n\r\n• [Tracing] Improve memory_load metric in .NET 10\r\n• [Tracing] Reduce buffer contention when writing spans\r\n• [CI Visibility] Improve CODEOWNERS parsing\r\n• [Continuous Profiling] Bug fixes and performance improvements\r\n• [Feature Flagging] Send split serial ids on exposure events \r\n\r\n## Changes\r\n\r\n### Tracer\r\n• Avoid unobserved tasks for synchronous delegate exceptions (#9071)\r\n• Reduce locking in `AgentWriter` to avoid contention (#9107)\r\n• Expose the `TrailerSize` of an `ISpanBufferSerializer` (#9115)\r\n• Fix lock-contention causing trace to be \"stranded\" (#9120)\r\n• Improve `GcMemoryLoadCalculator` by using `GC.GetConfigurationVariables()` where possible (#9146)\r\n\r\n\r\n### CI Visibility\r\n• [CI Visibility] Refactor CODEOWNERS parsing and source ownership resolution (#9099)\r\n• [CI Visibility] Fix coverage rewrites with shared framework dependencies (#9102)\r\n• [CI Visibility] Keep CODEOWNERS matches inside repository (#9127)\r\n• [CI Visibility] Stabilize CODEOWNERS concurrency test (#9143)\r\n• [CI Visibility] Resolve CODEOWNERS from matching local checkout (#9148)\r\n\r\n### Continuous Profiler\r\n• [Profiler] ManagedCodeCache updates synchronously (#8840)\r\n• [Profiler] Fix flaky tests caused by failing`timer_create` (#8988)\r\n• [Profiler] Fix start/stop crash at shutdown (#9037)\r\n• [Profiler] Fix crashes at shutdown (#9050)\r\n• [Profiler] Measure and reduce GC profiling impact (#9119)\r\n• [Profiler] Fix flacky tests (#9126)\r\n• [Profiler] Fix bug in FrameStore (#9140)\r\n\r\n### Feature Flags and Experimentation\r\n• [Feature Flags] Send the split serial id on exposure events (#9088)\r\n• feat(feature-flags)：add agentless configuration keys, settings, and endpoint derivation (#9040)\r\n• feat(feature-flags)：add UFC parser and agentless HTTP poller (#9042)\r\n• feat(openfeature)：support arbitrary semver parts (#9122)\r\n\r\n### Build / Test\r\n• Migrate remaining integration tests to CombinatorialOrPairwiseData (#8528)\r\n• Move secrets to be protected environment secrets (#8865)\r\n• Try to make it so that CODEOWNERs triggers tests (#9092)\r\n• Split system-test docker image creation to work in both protected and unprotected environments (#9094)\r\n• [Test Package Versions Bump] Updating package versions (#9100)\r\n• Consolidate and fix bugs in GitLab \"download from Azure\" scripts (#9103)\r\n• Don't need to download and sign when pushing a tag (#9105)\r\n• Mark DSM TransportsWorkCorrectly as flaky (#9116)\r\n• Mark DSM ContextPropagation as flaky (#9117)\r\n• [Test Package Versions Bump] Updating package versions (#9124)\r\n• Bump test logger to latest (to try to fix codeowners) (#9128)\r\n• Add `new Random()` to the banned API list, to discourage using those APIs (#9129)\r\n• Add SDK capabilities and LP as owners in addition to tracing-dotnet (#9130)\r\n• Bump SLO for throughput tests (#9131)\r\n• [Smoke Test Docker Image Bump] Updating docker image tags (#9134)\r\n• Add many timeouts and retries to build stages in Azure DevOps (#9141)\r\n• Move CI uploads to new subscription (#9142)\r\n• Refine listed non-IDM tests to single owner (#9149)\r\n• [CI Visibility] Bump Datadog test packages to 0.0.59 (#9151)\r\n• [Test Package Versions Bump] Updating package versions (#9152)\r\n• [Smoke Test Docker Image Bump] Updating docker image tags (#9153)\r\n• Increase profiler integration test timeout (#9158)\r\n• Bump the gh-actions-packages group across 2 directories with 4 updates (#9161)\r\n• [Test Package Versions Bump] Updating package versions (#9163)\r\n• Don't run high-concurrency tests in parallel with other tests (#9166)\r\n• Fix release creation (#9190)\r\n• Fix broken unit tests in `GcMemoryLoadCalculatorTests` (#9101)\r\n\r\n### Miscellaneous\r\n• [Propagators] Add OpenTelemetry consistent probability sampling (#8983)\r\n• Revert \"[Propagators] Add OpenTelemetry consistent probability sampling\" (#9171)\r\n• feat(otel)：Emit OpenTelemetry HTTP semantic conventions on HTTP server spans (ASP.NET Core) (#8995)\r\n• [Propagators] Generalize tracestate parsing (#9000)\r\n• Remove exception throwing from `CanCreate()` paths in DuckTyping (#9005)\r\n• Revert \"[Propagators] Add OpenTelemetry consistent probability sampling\" (#9171)\r\n\r\n[Changes since 3.52.0](https://github.com/DataDog/dd-trace-dotnet/compare/v3.52.0...v3.53.0)"
+ReleaseNotesUrl: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.53.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.yaml
+++ b/manifests/d/Datadog/dd-trace-dotnet/3.53.0/Datadog.dd-trace-dotnet.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: Datadog.dd-trace-dotnet
+PackageVersion: 3.53.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update Datadog.dd-trace-dotnet to version 3.53.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431131)