### PR TITLE
New package: mtai0524.Cowork version 1.0.0

### DIFF
--- a/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.installer.yaml
+++ b/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.installer.yaml
@@ -1,0 +1,25 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: mtai0524.Cowork
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{DC300C3E-5640-4C1B-A2A2-FEC770B511F1}'
+ReleaseDate: 2026-09-08
+AppsAndFeaturesEntries:
+- ProductCode: '{DC300C3E-5640-4C1B-A2A2-FEC770B511F1}'
+  UpgradeCode: '{6F3D2A41-8C7B-4F0E-9D1A-2B5E7C4A9F30}'
+  DisplayVersion: 1.0.0
+  InstallerType: wix
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/mtai0524/cowork-launcher/releases/download/v1.0.0/Cowork-1.0.0-win-x64.msi
+  InstallerSha256: ED05A4D52EB005261626C7C3062F8C0EDCBC54BA55A46B123B9BDC61E6236947
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.locale.en-US.yaml
+++ b/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.locale.en-US.yaml
@@ -1,0 +1,36 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: mtai0524.Cowork
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: mtai0524
+PublisherUrl: https://github.com/mtai0524
+PublisherSupportUrl: https://github.com/mtai0524/cowork-launcher/issues
+Author: mtai0524
+PackageName: Cowork
+PackageUrl: https://github.com/mtai0524/cowork-launcher
+License: Proprietary
+Copyright: Copyright (c) mtai0524
+ShortDescription: Declare the programs you run every day, then launch them by hand or on a schedule
+Description: |-
+  Cowork keeps the programs you have to run every day in one window: declare each one
+  once with its arguments, working directory and environment, then launch it by hand or
+  let Cowork run it on a schedule or on a machine event such as waking from sleep.
+  It edits those programs' JSON, INI, .env and XML config files in place with backups
+  and diffs, keeps services alive, catches hung ones, retries failed jobs, and writes a
+  self-describing log for every run. Several machines can report to one web hub. A
+  built-in RSS reader gives you the day's news and trending GitHub repos by topic.
+Moniker: cowork
+Tags:
+- automation
+- launcher
+- rss
+- scheduler
+- task-runner
+- windows
+ReleaseNotesUrl: https://github.com/mtai0524/cowork-launcher/releases/tag/v1.0.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/mtai0524/cowork-launcher/blob/main/docs/04-huong-dan-su-dung.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.yaml
+++ b/manifests/m/mtai0524/Cowork/1.0.0/mtai0524.Cowork.yaml
@@ -1,0 +1,7 @@
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: mtai0524.Cowork
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package

`mtai0524.Cowork` 1.0.0 — https://github.com/mtai0524/cowork-launcher

A Windows desktop app for the programs you have to run every day: declare each one once with its
arguments, working directory and environment, then launch it by hand or let it run on a schedule or
on a machine event. It also edits those programs' JSON / INI / .env / XML config files in place with
backups and diffs, keeps services alive, retries failed jobs, and writes a log for every run.

### Checklist

- [x] Manifest validated locally — `winget validate --manifest .` reports **Manifest validation succeeded** with no warnings.
- [x] Conforms to the 1.6 manifest schema.
- [x] No other open pull request for this package. It is a new publisher: `manifests/m/mtai0524` does not exist in this repo yet.
- [ ] **Not** installed via `winget install --manifest`, which needs the `LocalManifestFiles` setting and elevation. Verified another way instead: the MSI was downloaded from the exact `InstallerUrl` in the manifest, its SHA-256 compared against `InstallerSha256`, installed with `msiexec /i /qn`, launched, and uninstalled — leaving no files, no Start Menu entry and no PATH entry behind. The `ProductCode` in the manifest is the one the install actually registers, read out of the published MSI rather than copied from a local build.

### Notes for review

- **Per-user install** (`Scope: user`). The MSI is built `Scope="perUser"` and installs to `%LOCALAPPDATA%\Programs\Cowork`, so no elevation is required.
- **Self-contained**, so there is no .NET runtime dependency to declare — that is why the installer is ~54 MB.
- The installer is served from the project's own GitHub release: https://github.com/mtai0524/cowork-launcher/releases/tag/v1.0.0
- `SHA256SUMS` is published alongside it on that release if you want an independent check.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431189)