### PR TITLE
New version: oipoistar.Tinta version 3.5.6

### DIFF
--- a/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.5.6
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v3.5.6/tinta.exe
+  InstallerSha256: 715229ACD8D647CAF54A7DFA440A7D47AB613257180905196940B9AA8029E20A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.5.6
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable of about 2.3 MB that starts in under 100 ms -
+  no Electron, no web engine, no installer. Features review annotations with a copy-for-agent loop, plain-text file references with mouse back and forward navigation, rendered link previews on hover, export to HTML, DOCX
+  and PDF plus optional Pandoc export to EPUB, ODT, PPTX, RTF and LaTeX, a Win11-style tabbed interface with drag and drop, session
+  restore and a tab context menu, native LaTeX math with matrices, cases,
+  aligned equations and equation-local macros, native rendering for
+  twenty-two Mermaid diagram families (flowcharts with subgraphs, sequence,
+  class, state, ER, C4, requirement, architecture, block, sankey, packet,
+  kanban, treemap, radar, pie, git graphs, gantt, mindmaps, timelines,
+  journeys, quadrant and xy charts), custom themes with a built-in editor,
+  shortcut profiles, a UI in seven languages, first-class CJK text layout,
+  glyph-precise text selection, a table of contents and folder browser that
+  can be pinned open beside the document, full-text search, zoom, a start
+  page with recent files, and a unified editor whose rendered page floats
+  beside the source with live diagram preview and click-to-edit tables.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- latex
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v3.5.6
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/3.5.6/oipoistar.Tinta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.5.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New version of oipoistar.Tinta (3.5.6), a portable native Markdown viewer with expanded LaTeX math support.

- [x] Signed the Contributor License Agreement.
- [x] Checked that there are no other open pull requests for the same manifest update.
- [x] Validated the manifest locally with `winget validate --manifest <path>`.
- [ ] Tested the manifest locally with `winget install --manifest <path>`.
- [x] Manifest conforms to the 1.12 schema.

Local installation was attempted but is blocked because this host disables the administrator-controlled LocalManifestFiles setting. The downloaded release executable passed native rendering and HTML export checks for 49 equations in mixed Markdown documents. The installer hash matches the published asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431257)