### PR TITLE
New package: MikhailKazakov.ForceAutoHDRNet version 1.0.0

### DIFF
--- a/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.installer.yaml
+++ b/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.installer.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MikhailKazakov.ForceAutoHDRNet
+PackageVersion: 1.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.22621.0
+InstallerType: msi
+
+# Scope is deliberately absent, not forgotten.
+#
+# The MSI is authored Scope="perUser" (InstallPrivileges="limited") and genuinely installs with no
+# elevation prompt into the user's own profile. Windows Installer nonetheless writes the
+# Add/Remove Programs key to HKLM rather than HKCU, so winget reports the installed package as
+# ARP\Machine\X64\{ProductCode} regardless. That makes the field a trap in both directions:
+# "user" contradicts what winget observes and can break upgrade correlation, "machine" would make
+# winget ask for elevation this installer does not need and must not have. Leaving it out means
+# winget asserts nothing and correlates on ProductCode, which is exact.
+#
+# Measured, not assumed: notes/per-user-msi-still-registers-arp-under-hklm.md.
+
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+
+# The MSI carries <MajorUpgrade>, so Windows Installer replaces the previous version itself.
+UpgradeBehavior: install
+
+# Both codes are generated at build time and read back out of the .msi by
+# packaging/msi/Get-MsiProperty.ps1. The ProductCode changes with every version by design; the
+# UpgradeCode is derived from Package/@Id and stays put. winget uses them to match the package
+# against its Add/Remove Programs entry for `winget list` and `winget upgrade`.
+# Quoted because a bare {GUID} is a YAML flow mapping, not a string, and winget validate
+# rejects it with "Value type not permitted by 'type' constraint".
+ProductCode: '{CD3F0E35-C1A9-4F43-8190-854E82255BBC}'
+AppsAndFeaturesEntries:
+  - DisplayName: ForceAutoHDR.Net
+    DisplayVersion: 1.0.0
+    Publisher: Mikhail Kazakov
+    ProductCode: '{CD3F0E35-C1A9-4F43-8190-854E82255BBC}'
+    UpgradeCode: '{EF67DA39-D824-5120-A214-F835571F23CB}'
+    InstallerType: msi
+
+ReleaseDate: 2026-09-08
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Phoenix-/ForceAutoHDR.Net/releases/download/v1.0.0/ForceAutoHDR-1.0.0-win-x64.msi
+    InstallerSha256: 5901599568C427DE6E0DFF10961904F67B790ACAA56053B5DC2CAFA37FF73352
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.locale.en-US.yaml
+++ b/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MikhailKazakov.ForceAutoHDRNet
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Mikhail Kazakov
+PublisherUrl: https://github.com/Phoenix-
+PublisherSupportUrl: https://github.com/Phoenix-/ForceAutoHDR.Net/issues
+Author: Mikhail Kazakov
+PackageName: ForceAutoHDR.Net
+PackageUrl: https://github.com/Phoenix-/ForceAutoHDR.Net
+License: MIT
+LicenseUrl: https://github.com/Phoenix-/ForceAutoHDR.Net/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Mikhail Kazakov
+CopyrightUrl: https://github.com/Phoenix-/ForceAutoHDR.Net/blob/main/LICENSE
+ShortDescription: Windows Auto HDR, per game, without the Settings app.
+Description: |-
+  Windows decides on its own which games get Auto HDR, and the per-game switch is buried three
+  clicks deep in Settings, one game at a time, with no list of what you have already configured.
+  ForceAutoHDR.Net puts every configured game in one window and drives both registry mechanisms
+  from there: the per-app Auto HDR preference and the Force override.
+
+  Games are discovered from Game Bar's game list, from the preferences already on the machine and
+  from what is rendering right now, rather than by enumerating store libraries, because
+  launcher-fronted games render from a different executable than the one the store starts.
+
+  Everything it touches lives under HKCU, so it never asks for elevation.
+Moniker: forceautohdr
+Tags:
+  - auto-hdr
+  - directx
+  - display
+  - gaming
+  - hdr
+  - windows-11
+ReleaseNotesUrl: https://github.com/Phoenix-/ForceAutoHDR.Net/releases/tag/v1.0.0
+Documentations:
+  - DocumentLabel: Readme
+    DocumentUrl: https://github.com/Phoenix-/ForceAutoHDR.Net#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.yaml
+++ b/manifests/m/MikhailKazakov/ForceAutoHDRNet/1.0.0/MikhailKazakov.ForceAutoHDRNet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MikhailKazakov.ForceAutoHDRNet
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **MikhailKazakov.ForceAutoHDRNet** version 1.0.0.

[ForceAutoHDR.Net](https://github.com/Phoenix-/ForceAutoHDR.Net) turns Windows Auto HDR on or off
per game without going through the Settings app, and also drives the `D3DBehaviors` override. MIT
licensed, and submitted by its author.

The installer is a per-user MSI (`Scope="perUser"`, so `InstallPrivileges="limited"`): it installs
into the user's profile with no elevation prompt, which matches the app itself — everything it
writes at runtime lives under `HKCU`.

One manifest decision worth flagging so it does not look like an omission: **`Scope` is
deliberately absent.** Windows Installer writes the Add/Remove Programs key to `HKLM` even for this
per-user package, so WinGet reports the installed package as `ARP\Machine\X64\{ProductCode}`.
Declaring `Scope: user` would contradict what the client observes, and `machine` would ask for
elevation the installer neither needs nor should have. Correlation is by `ProductCode` and
`AppsAndFeaturesEntries` instead, both verified against the published `.msi`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431440)