### PR TITLE
New package: FlySoft.FlyText version 1.4.0

### DIFF
--- a/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.installer.yaml
+++ b/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FlySoft.FlyText
+PackageVersion: 1.4.0
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+AppsAndFeaturesEntries:
+  - DisplayName: FlyText
+    Publisher: FlyText
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://flytext.flysoft.vip/downloads/FlyText-Setup-v1.4.0-x64.exe
+    InstallerSha256: 2AFCF98396D346D2EBDC2CD9329A41ACB776F4FBDD27DFB8E9D799C58511BB47
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+  - Architecture: x86
+    InstallerUrl: https://flytext.flysoft.vip/downloads/FlyText-Setup-v1.4.0-x32.exe
+    InstallerSha256: F51A9A4A40DC139AE5B049488880B0A0E0E93DFFE5E01C3B20F70BF8D0C13500
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.locale.en-US.yaml
+++ b/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.locale.en-US.yaml
@@ -3,14 +3,14 @@ PackageIdentifier: FlySoft.FlyText
 PackageVersion: 1.4.0
 PackageLocale: en-US
 Publisher: FlySoft
-PublisherUrl: https://www.flysoft.vip/
-PublisherSupportUrl: https://www.flysoft.vip/support/
-PrivacyUrl: https://www.flysoft.vip/privacy/
+PublisherUrl: https://flytext.flysoft.vip/
+PublisherSupportUrl: https://flytext.flysoft.vip/support/
+PrivacyUrl: https://flytext.flysoft.vip/privacy/
 Author: FlySoft
 PackageName: FlyText
-PackageUrl: https://www.flysoft.vip/
+PackageUrl: https://flytext.flysoft.vip/
 License: Proprietary
-LicenseUrl: https://www.flysoft.vip/terms/
+LicenseUrl: https://flytext.flysoft.vip/terms/
 ShortDescription: Lightweight text editor for Windows
 Description: FlyText is a lightweight text editor for Windows built on native Win32 and Scintilla. At roughly 2 MB with zero runtime dependencies it starts instantly, and opens a 20 GB file in under a second using memory-mapped chunked loading. Features include optional fully-local AI autocomplete, syntax highlighting for dozens of languages, multi-tab editing with session restore, HEX mode for binary files, column and multi-line editing, code folding, regex find and replace with capture groups, split view, and 7 themes. No ads, no telemetry, no background processes.
 Moniker: flytext
@@ -23,9 +23,9 @@ Tags:
   - scintilla
   - lightweight
   - offline
-ReleaseNotes: https://www.flysoft.vip/changelog/
+ReleaseNotes: https://flytext.flysoft.vip/changelog/
 Documentations:
   - DocumentLabel: Keybindings
-    DocumentUrl: https://www.flysoft.vip/blog/flytext-keybindings/
+    DocumentUrl: https://flytext.flysoft.vip/blog/flytext-keybindings/
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.locale.en-US.yaml
+++ b/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FlySoft.FlyText
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: FlySoft
+PublisherUrl: https://www.flysoft.vip/
+PublisherSupportUrl: https://www.flysoft.vip/support/
+PrivacyUrl: https://www.flysoft.vip/privacy/
+Author: FlySoft
+PackageName: FlyText
+PackageUrl: https://www.flysoft.vip/
+License: Proprietary
+LicenseUrl: https://www.flysoft.vip/terms/
+ShortDescription: Lightweight text editor for Windows
+Description: FlyText is a lightweight text editor for Windows built on native Win32 and Scintilla. At roughly 2 MB with zero runtime dependencies it starts instantly, and opens a 20 GB file in under a second using memory-mapped chunked loading. Features include optional fully-local AI autocomplete, syntax highlighting for dozens of languages, multi-tab editing with session restore, HEX mode for binary files, column and multi-line editing, code folding, regex find and replace with capture groups, split view, and 7 themes. No ads, no telemetry, no background processes.
+Moniker: flytext
+Tags:
+  - text-editor
+  - notepad-replacement
+  - large-file-viewer
+  - log-viewer
+  - hex-editor
+  - scintilla
+  - lightweight
+  - offline
+ReleaseNotes: https://www.flysoft.vip/changelog/
+Documentations:
+  - DocumentLabel: Keybindings
+    DocumentUrl: https://www.flysoft.vip/blog/flytext-keybindings/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.yaml
+++ b/manifests/f/FlySoft/FlyText/1.4.0/FlySoft.FlyText.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FlySoft.FlyText
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds a new package: **FlySoft.FlyText** version **1.4.0**.

FlyText is a lightweight text editor for Windows built on native Win32 + Scintilla (~2 MB, zero runtime dependencies), able to open a 20 GB file in under a second via memory-mapped chunked loading. Free to use with an optional Pro license.

- Homepage: https://www.flysoft.vip/
- Installer host: https://flytext.flysoft.vip/downloads/ (same domain owner as flysoft.vip)
- Privacy policy: https://www.flysoft.vip/privacy/
- Support: https://www.flysoft.vip/support/

Installer is an NSIS package (`RequestExecutionLevel user`, installs to `%LOCALAPPDATA%\Programs\FlyText`, writes HKCU), submitted with `Scope: user` and silent switch `/S`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>` (install + uninstall both succeeded, installer hash verified)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## 🔎 Local validation output

```
winget validate --manifest .\manifests\f\FlySoft\FlyText\1.4.0
清单验证成功。

winget install --manifest .\manifests\f\FlySoft\FlyText\1.4.0
已找到 FlyText [FlySoft.FlyText] 版本 1.4.0
正在下载 https://flytext.flysoft.vip/downloads/FlyText-Setup-v1.4.0-x64.exe
已成功验证安装程序哈希
已成功安装

winget uninstall --id "ARP\User\X64\FlyText"
已成功卸载
```
