### PR TITLE
Fix InstallerSha256 for CryptographicTriangles.TrianglesQt 6.2.6.7

### DIFF
--- a/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.7/CryptographicTriangles.TrianglesQt.installer.yaml
+++ b/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.7/CryptographicTriangles.TrianglesQt.installer.yaml
@@ -11,6 +11,6 @@ Installers:
   - Architecture: x64
     InstallerType: exe
     InstallerUrl: https://github.com/SamiAhmed7777/triangles_v5/releases/download/v6.2.6.7/Cryptographic-Triangles-6.2.6.7-win-x64-setup.exe
-    InstallerSha256: 59fee038672e6a6dd3a8b1f42b60799d68e6a7d3a3e4141f636ddc4ae981fd37
+    InstallerSha256: e4d5325a99283ec7f963c314884d850ab1ffc8a0d9eaa5aea01bf30e7289ef62
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The 6.2.6.7 manifest (merged in #430625) pins InstallerSha256 `59fee038672e6a6dd3a8b1f42b60799d68e6a7d3a3e4141f636ddc4ae981fd37`, which does not match the published release asset at https://github.com/SamiAhmed7777/triangles_v5/releases/download/v6.2.6.7/Cryptographic-Triangles-6.2.6.7-win-x64-setup.exe

The actual asset (downloaded and verified twice, byte-identical, 75,014,377 bytes) hashes to:

```
e4d5325a99283ec7f963c314884d850ab1ffc8a0d9eaa5aea01bf30e7289ef62
```

The PR that introduced the wrong hash merged ~5 minutes before the release was finalized, so the pinned hash was computed against a pre-final upload. This PR corrects the hash so winget installs of 6.2.6.7 pass validation.

-----

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/CodeFlow?openpr.gitrepo=winget-pkgs&openpr.pr=THIS_PR&openpr.commit=HEAD&openpr.filepath=manifests%2Fc%2FCryptographicTriangles%2FTrianglesQt%2F6.2.6.7%2FCryptographicTriangles.TrianglesQt.installer.yaml&openpr.filetype=Edit)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431290)