### PR TITLE
New package: KoukeNeko.Aihki version 0.5.2

### DIFF
--- a/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.installer.yaml
+++ b/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.Aihki
+PackageVersion: 0.5.2
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/KoukeNeko/aihki/releases/download/v0.5.2/aihki_0.5.2_windows_amd64.zip
+  InstallerSha256: CA34039F372D30C7943336E884775FC78299926A2E5824D91FA00CD62C73D1E1
+  NestedInstallerFiles:
+  - RelativeFilePath: aihki_0.5.2_windows_amd64\aihki.exe
+    PortableCommandAlias: aihki
+- Architecture: arm64
+  InstallerUrl: https://github.com/KoukeNeko/aihki/releases/download/v0.5.2/aihki_0.5.2_windows_arm64.zip
+  InstallerSha256: 5204A6412C70BD5223F15EA6856450F61156EBAC06D902803FEC4C2038B69AB3
+  NestedInstallerFiles:
+  - RelativeFilePath: aihki_0.5.2_windows_arm64\aihki.exe
+    PortableCommandAlias: aihki
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.locale.en-US.yaml
+++ b/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.Aihki
+PackageVersion: 0.5.2
+PackageLocale: en-US
+Publisher: KoukeNeko
+PublisherUrl: https://github.com/KoukeNeko
+PublisherSupportUrl: https://github.com/KoukeNeko/aihki/issues
+PackageName: Aihki
+PackageUrl: https://github.com/KoukeNeko/aihki
+License: MIT
+LicenseUrl: https://github.com/KoukeNeko/aihki/blob/main/LICENSE
+Copyright: Copyright (c) KoukeNeko
+ShortDescription: Independent command-line client for Taiga
+Description: |-
+  Aihki drives Taiga 6 projects, agile boards and wikis from the terminal. The
+  same command serves a person and a program: it prints aligned tables, and
+  with --json it answers with a versioned contract that shell scripts, CI jobs
+  and agents can be pointed at. Tokens are kept in the operating system
+  credential store rather than a configuration file.
+
+  Taiga is a trademark of its respective owners. This is an independent client,
+  not affiliated with or endorsed by the Taiga project.
+Moniker: aihki
+Tags:
+- agile
+- cli
+- issue-tracker
+- kanban
+- project-management
+- scrum
+- taiga
+ReleaseNotesUrl: https://github.com/KoukeNeko/aihki/releases/tag/v0.5.2
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://github.com/KoukeNeko/aihki/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.locale.zh-TW.yaml
+++ b/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.locale.zh-TW.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.Aihki
+PackageVersion: 0.5.2
+PackageLocale: zh-TW
+Publisher: KoukeNeko
+PackageName: Aihki
+License: MIT
+ShortDescription: 獨立的 Taiga 命令列客戶端
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.yaml
+++ b/manifests/k/KoukeNeko/Aihki/0.5.2/KoukeNeko.Aihki.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.Aihki
+PackageVersion: 0.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: `KoukeNeko.Aihki` version 0.5.2, an independent command-line client for Taiga. I am the author of the package.

The Windows release is a zip holding a single portable `aihki.exe`, so the installer manifest uses `InstallerType: zip` with `NestedInstallerType: portable`, for x64 and arm64. The digests are the ones published in the release's `SHA256SUMS`.

Installed and uninstalled locally from the manifest on Windows 11 x64: the installer hash verified, the archive extracted, the `aihki` alias was added and reported `aihki v0.5.2`, and uninstalling removed both the alias and the package directory.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431282)