### PR TITLE
New package: ShakaProject.MpdGenerator version 3.9.3

### DIFF
--- a/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.installer.yaml
+++ b/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ShakaProject.MpdGenerator
+PackageVersion: 3.9.3
+InstallerType: portable
+Commands:
+- mpd_generator
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+ReleaseDate: 2026-07-27
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/shaka-project/shaka-packager/releases/download/v3.9.3/mpd_generator-win-x64.exe
+  InstallerSha256: 9777C3C6BB27F68689A0044AD36CDBBFFAE1235CEFC9C11CBD3C645BAF9BA19D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.locale.en-US.yaml
+++ b/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ShakaProject.MpdGenerator
+PackageVersion: 3.9.3
+PackageLocale: en-US
+Publisher: Shaka Project
+PublisherUrl: https://shaka-project.github.io/
+PublisherSupportUrl: https://github.com/shaka-project/shaka-packager/issues
+PackageName: Shaka Packager MPD Generator
+PackageUrl: https://shaka-project.github.io/shaka-packager/html/
+License: BSD-3-Clause
+LicenseUrl: https://github.com/shaka-project/shaka-packager/blob/HEAD/LICENSE
+Copyright: Copyright 2026, Google LLC. All rights reserved.
+ShortDescription: Generates a DASH MPD from the MediaInfo files written by Shaka Packager. The mpd_generator companion tool shipped with each Shaka Packager release.
+Tags:
+- dash
+- media
+- mpd
+- packaging
+- vod
+ReleaseNotesUrl: https://github.com/shaka-project/shaka-packager/releases/tag/v3.9.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.yaml
+++ b/manifests/s/ShakaProject/MpdGenerator/3.9.3/ShakaProject.MpdGenerator.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ShakaProject.MpdGenerator
+PackageVersion: 3.9.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: ShakaProject.MpdGenerator version 3.9.3.

`mpd_generator` is the companion tool shipped with every Shaka Packager release (`mpd_generator-win-x64.exe`). It generates a DASH MPD from the MediaInfo files that `packager` writes. Until now it was only reachable through `ShakaProject.ShakaPackager`, whose installer manifest has been pointing at this asset by mistake since 3.5.0 while advertising the `packager` command; a separate PR points that package back at `packager-win-x64.exe`. A portable manifest cannot carry two executables from separate release assets, so the generator gets its own package with its own `mpd_generator` command.

The installer URL, SHA256, release date and VC++ redistributable dependency are the values the existing 3.9.3 ShakaPackager manifest already carried for this asset. License is `BSD-3-Clause`, which is what the upstream LICENSE file states.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>` (this exact binary is what `winget install ShakaProject.ShakaPackager` 3.9.3 currently installs; verified it runs and reports `mpd_generator version v3.9.3-0a8ba4f-release`)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431359)