### PR TITLE
New version: M-Igashi.mp3rgain version 3.6.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgain.exe
+ReleaseDate: 2026-09-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.1/mp3rgain-v3.6.1-windows-x86_64.zip
+    InstallerSha256: 90BECD940842A4C1DED7E13EF104AA5272320C5381EF46CDB948E823879EF60F
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.1/mp3rgain-v3.6.1-windows-arm64.zip
+    InstallerSha256: 8128DDE3F9FD517FB2E4814ED182980C2241F6C895E1CE8E168D84871AD762E9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgain
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: Lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgain adjusts MP3 volume without re-encoding by modifying the global_gain field in each frame's side information.
+  This preserves audio quality while achieving permanent volume changes.
+  Features include ReplayGain analysis, AAC/M4A support, and full mp3gain command-line compatibility.
+Moniker: mp3rgain
+Tags:
+  - audio
+  - cli
+  - flac
+  - gain
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.yaml
+++ b/manifests/m/M-Igashi/mp3rgain/3.6.1/M-Igashi.mp3rgain.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgain
+PackageVersion: 3.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Package

`M-Igashi.mp3rgain` version 3.6.1

mp3rgain is a lossless MP3/AAC volume normalizer using ReplayGain, a modern Rust reimplementation of the classic mp3gain tool.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.1

## Changes in this version

- `-a --per-directory` computes one album gain per folder instead of pooling every input into a single album.
- `-o tsv` prints the ReplayGain float peak under `--rg2` / `--r128`, matching the value written to `REPLAYGAIN_*_PEAK`.

## Manifest

- Unchanged from 3.6.0 apart from `PackageVersion`, `ReleaseDate`, `InstallerUrl`, `InstallerSha256` and `ReleaseNotesUrl`.
- `InstallerType: zip` + `NestedInstallerType: portable`, one entry per architecture (x64, arm64), same as previous versions.
- Tags, `Publisher`, `Author` and `PublisherSupportUrl` are unchanged.

## Validation

- SHA256 values were taken from the `.sha256` files published alongside the release assets and verified against the uploaded zips.
- Manifests authored on macOS, so `winget validate` and `winget install` were not run locally. Relying on the automated validation pipeline for those.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431436)