### PR TITLE
New version: JYH1878.KimiCodeBar version 1.9.2

### DIFF
--- a/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.installer.yaml
+++ b/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: JYH1878.KimiCodeBar
+PackageVersion: 1.9.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JYH1878/KimiCodeBar-Windows/releases/download/v1.9.2/KimiCodeBar_1.9.2_x64-setup.exe
+  InstallerSha256: 8F98BFE79E51EE2A1C3FFABFAE01048F99FB4396B0925B662FEC2ADE51665FB2
+  ProductCode: KimiCodeBar
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.locale.en-US.yaml
+++ b/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: JYH1878.KimiCodeBar
+PackageVersion: 1.9.2
+PackageLocale: en-US
+Publisher: JYH1878
+PublisherUrl: https://github.com/JYH1878
+PackageName: KimiCodeBar
+PackageUrl: https://github.com/JYH1878/KimiCodeBar-Windows
+License: MIT
+LicenseUrl: https://github.com/JYH1878/KimiCodeBar-Windows/blob/main/LICENSE
+Copyright: Copyright (c) 2026 xifandev & JYH1878
+CopyrightUrl: https://github.com/JYH1878/KimiCodeBar-Windows/blob/main/LICENSE
+ShortDescription: Windows system tray app that monitors Kimi Code usage quotas and alerts before they run out
+Moniker: kimicodebar
+Tags:
+- kimi
+- kimi-code
+- usage-monitor
+- quota
+- system-tray
+- tauri
+ReleaseNotesUrl: https://github.com/JYH1878/KimiCodeBar-Windows/releases/tag/v1.9.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.locale.zh-CN.yaml
+++ b/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.locale.zh-CN.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+PackageIdentifier: JYH1878.KimiCodeBar
+PackageVersion: 1.9.2
+PackageLocale: zh-CN
+License: MIT
+ShortDescription: Windows 系统托盘上的 Kimi Code 用量监控工具，额度将尽时提前告警
+Tags:
+- kimi
+- kimi-code
+- usage-monitor
+- quota
+- system-tray
+- tauri
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.yaml
+++ b/manifests/j/JYH1878/KimiCodeBar/1.9.2/JYH1878.KimiCodeBar.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: JYH1878.KimiCodeBar
+PackageVersion: 1.9.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Manifests for KimiCodeBar 1.9.2

Release: https://github.com/JYH1878/KimiCodeBar-Windows/releases/tag/v1.9.2

What's new in 1.9.2:
- Fix: page-switch animation stutter in the tray panel (issue #48)
- Fix: polling no longer disturbs fullscreen games (fullscreen guard now also detects borderless-fullscreen windows; WSL scan no longer wakes stopped VMs)
- New: click the mascot in the panel footer to jump back to the overview page

InstallerSha256 verified against the published release asset.