### PR TITLE
New package: GrafanaLabs.xk6 version 1.4.12

### DIFF
--- a/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.installer.yaml
+++ b/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.installer.yaml
@@ -1,0 +1,30 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: GrafanaLabs.xk6
+PackageVersion: 1.4.12
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: xk6.exe
+  PortableCommandAlias: xk6
+InstallModes:
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- xk6
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: GoLang.Go
+    MinimumVersion: 1.25.0
+ReleaseDate: 2026-08-25
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/grafana/xk6/releases/download/v1.4.12/xk6_1.4.12_windows_amd64.zip
+  InstallerSha256: 086C50767A738C88F536A77A14EB6930A62070F5F1BCCD0FB491A57E4C4F7FCB
+- Architecture: arm64
+  InstallerUrl: https://github.com/grafana/xk6/releases/download/v1.4.12/xk6_1.4.12_windows_arm64.zip
+  InstallerSha256: 560C4737D64D07BB90B1D4ED7DDE3394989EB6F218E2E5CF83F7CC927FDCEC27
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.locale.en-US.yaml
+++ b/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: GrafanaLabs.xk6
+PackageVersion: 1.4.12
+PackageLocale: en-US
+Publisher: Grafana Labs
+PublisherUrl: https://grafana.com/
+PublisherSupportUrl: https://github.com/grafana/xk6/issues
+Author: Grafana Labs
+PackageName: xk6
+PackageUrl: https://github.com/grafana/xk6
+License: Apache-2.0
+LicenseUrl: https://github.com/grafana/xk6/blob/HEAD/LICENSE
+ShortDescription: k6 extension development toolbox
+Description: xk6 is a command-line tool for building k6 with extensions written in Go, similar to how xcaddy builds Caddy. It scaffolds new extension projects, compiles k6 binaries bundled with one or more extensions, runs and integration-tests the resulting binary, and lints extensions for compliance, without requiring you to fork or patch the k6 source itself.
+Moniker: xk6
+Tags:
+- k6
+- xk6
+ReleaseNotesUrl: https://github.com/grafana/xk6/releases/tag/v1.4.12
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.yaml
+++ b/manifests/g/GrafanaLabs/xk6/1.4.12/GrafanaLabs.xk6.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: GrafanaLabs.xk6
+PackageVersion: 1.4.12
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds the initial manifest for GrafanaLabs.xk6 (k6 extension development toolbox), version 1.4.12.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431292)