### PR TITLE
New package: Kilo-Org.Kilo version 7.5.9

### DIFF
--- a/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.installer.yaml
+++ b/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Kilo-Org.Kilo
+PackageVersion: 7.5.9
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: kilo.exe
+Commands:
+- kilo
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Kilo-Org/kilocode/releases/download/v7.5.9/kilo-windows-x64-baseline.zip
+  InstallerSha256: ED3B8BC9B3B622CC63981CC7AA71DBAD32D034ADA090DAA9ADF1BD3D084E2F5A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.locale.en-US.yaml
+++ b/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Kilo-Org.Kilo
+PackageVersion: 7.5.9
+PackageLocale: en-US
+Publisher: Kilo Code
+PublisherUrl: https://kilo.ai/
+PublisherSupportUrl: https://github.com/Kilo-Org/kilocode/issues
+PackageName: Kilo Code CLI
+PackageUrl: https://kilo.ai/cli
+License: MIT
+LicenseUrl: https://github.com/Kilo-Org/kilocode/blob/main/LICENSE
+ShortDescription: Open-source AI coding agent for the terminal.
+Description: Kilo Code CLI is an open-source coding agent that can inspect projects, assist with code changes, and connect to supported AI providers from the terminal.
+Tags:
+- ai
+- cli
+- code
+- coding
+- development
+- terminal
+ReleaseNotesUrl: https://github.com/Kilo-Org/kilocode/releases/tag/v7.5.9
+Documentations:
+- DocumentLabel: CLI documentation
+  DocumentUrl: https://kilo.ai/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.yaml
+++ b/manifests/k/Kilo-Org/Kilo/7.5.9/Kilo-Org.Kilo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Kilo-Org.Kilo
+PackageVersion: 7.5.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds Kilo Code CLI 7.5.9 using the official x64 baseline portable ZIP from the versioned GitHub release. The installer SHA-256 matches the digest published by the Kilo release API.

## Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] No separate issue is required for this routine new-package manifest submission.

## Manifest Checklist

- [x] Checked that there are no other open or closed pull requests for `Kilo-Org.Kilo`.
- [x] This PR modifies one package version only.
- [x] Validated locally with `winget validate --manifest manifests/k/Kilo-Org/Kilo/7.5.9`.
- [ ] Local-manifest installation was not enabled on the enterprise-managed test device; the repository validation pipeline should perform installer verification.
- [x] Manifest conforms to schema 1.12.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431261)