### PR TITLE
New package: automationjp.HyperDU version 0.5.0-beta.2

### DIFF
--- a/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.installer.yaml
+++ b/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: automationjp.HyperDU
+PackageVersion: "0.5.0-beta.2"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - hyperdu
+ReleaseDate: 2026-09-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/automationjp/HyperDiskUsage/releases/download/v0.5.0-beta.2/hyperdu-cli-windows-x86_64-generic.exe
+    InstallerSha256: 43dcaccc5688199acf1a2fa9cbfdc8480125e7b741bed76ef71453fef54f3b21
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.locale.en-US.yaml
+++ b/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: automationjp.HyperDU
+PackageVersion: "0.5.0-beta.2"
+PackageLocale: en-US
+Publisher: automationjp
+PublisherUrl: https://github.com/automationjp
+PublisherSupportUrl: https://github.com/automationjp/HyperDiskUsage/issues
+PackageName: HyperDU
+PackageUrl: https://github.com/automationjp/HyperDiskUsage
+License: MIT
+LicenseUrl: https://github.com/automationjp/HyperDiskUsage/blob/main/LICENSE
+ShortDescription: Fast cross-platform disk usage analyzer.
+Description: >-
+  HyperDU reports where disk space went. It uses each platform's bulk
+  enumeration API and a work-stealing scanner, and can read the NTFS MFT
+  directly when run elevated against a volume root.
+Moniker: hyperdu
+Tags:
+  - cli
+  - disk
+  - disk-usage
+  - du
+  - filesystem
+  - storage
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.yaml
+++ b/manifests/a/automationjp/HyperDU/0.5.0-beta.2/automationjp.HyperDU.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: automationjp.HyperDU
+PackageVersion: "0.5.0-beta.2"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been verified to be:

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not done**, see note below
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.12.0)?

---

New package: **automationjp.HyperDU** 0.5.0-beta.2

HyperDU is a cross-platform disk usage analyzer. It uses each platform's bulk
enumeration API and a work-stealing scanner, and can read the NTFS MFT directly
when run elevated against a volume root.

- Repository: https://github.com/automationjp/HyperDiskUsage
- Release: https://github.com/automationjp/HyperDiskUsage/releases/tag/v0.5.0-beta.2
- License: MIT

`InstallerType: portable` — the release asset is the bare executable, not an
installer. `Commands: hyperdu` so winget creates the expected shim.

### What was verified

- `winget validate --manifest` passes.
- The `InstallerUrl` returns HTTP 200 and its SHA256 matches `InstallerSha256`
  (computed from the downloaded asset, not from a local build).
- The executable itself was run from the published release: it reports
  `hyperdu 0.5.0-beta.2` and completes a scan.

### What was not verified

`winget install --manifest` was not run. It requires
`winget settings --enable LocalManifestFiles` as administrator, which was not
available in the environment this was prepared in. Everything the local install
would have exercised — URL reachability, hash, and that the binary runs — was
checked directly, as listed above.

### Note on the version

This is a pre-release version. It is the project's first publicly released
build; the crates are published on crates.io at the same version. If the
maintainers prefer to wait for a stable release before the package's debut,
please say so and I will close this and resubmit at 0.5.0.

> The CLA checkbox above is unchecked on purpose: the bot has applied `Needs-CLA`
> and the repository owner still needs to reply with the agreement comment.
