### PR TITLE
New version: M-Igashi.mp3rgui version 3.6.1

### DIFF
--- a/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.installer.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.6.1
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: mp3rgui.exe
+ReleaseDate: 2026-09-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.1/mp3rgui-v3.6.1-windows-x86_64.zip
+    InstallerSha256: DFD87AE8E78D7C1478D593302FB5DC66A1E681ADA603B2291ACDF99417634ECE
+  - Architecture: arm64
+    InstallerUrl: https://github.com/M-Igashi/mp3rgain/releases/download/v3.6.1/mp3rgui-v3.6.1-windows-arm64.zip
+    InstallerSha256: 8C6D41006713088DCC1FE07199F022865CAE204AEF85B0C4AAB6B4C1773F9424
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.locale.en-US.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.6.1
+PackageLocale: en-US
+Publisher: M-Igashi
+PublisherUrl: https://github.com/M-Igashi
+PublisherSupportUrl: https://github.com/M-Igashi/mp3rgain/issues
+Author: M-Igashi
+PackageName: mp3rgui
+PackageUrl: https://github.com/M-Igashi/mp3rgain
+License: MIT
+LicenseUrl: https://github.com/M-Igashi/mp3rgain/blob/master/LICENSE
+ShortDescription: GUI for lossless MP3 volume adjustment - a modern mp3gain replacement written in Rust
+Description: |-
+  mp3rgui is the graphical interface for mp3rgain, a lossless MP3 volume normalizer.
+  It provides an easy-to-use GUI for adjusting MP3 volume without re-encoding,
+  supporting ReplayGain analysis, AAC/M4A, FLAC, and OGG formats.
+Moniker: mp3rgui
+Tags:
+  - audio
+  - flac
+  - gain
+  - gui
+  - lossless
+  - mp3
+  - music
+  - normalize
+  - ogg
+  - replaygain
+  - rust
+  - volume
+ReleaseNotesUrl: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.yaml
+++ b/manifests/m/M-Igashi/mp3rgui/3.6.1/M-Igashi.mp3rgui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: M-Igashi.mp3rgui
+PackageVersion: 3.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Package

`M-Igashi.mp3rgui` version 3.6.1

mp3rgui is the graphical interface for mp3rgain, a lossless MP3/AAC volume normalizer using ReplayGain.

Release: https://github.com/M-Igashi/mp3rgain/releases/tag/v3.6.1

## Changes in this version

- CJK file names now render correctly. The GUI loads a system CJK font (Yu Gothic / Meiryo / MS Gothic on Windows) as a fallback, so Japanese, Chinese and Korean file names no longer appear as missing-glyph boxes.

## Manifest

- Unchanged from 3.6.0 apart from `PackageVersion`, `ReleaseDate`, `InstallerUrl`, `InstallerSha256` and `ReleaseNotesUrl`.
- `InstallerType: zip` + `NestedInstallerType: portable`, one entry per architecture (x64, arm64), same as previous versions.
- Tags, `Publisher`, `Author` and `PublisherSupportUrl` are unchanged.

## Validation

- SHA256 values were taken from the `.sha256` files published alongside the release assets and verified against the uploaded zips.
- Manifests authored on macOS, so `winget validate` and `winget install` were not run locally. Relying on the automated validation pipeline for those.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431439)