### PR TITLE
New package: CaptureHub.CaptureHub version 0.26.6

### DIFF
--- a/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.installer.yaml
+++ b/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.installer.yaml
@@ -11,10 +11,6 @@ Installers:
     InstallerUrl: https://github.com/ZaqueuLopesDaSilvaAraujo/capturehub-downloads/releases/download/v0.26.6/CaptureHub-0.26.6-instalador.exe
     InstallerSha256: BEB1FAD133E13FC7C0757366FFA92EC5DA95BF6B61B88717F01DAB5F9AF4EB70
     AppsAndFeaturesEntries:
-      # DisplayName fica de fora de propósito. Em Adicionar ou Remover Programas
-      # ele é "CaptureHub versão 0.26.6", ou seja, muda a cada release, e casar
-      # por um nome que muda faria o winget ver outro aplicativo a cada versão.
-      # O ProductCode é fixo, e é por ele que a atualização é reconhecida.
       - ProductCode: '{8F3A7C21-4D6E-4B19-9C52-CAP7UREHUB001}_is1'
         Publisher: ZAQUEU ARAUJO TECNOLOGIAS LTDA
         DisplayVersion: 0.26.6

--- a/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.installer.yaml
+++ b/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: CaptureHub.CaptureHub
+PackageVersion: 0.26.6
+MinimumOSVersion: 10.0.19041.0
+InstallerType: inno
+Scope: user
+ReleaseDate: 2026-09-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ZaqueuLopesDaSilvaAraujo/capturehub-downloads/releases/download/v0.26.6/CaptureHub-0.26.6-instalador.exe
+    InstallerSha256: BEB1FAD133E13FC7C0757366FFA92EC5DA95BF6B61B88717F01DAB5F9AF4EB70
+    AppsAndFeaturesEntries:
+      # DisplayName fica de fora de propósito. Em Adicionar ou Remover Programas
+      # ele é "CaptureHub versão 0.26.6", ou seja, muda a cada release, e casar
+      # por um nome que muda faria o winget ver outro aplicativo a cada versão.
+      # O ProductCode é fixo, e é por ele que a atualização é reconhecida.
+      - ProductCode: '{8F3A7C21-4D6E-4B19-9C52-CAP7UREHUB001}_is1'
+        Publisher: ZAQUEU ARAUJO TECNOLOGIAS LTDA
+        DisplayVersion: 0.26.6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.locale.en-US.yaml
+++ b/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: CaptureHub.CaptureHub
+PackageVersion: 0.26.6
+PackageLocale: en-US
+Publisher: CaptureHub
+PublisherUrl: https://capturehub.com.br
+PublisherSupportUrl: https://capturehub.com.br/perguntas
+PrivacyUrl: https://capturehub.com.br/privacidade
+Author: Zaqueu Lopes da Silva Araujo
+PackageName: CaptureHub
+PackageUrl: https://capturehub.com.br
+License: Proprietary
+LicenseUrl: https://capturehub.com.br/termos
+Copyright: Copyright (c) 2026 CaptureHub
+ShortDescription: Windows screen recorder and capture tool that writes the test evidence for you.
+Description: |-
+  CaptureHub records your Windows screen with no time limit and no watermark,
+  takes screenshots, annotates them and redacts what must not leave the machine.
+  The blur is destructive: it removes the pixels instead of covering them.
+
+  When you need to prove what happened, every click becomes a written step. The
+  caption is read from the real interface element, next to the screen of that
+  moment and a magnified view of the action point. The same recording produces a
+  single-file HTML report that opens offline with nothing installed, and an
+  editable PPTX deck generated without requiring Office.
+
+  Every capture ships with the file SHA-256 and a provenance sheet: time range
+  with timezone, operator, system, screen resolution and running applications.
+
+  Recording, processing and files never leave your machine. The cloud layer
+  carries account and licence only.
+
+  About 1.3 MB per minute and 3.2% CPU at the default level. The best encoder
+  available, NVIDIA, Intel or AMD, is benchmarked and picked automatically.
+
+  The Free plan never expires and keeps recording with no time limit and no
+  watermark. Pro and Team unlock the report, the presentation and team seats.
+Tags:
+  - screen-recorder
+  - screenshot
+  - screencast
+  - annotation
+  - qa
+  - software-testing
+  - test-evidence
+  - documentation
+  - step-by-step
+  - offline
+ReleaseNotesUrl: https://capturehub.com.br/novidades
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.locale.pt-BR.yaml
+++ b/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.locale.pt-BR.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: CaptureHub.CaptureHub
+PackageVersion: 0.26.6
+PackageLocale: pt-BR
+Publisher: CaptureHub
+PublisherUrl: https://capturehub.com.br
+PublisherSupportUrl: https://capturehub.com.br/perguntas
+PrivacyUrl: https://capturehub.com.br/privacidade
+Author: Zaqueu Lopes da Silva Araujo
+PackageName: CaptureHub
+PackageUrl: https://capturehub.com.br
+License: Proprietário
+LicenseUrl: https://capturehub.com.br/termos
+Copyright: Copyright (c) 2026 CaptureHub
+ShortDescription: Gravador de tela e captura para Windows que documenta a evidência sozinho.
+Description: |-
+  O CaptureHub grava a tela do Windows sem limite de tempo e sem marca d'água,
+  tira o print, anota e apaga o que não pode sair. O borrão é definitivo: some
+  dos pixels, e não fica numa camada por cima.
+
+  Quando você precisa provar o que aconteceu, cada clique vira um passo escrito.
+  A legenda sai do elemento real da interface, com a tela do momento e o ponto
+  da ação ampliado ao lado. Da mesma gravação saem um relatório HTML de arquivo
+  único, que abre sem rede e sem instalar nada, e uma apresentação PPTX
+  editável, gerada sem exigir Office na máquina.
+
+  Toda captura sai com o SHA-256 do arquivo e uma ficha de procedência: período
+  com fuso, operador, sistema, resolução da tela e aplicativos em uso. Quem
+  recebe confere que o arquivo é o mesmo que saiu da execução.
+
+  Gravação, processamento e arquivos nunca saem da sua máquina. A camada de
+  nuvem carrega apenas conta e licença.
+
+  Cerca de 1,3 MB por minuto e 3,2% de CPU no nível padrão. O melhor encoder da
+  máquina, seja NVIDIA, Intel ou AMD, é testado e escolhido sozinho.
+
+  O plano Gratuito não expira e continua gravando sem limite de tempo e sem
+  marca d'água. Os planos Pro e Time liberam relatório, apresentação e equipe.
+Moniker: capturehub
+Tags:
+  - gravador-de-tela
+  - captura-de-tela
+  - screen-recorder
+  - screenshot
+  - screencast
+  - anotacao
+  - qa
+  - teste-de-software
+  - evidencia-de-teste
+  - documentacao
+  - passo-a-passo
+  - offline
+ReleaseNotesUrl: https://capturehub.com.br/novidades
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.yaml
+++ b/manifests/c/CaptureHub/CaptureHub/0.26.6/CaptureHub.CaptureHub.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: CaptureHub.CaptureHub
+PackageVersion: 0.26.6
+DefaultLocale: pt-BR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Package

New package: `CaptureHub.CaptureHub` version 0.26.6.

CaptureHub is a Windows screen recorder and capture tool. During a recording it
turns each click into a written step, and from the same recording it produces a
single-file HTML report, an editable PPTX deck and an MP4, with a SHA-256 hash
on every capture. Recording and processing happen locally.

Homepage: https://capturehub.com.br
I am the publisher.

### What was verified, and how

- `winget validate --manifest <path>` passes.
- `InstallerType: inno` was read from the installer binary itself, which carries
  the string `Inno Setup Setup Data (6.7.0)`.
- `InstallerSha256` matches the `.sha256` file published next to the installer in
  the same GitHub release.
- `Architecture: x64` was read from the PE header of the installed
  `CaptureHub.exe` (machine type `0x8664`).
- `Scope: user` and the `ProductCode` were read from the live Add/Remove Programs
  entry. `winget list` reports the package as
  `ARP\User\X64\{8F3A7C21-4D6E-4B19-9C52-CAP7UREHUB001}_is1`, which independently
  confirms scope, architecture and product code.

### What was not done, stated plainly

`winget install --manifest` has **not** been run yet. It requires
`winget settings --enable LocalManifestFiles` from an elevated prompt, which was
not available where these manifests were prepared. I will run it and report the
result in this thread before asking for review.

### Notes for reviewers

- `DisplayName` is deliberately omitted from `AppsAndFeaturesEntries`. In ARP the
  name is `CaptureHub versão 0.26.6`, which changes on every release, so matching
  on it would make each version look like a different package. The `ProductCode`
  is stable and handles correlation on its own.
- The installer is **not code signed** yet, so SmartScreen shows a warning. A code
  signing certificate is being arranged. The `.sha256` published with every
  release is the interim way to verify provenance.
- Top-level `Publisher` is the trade name `CaptureHub`, which matches the
  `PackageIdentifier`. The legal entity `ZAQUEU ARAUJO TECNOLOGIAS LTDA` appears
  in `AppsAndFeaturesEntries.Publisher`, where it has to match the ARP value
  exactly for correlation to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431459)