### PR TITLE
Add: abkus.abkus-code version 0.5.0

### DIFF
--- a/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.installer.yaml
+++ b/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.installer.yaml
@@ -13,4 +13,6 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://studio.abkus.com/daemon/download/abkus-code-0.5.0.zip
     InstallerSha256: 7d20a3f9b97b953627e2c62a905d2c836f665b495a832204c8697a7d1b9d306d
+ManifestType: installer
 ManifestVersion: 1.6.0
+

--- a/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.installer.yaml
+++ b/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: abkus.abkus-code
+PackageVersion: 0.5.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: abkus-code.cmd
+    PortableCommandAlias: abkus-code
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: OpenJS.NodeJS.LTS
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://studio.abkus.com/daemon/download/abkus-code-0.5.0.zip
+    InstallerSha256: 7d20a3f9b97b953627e2c62a905d2c836f665b495a832204c8697a7d1b9d306d
+ManifestVersion: 1.6.0

--- a/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.locale.en-US.yaml
+++ b/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: abkus.abkus-code
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Abkus
+PublisherUrl: https://www.abkus.com
+PackageName: Abkus Code
+PackageUrl: https://studio.abkus.com
+License: Proprietary
+ShortDescription: Abkus Studio local daemon — lets the browser IDE read, edit and run your project's files.
+Description: |-
+  Abkus Code is the local companion of Abkus Studio (https://studio.abkus.com), a browser IDE.
+  It runs a small loopback service so the browser IDE can read, edit and run your project's
+  files, and powers the local AI agent workflows. Installing it registers a per-user launcher
+  that starts automatically at login; Abkus Studio detects and connects by itself.
+Moniker: abkus-code
+Tags:
+  - ai
+  - ide
+  - development
+  - agent
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://studio.abkus.com/daemon/download/abkus-code-0.5.0.zip
+    InstallerSha256: 7d20a3f9b97b953627e2c62a905d2c836f665b495a832204c8697a7d1b9d306d
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: abkus-code.cmd
+        PortableCommandAlias: abkus-code
+ManifestVersion: 1.6.0

--- a/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.locale.en-US.yaml
+++ b/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.locale.en-US.yaml
@@ -19,12 +19,6 @@ Tags:
   - ide
   - development
   - agent
-Installers:
-  - Architecture: x64
-    InstallerUrl: https://studio.abkus.com/daemon/download/abkus-code-0.5.0.zip
-    InstallerSha256: 7d20a3f9b97b953627e2c62a905d2c836f665b495a832204c8697a7d1b9d306d
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: abkus-code.cmd
-        PortableCommandAlias: abkus-code
+ManifestType: defaultLocale
 ManifestVersion: 1.6.0
+

--- a/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.yaml
+++ b/manifests/a/abkus/abkus-code/0.5.0/abkus.abkus-code.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: abkus.abkus-code
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Adds the **Abkus Code** CLI (the local companion of Abkus Studio, https://studio.abkus.com) — an AI development agent/daemon that lets the browser IDE read, edit and run project files.

- Portable zip distribution (x64), installed with the `abkus-code` command alias; requires Node.js (declared as a package dependency).
- Installer URL is served by our production site with an immutable per-version path (`/daemon/download/abkus-code-0.5.0.zip`) and sha256 `7d20a3f9b97b953627e2c62a905d2c836f665b495a832204c8697a7d1b9d306d`.
- The zip carries no secrets: it is the same content published on npm (`npm view abkus-code@0.5.0`), plus its production node_modules.

## Have you validated the manifest locally?

- [x] I have validated the manifest locally (winget validate produced no errors beyond warnings for the nested portable layout)

## Manifest checks

- [x] My package does not violate the [policies](https://github.com/microsoft/winget-pkgs/blob/master/Policy%20and%20Terms.md)
- [x] This is not a fictitious package

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431391)