### PR TITLE
New version: rstream.rstream version 1.31.0

### DIFF
--- a/manifests/r/rstream/rstream/1.31.0/rstream.rstream.installer.yaml
+++ b/manifests/r/rstream/rstream/1.31.0/rstream.rstream.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.31.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin/rstream.exe
+    PortableCommandAlias: rstream
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://rstream.io/api/packages/cmtrmp8eb001n04l7ziougfel/download
+    InstallerSha256: 11dc800693ea27bc29833988a315a36f53e663c21554ab6570e6d58ef15b68bc
+  - Architecture: arm64
+    InstallerUrl: https://rstream.io/api/packages/cmtrmp351001m04l7740sfulm/download
+    InstallerSha256: 4c6ce2c8d81cc7f1780d1f61d00c155773faa6b474762a0201db148fa0507374
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/r/rstream/rstream/1.31.0/rstream.rstream.locale.en-US.yaml
+++ b/manifests/r/rstream/rstream/1.31.0/rstream.rstream.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.31.0
+PackageLocale: en-US
+Publisher: rstream
+PublisherUrl: https://rstream.io
+PublisherSupportUrl: https://rstream.io/docs
+Author: rstream
+PackageName: rstream
+PackageUrl: https://rstream.io
+License: Apache-2.0
+LicenseUrl: https://github.com/rstreamlabs/rstream-go/blob/main/LICENSE
+ShortDescription: Command-line client for rstream.
+Description: rstream is a developer-first platform for zero-trust networking.
+Moniker: rstream
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/r/rstream/rstream/1.31.0/rstream.rstream.yaml
+++ b/manifests/r/rstream/rstream/1.31.0/rstream.rstream.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: rstream.rstream
+PackageVersion: 1.31.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Description

Updates the existing rstream.rstream package to version 1.31.0. The manifests reference the existing published Windows x64 and arm64 archives.

## Validation

- Confirmed that no other open pull request targets rstream.rstream 1.31.0
- Parsed all three manifests as YAML
- Downloaded both archives and verified their SHA-256 checksums
- Verified both ZIP archives contain bin/rstream.exe with the expected Windows architecture
- WinGet validation and installation are left to the repository CI because WinGet is not available on this macOS workstation