### PR TITLE
Stan-Ely.qrdrop-app version 0.1.0

### DIFF
--- a/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.installer.yaml
+++ b/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Stan-Ely.qrdrop-app
+PackageVersion: 0.1.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: qrdrop
+  DisplayVersion: 0.1.0
+  ProductCode: qrdrop
+  InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/stan-ely/qrdrop/releases/download/app-v0.1.0/qrdrop_0.1.0_x64-setup.exe
+  InstallerSha256: 6D5CA27F0E4C2518A43DA4D99E7FC7B9C7F1269DE610F05745F0D372A7FD9774
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-09-06

--- a/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.locale.en-US.yaml
+++ b/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Stan-Ely.qrdrop-app
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Bevan Stanely
+PublisherUrl: https://github.com/stan-ely
+PublisherSupportUrl: https://github.com/stan-ely/qrdrop/issues
+Author: Bevan Stanely
+PackageName: qrdrop
+PackageUrl: https://github.com/stan-ely/qrdrop
+License: MIT
+LicenseUrl: https://github.com/stan-ely/qrdrop/blob/main/LICENSE
+Copyright: Copyright (c) Bevan Stanely
+ShortDescription: Send a file straight from one device to another, end-to-end encrypted
+Description: |-
+  qrdrop sends a file straight from one device to another. The file is encrypted
+  end to end and never touches a server: pairing happens by scanning a QR code or
+  reading out a short code, and the transfer itself runs peer to peer. Before
+  anything is sent, both ends show the same short emoji phrase and each person
+  confirms the other's out loud -- so a stranger who has the pairing code still
+  cannot get in the middle without one of you noticing.
+
+  There is also Beam, which moves a file as animated QR codes across a camera and
+  needs no network at all.
+
+  This installer is NOT code-signed. There is no Windows code-signing certificate
+  behind this project, so SmartScreen will warn about it: "More info", then "Run
+  anyway", if you decide to trust it. That warning is accurate -- nobody has
+  vouched for this binary. What it does carry is a build provenance attestation,
+  which is a verifiable claim about where it was built and is not a signature:
+
+    gh attestation verify <file> --repo stan-ely/qrdrop
+
+  Verifying that, or the download against SHA256SUMS on the release page, is the
+  honest substitute. A tool whose whole subject is authenticating the other end is
+  the worst possible place to learn to click through a publisher warning.
+Moniker: qrdrop
+Tags:
+- file-transfer
+- p2p
+- encryption
+- end-to-end-encryption
+- qr-code
+- webrtc
+- airdrop
+- sharing
+ReleaseNotesUrl: https://github.com/stan-ely/qrdrop/releases/tag/app-v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.yaml
+++ b/manifests/s/Stan-Ely/qrdrop-app/0.1.0/Stan-Ely.qrdrop-app.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Stan-Ely.qrdrop-app
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
<!-- Describe what this PR changes. For manifest submissions, include the package name and version. -->

New package: `Stan-Ely.qrdrop-app` version 0.1.0 — one manifest (installer + en-US locale + version).

qrdrop is an MIT-licensed, end-to-end-encrypted peer-to-peer file-transfer tool; this Tauri
desktop build is its first winget submission. The installer is the NSIS `user`-scope setup
from the project's own GitHub release (`app-v0.1.0`), pinned by SHA256 in the manifest.

It is not code-signed — there is no code-signing certificate for the project, so SmartScreen
will warn. The build carries a GitHub build-provenance attestation
(`gh attestation verify <file> --repo stan-ely/qrdrop`) instead; the manifest `Description`
field notes the same.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431374)
