### PR TITLE
Add SHAR Production Metadata Linter 1.2.0

### DIFF
--- a/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.installer.yaml
+++ b/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: SHARProduction.ProductionMetadataLinter
+PackageVersion: 1.2.0
+Installers:
+- Architecture: x64
+  InstallerType: portable
+  InstallerUrl: https://github.com/SHARProduction/production-metadata-linter/releases/download/v1.2.0/production-metadata-linter.exe
+  InstallerSha256: F9F91567ECDB2FB538FF37BF1A22A309EA8859460A09613FB2A6742B15B598B9
+  Commands:
+  - production-metadata-linter
+ManifestType: installer
+ManifestVersion: 1.10.0
+
+

--- a/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.locale.en-US.yaml
+++ b/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: SHARProduction.ProductionMetadataLinter
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: SHAR Production
+PublisherUrl: https://sharprod.com/
+PublisherSupportUrl: https://github.com/SHARProduction/production-metadata-linter/issues
+PackageName: Production Metadata Linter
+PackageUrl: https://github.com/SHARProduction/production-metadata-linter
+License: MIT
+LicenseUrl: https://github.com/SHARProduction/production-metadata-linter/blob/main/LICENSE
+ShortDescription: Rights-aware production metadata manifest linter for delivery checks.
+Description: Dependency-free Windows CLI for validating rights-aware production metadata manifests before delivery.
+Moniker: production-metadata-linter
+Tags:
+- video-production
+- metadata
+- validation
+- rights-aware
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+
+

--- a/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.yaml
+++ b/manifests/s/SHARProduction/ProductionMetadataLinter/1.2.0/SHARProduction.ProductionMetadataLinter.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: SHARProduction.ProductionMetadataLinter
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+
+


### PR DESCRIPTION
## SHAR Production Metadata Linter 1.2.0

Adds a portable Windows manifest for the existing public, MIT-licensed `production-metadata-linter.exe` release.

Validation completed before submission:
- `winget validate --manifest` completed successfully.
- The published release SHA-256 matches the manifest: `F9F91567ECDB2FB538FF37BF1A22A309EA8859460A09613FB2A6742B15B598B9`.
- The standalone executable passed its releasable-manifest contract locally.

The tool is a dependency-free CLI for validating rights-aware video-production metadata before delivery. It is read-only and requires no credentials or network access.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431460)