### PR TITLE
New version: Finesssee.Win-CodexBar version 0.56.8

### DIFF
--- a/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.installer.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.installer.yaml
@@ -1,0 +1,21 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.56.8
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: WinCodexBar_is1
+AppsAndFeaturesEntries:
+- DisplayName: CodexBar 0.56.8
+  Publisher: CodexBar Contributors
+  DisplayVersion: 0.56.8
+  ProductCode: WinCodexBar_is1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/nesszer/Win-CodexBar/releases/download/v0.56.8/CodexBar-0.56.8-Setup.exe
+  InstallerSha256: 4164BD5D4D6253DE24A86F633A2E89EEA2AB5B0B959100B9AFCCF1DC092EF57E
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-08

--- a/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.locale.en-US.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.56.8
+PackageLocale: en-US
+Publisher: CodexBar Contributors
+PublisherUrl: https://github.com/nesszer
+PublisherSupportUrl: https://github.com/nesszer/Win-CodexBar/issues
+Author: Finesssee
+PackageName: Win-CodexBar
+PackageUrl: https://github.com/nesszer/Win-CodexBar
+License: MIT
+LicenseUrl: https://github.com/nesszer/Win-CodexBar/blob/main/LICENSE
+Copyright: Copyright (c) CodexBar contributors
+ShortDescription: Windows-native menu bar app for OpenAI Codex and Claude Code usage stats.
+Description: Win-CodexBar is a Windows-native desktop app for viewing AI coding-tool usage stats from a small Tauri shell.
+Moniker: win-codexbar
+Tags:
+- claude-code
+- codex
+- desktop
+- tauri
+- usage
+- windows
+ReleaseNotes: |-
+  Windows release aligned to the reviewed upstream CodexBar 0.56.8 behavior baseline, plus Windows-specific account switching, reliability, UI, browser-import, and release-pipeline improvements since 0.55.0.
+
+  Added saved Codex and Claude accounts with switching from Settings and the native tray, expanded Codex usage/cost history and reset diagnostics, improved Antigravity history and quota handling, and Claude Desktop/session discovery.
+
+  Fixed Codex authenticated HTTP permission handling, Claude credential refresh, Copilot identity-first account reuse, Kiro regional enrichment, bundled Codex CLI discovery and restart flows, Brave App-Bound Encryption messaging, Ollama browser-cookie fallback, and Minimax API-key quota retrieval.
+ReleaseNotesUrl: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.56.8
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.yaml
+++ b/manifests/f/Finesssee/Win-CodexBar/0.56.8/Finesssee.Win-CodexBar.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Finesssee.Win-CodexBar
+PackageVersion: 0.56.8
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
﻿## 📖 Description

Updates `Finesssee.Win-CodexBar` to Windows release `0.56.8`.

- Installer: `CodexBar-0.56.8-Setup.exe`
- Release: https://github.com/nesszer/Win-CodexBar/releases/tag/v0.56.8
- Installer SHA-256: `4164BD5D4D6253DE24A86F633A2E89EEA2AB5B0B959100B9AFCCF1DC092EF57E`

## ✅ Checklist

- [x] Signed the Contributor License Agreement in prior accepted submissions from this account
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for this manifest update
- [x] This PR only modifies one manifest package/version
- [x] Validated locally with `winget validate --manifest manifests/f/Finesssee/Win-CodexBar/0.56.8`
- [ ] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema

The current test machine has Winget's administrator-controlled `LocalManifestFiles` feature disabled, so `winget install/download --manifest` was not enabled by changing system settings. The exact published installer independently passed the Win-CodexBar CircleCI release install/version/uninstall smoke test before publication, and the manifest SHA-256 matches the published release asset digest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431388)