### PR TITLE
New package: HyperWorX.DopusWorX version 1.5.0

### DIFF
--- a/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.installer.yaml
+++ b/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: HyperWorX.DopusWorX
+PackageVersion: 1.5.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/HyperWorX/DopusWorX/releases/download/v1.5.0/DopusWorX_v1.5.0_Setup.exe
+  InstallerSha256: DA91CC4602E9BFFB33B5FD33CF5193B6541B3C75C28D4E1EA9E596738270FD7E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.locale.en-US.yaml
+++ b/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: HyperWorX.DopusWorX
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: HyperWorX
+PublisherUrl: https://github.com/HyperWorX
+PublisherSupportUrl: https://github.com/HyperWorX/DopusWorX/issues
+PackageName: DopusWorX
+PackageUrl: https://github.com/HyperWorX/DopusWorX
+License: Freeware
+Copyright: (c) HyperWorX. All rights reserved.
+ShortDescription: Markdown, maths, code and CSV viewer/editor plugin for Directory Opus
+Moniker: dopusworx
+Tags:
+- directory-opus
+- markdown
+- viewer
+- editor
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.yaml
+++ b/manifests/h/HyperWorX/DopusWorX/1.5.0/HyperWorX.DopusWorX.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: HyperWorX.DopusWorX
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

New package: HyperWorX.DopusWorX version 1.5.0.

DopusWorX is a document viewer and in-place editor plugin for Directory Opus (markdown, maths, diagrams, code, CSV, HTML and binary files). Installer is Inno Setup, x64, machine scope, published on the GitHub releases page the InstallerUrl points at.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for the same manifest
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` (validation succeeded)
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the 1.12 schema (written against the 1.6.0 schema; local validation passes)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431190)