### PR TITLE
New package: GeoParquet.Validator version 0.2.0

### DIFF
--- a/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.installer.yaml
+++ b/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: GeoParquet.Validator
+PackageVersion: 0.2.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: geoparquet-validator-v0.2.0-x86_64-pc-windows-msvc\geoparquet-validator.exe
+    PortableCommandAlias: geoparquet-validator
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/geoparquet/geoparquet-validator/releases/download/v0.2.0/geoparquet-validator-v0.2.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: D119FC26753B79F09BDD48E9FBE3DC15C27A9ACE09B6094C832F7DFEE6202A15
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.locale.en-US.yaml
+++ b/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: GeoParquet.Validator
+PackageVersion: 0.2.0
+PackageLocale: en-US
+Publisher: GeoParquet
+PublisherUrl: https://geoparquet.org/
+PublisherSupportUrl: https://github.com/geoparquet/geoparquet-validator/issues
+PackageName: GeoParquet Validator
+PackageUrl: https://validator.geoparquet.org/
+License: Apache-2.0
+LicenseUrl: https://github.com/geoparquet/geoparquet-validator/blob/main/LICENSE
+ShortDescription: Validate GeoParquet files against the OGC abstract tests and the 1.0/1.1 community specifications
+Description: A single command that runs the abstract tests of the OGC GeoParquet 2.0 draft on a file, a directory or an object-store URL, checks GeoParquet 1.0 and 1.1 files against their own community specification, and reports the distribution best practices as advice.
+Moniker: geoparquet-validator
+Tags:
+  - geoparquet
+  - parquet
+  - geospatial
+  - validation
+  - ogc
+ReleaseNotesUrl: https://github.com/geoparquet/geoparquet-validator/releases/tag/v0.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.yaml
+++ b/manifests/g/GeoParquet/Validator/0.2.0/GeoParquet.Validator.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: GeoParquet.Validator
+PackageVersion: 0.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: **GeoParquet.Validator** version 0.2.0, the `geoparquet-validator` command that checks GeoParquet files against the specification (https://github.com/geoparquet/geoparquet-validator, Apache-2.0). Portable install from the release zip; the executable gets the alias `geoparquet-validator`.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (no Windows machine at hand; relying on the pipeline validation)
- [ ] Tested manifest locally with `winget install --manifest <path>` (same)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

https://claude.ai/code/session_015wJ16bE4vEfrojEzqRG9ab

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431399)