### PR TITLE
New package: wnunezc.FlyffWebClient version 0.1.24

### DIFF
--- a/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.installer.yaml
+++ b/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: wnunezc.FlyffWebClient
+PackageVersion: 0.1.24
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-09-08
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://github.com/wnunezc/Flyff-Web-Client/releases/download/v0.1.24/FlyffWebClient-0.1.24-x86.msi
+    InstallerSha256: 3370D32030C0C28501867D68F0696BA82FBD0E6F9678FF2DFCF1F5DF5BF73B19
+    ProductCode: '{F1B3381A-E5CA-4C5F-BA34-A83C9E98BE53}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Flyff Web Client
+        Publisher: Flyff Web Client
+        ProductCode: '{F1B3381A-E5CA-4C5F-BA34-A83C9E98BE53}'
+        UpgradeCode: '{8A4B8199-47A5-46E1-A9C9-B4C08D7D86FD}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\\Flyff Web Client'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.locale.en-US.yaml
+++ b/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: wnunezc.FlyffWebClient
+PackageVersion: 0.1.24
+PackageLocale: en-US
+Publisher: Flyff Web Client
+PublisherUrl: https://github.com/wnunezc
+PublisherSupportUrl: https://github.com/wnunezc/Flyff-Web-Client/issues
+PackageName: Flyff Web Client
+PackageUrl: https://github.com/wnunezc/Flyff-Web-Client
+License: Proprietary
+ShortDescription: Windows desktop client for playing Flyff Universe through an embedded Chromium browser.
+Description: Flyff Web Client is a Windows desktop client for playing Flyff Universe through an embedded Chromium browser. It provides a local profile launcher, isolated browser storage per profile, graphics settings, multi-window profile support, window utilities and diagnostic reports.
+Moniker: flyff-web-client
+ReleaseNotesUrl: https://github.com/wnunezc/Flyff-Web-Client/releases/tag/v0.1.24
+InstallationNotes: Flyff Web Client installs per-machine under Program Files and uses local user profile data under AppData.
+Tags:
+  - flyff
+  - flyff-universe
+  - game
+  - browser
+  - cefsharp
+  - chromium
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.yaml
+++ b/manifests/w/wnunezc/FlyffWebClient/0.1.24/wnunezc.FlyffWebClient.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: wnunezc.FlyffWebClient
+PackageVersion: 0.1.24
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Package submission

Adds Flyff Web Client 0.1.24 to winget.

- PackageIdentifier: wnunezc.FlyffWebClient
- PackageVersion: 0.1.24
- InstallerType: wix
- Architecture: x86
- Scope: machine
- InstallerUrl: https://github.com/wnunezc/Flyff-Web-Client/releases/download/v0.1.24/FlyffWebClient-0.1.24-x86.msi
- InstallerSha256: 3370D32030C0C28501867D68F0696BA82FBD0E6F9678FF2DFCF1F5DF5BF73B19

Local validation:

```text
winget validate --manifest packaging/winget/0.1.24
Manifest validation succeeded.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431455)