### PR TITLE
New package: DanielGrasso.P7MExtractor version 1.2.0

### DIFF
--- a/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.installer.yaml
+++ b/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DanielGrasso.P7MExtractor
+PackageVersion: 1.2.0
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+FileExtensions:
+- p7m
+ProductCode: '{9B7C1F2E-6D34-4A8B-9C55-2E7F0D1A6B93}_is1'
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/daniel-g-carrasco/p7m-extractor/releases/download/v1.2.0/p7m-extractor-setup-v1.2.0-windows-x64.exe
+  InstallerSha256: 1A24BC7FDF277EAECFCF2DD694EF594D3DD9BB298F6B71934B3500C5D9BA9065
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.locale.en-US.yaml
+++ b/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DanielGrasso.P7MExtractor
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: Daniel Grasso
+PublisherUrl: https://github.com/daniel-g-carrasco
+PublisherSupportUrl: https://github.com/daniel-g-carrasco/p7m-extractor/issues
+PackageName: P7M Extractor
+PackageUrl: https://p7m.neistar.com
+License: MIT
+LicenseUrl: https://github.com/daniel-g-carrasco/p7m-extractor/blob/v1.2.0/LICENSE
+Copyright: Copyright (c) 2026 Daniel Grasso
+ShortDescription: Extract the original document from CAdES .p7m digitally signed files
+Description: |-
+  P7M Extractor unwraps CAdES (.p7m) digitally signed files and saves the original document, byte for byte, next to the signed one. The format is used across Italy for signed contracts, drawings, PEC attachments and electronic invoices.
+  Drag and drop files or whole folders, or double-click a .p7m; every file is queued in a single window with its extraction progress. Nested signatures, binary, base64 and PEM containers and BER streaming are supported. English and Italian interface, light and dark theme.
+  The tool extracts the signed content; it does not validate certificates or the legal value of the signature.
+Moniker: p7m-extractor
+Tags:
+- cades
+- digital-signature
+- fattura-elettronica
+- firma-digitale
+- gtk
+- p7m
+- pec
+- pkcs7
+ReleaseNotesUrl: https://github.com/daniel-g-carrasco/p7m-extractor/releases/tag/v1.2.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.locale.it-IT.yaml
+++ b/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.locale.it-IT.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: DanielGrasso.P7MExtractor
+PackageVersion: 1.2.0
+PackageLocale: it-IT
+Publisher: Daniel Grasso
+PackageName: P7M Extractor
+ShortDescription: Estrae il documento originale dai file firmati digitalmente .p7m (CAdES)
+Description: |-
+  P7M Extractor apre i file firmati digitalmente in formato CAdES (.p7m) e salva il documento originale, byte per byte, accanto al file firmato. Il formato è usato in Italia per contratti, disegni, allegati PEC e fatture elettroniche.
+  Trascina file o intere cartelle, oppure fai doppio clic su un .p7m: ogni file viene messo in coda in un'unica finestra con l'avanzamento dell'estrazione. Firme annidate, contenitori binari, base64 e PEM e streaming BER sono supportati. Interfaccia in italiano e inglese, tema chiaro e scuro.
+  Lo strumento estrae il contenuto firmato; non verifica i certificati né il valore legale della firma.
+Tags:
+- cades
+- fattura-elettronica
+- firma-digitale
+- p7m
+- pec
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.yaml
+++ b/manifests/d/DanielGrasso/P7MExtractor/1.2.0/DanielGrasso.P7MExtractor.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DanielGrasso.P7MExtractor
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: **DanielGrasso.P7MExtractor** version 1.2.0.

P7M Extractor extracts the original document from CAdES (.p7m) digitally signed files, a format used across Italy for signed contracts, PEC attachments and electronic invoices. Open source (MIT), GTK 4 desktop app with a CLI. Homepage: https://p7m.neistar.com, source: https://github.com/daniel-g-carrasco/p7m-extractor.

The installer is the Inno Setup package attached to the GitHub release (per-user install by default, no administrator rights needed; `.p7m` file association optional). I am the author of the application.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable): N/A, new package

## 📦 Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`: the same installer was tested on Windows 11 in silent mode (`/SILENT /CLOSEAPPLICATIONS`, upgrade of an existing installation); the local-manifest install was not run on this machine because the app is already installed there per machine
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431450)