### PR TITLE
New package: OpsMaxx.OpsMaxx version 0.28.2

### DIFF
--- a/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
@@ -11,7 +11,7 @@ UpgradeBehavior: install
 ReleaseDate: "2026-09-08"
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/OpsMaxx/ShellPilot/releases/download/v0.28.2/OpsMaxx-0.28.2-setup.exe
+    InstallerUrl: https://github.com/OpsMaxx/OpsMaxx/releases/download/v0.28.2/OpsMaxx-0.28.2-setup.exe
     InstallerSha256: B59013A378F0C2FE7CE75CE8A4D048AD54A2A2F84EA536D1E2EAB926335F0515
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-09-08"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/OpsMaxx/ShellPilot/releases/download/v0.28.2/OpsMaxx-0.28.2-setup.exe
+    InstallerSha256: B59013A378F0C2FE7CE75CE8A4D048AD54A2A2F84EA536D1E2EAB926335F0515
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
@@ -4,11 +4,11 @@ PackageVersion: 0.28.2
 PackageLocale: en-US
 Publisher: OpsMaxx
 PublisherUrl: https://opsmaxx.dev/
-PublisherSupportUrl: https://github.com/OpsMaxx/ShellPilot/issues
+PublisherSupportUrl: https://github.com/OpsMaxx/OpsMaxx/issues
 PackageName: OpsMaxx
 PackageUrl: https://opsmaxx.dev/
 License: MIT
-LicenseUrl: https://github.com/OpsMaxx/ShellPilot/blob/main/LICENSE
+LicenseUrl: https://github.com/OpsMaxx/OpsMaxx/blob/main/LICENSE
 Copyright: Copyright (c) OpsMaxx
 ShortDescription: SSH client, SFTP browser, database manager, secrets vault and MCP gateway for AI agents.
 Description: |-
@@ -33,6 +33,6 @@ Tags:
   - vault
   - tunnel
   - vpn
-ReleaseNotesUrl: https://github.com/OpsMaxx/ShellPilot/releases/tag/v0.28.2
+ReleaseNotesUrl: https://github.com/OpsMaxx/OpsMaxx/releases/tag/v0.28.2
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+PackageLocale: en-US
+Publisher: OpsMaxx
+PublisherUrl: https://opsmaxx.dev/
+PublisherSupportUrl: https://github.com/OpsMaxx/ShellPilot/issues
+PackageName: OpsMaxx
+PackageUrl: https://opsmaxx.dev/
+License: MIT
+LicenseUrl: https://github.com/OpsMaxx/ShellPilot/blob/main/LICENSE
+Copyright: Copyright (c) OpsMaxx
+ShortDescription: SSH client, SFTP browser, database manager, secrets vault and MCP gateway for AI agents.
+Description: |-
+  OpsMaxx is a free, open-source desktop application that keeps an SSH terminal, an SFTP
+  browser, five database engines, SSH tunnels and VPN, an encrypted secrets vault and fleet
+  operations in one window, all sharing a single credential store.
+
+  It also exposes a policy-scoped MCP bridge, so Claude Code, Codex, Gemini CLI and other
+  MCP clients can operate servers by friendly name without ever receiving an SSH password,
+  a private key, a database credential or a hostname. Every capability is ALLOW, ASK or DENY
+  per access group, sensitive actions wait for approval, and every action is written to an
+  audit log.
+Moniker: opsmaxx
+Tags:
+  - ssh
+  - ssh-client
+  - sftp
+  - terminal
+  - database
+  - devops
+  - mcp
+  - vault
+  - tunnel
+  - vpn
+ReleaseNotesUrl: https://github.com/OpsMaxx/ShellPilot/releases/tag/v0.28.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been verified

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

**On the two unchecked boxes:** these manifests were authored on macOS, where `winget` is not available, so `winget validate` and `winget install` have not been run against them. Instead all three files were validated programmatically against the published v1.6.0 JSON schemas (`manifest.version`, `manifest.installer`, `manifest.defaultLocale`) and pass. I would rather say that plainly than tick a box I did not earn. If the pipeline finds something a local run would have caught, tell me and I will fix it promptly.

### Package

[OpsMaxx](https://opsmaxx.dev) is a free, MIT-licensed desktop application: an SSH terminal, SFTP browser, multi-engine database client, SSH tunnel and VPN manager, encrypted secrets vault, and a policy-scoped MCP bridge for AI agents, in one window.

I am the publisher. Source: https://github.com/OpsMaxx/ShellPilot

### Notes for the reviewer

The installer is **not code signed**. A code-signing certificate is $200-$400 a year and the project is free and MIT licensed with no income behind it, so SmartScreen will warn on first run. Every release is scanned with ClamAV, Windows Defender and VirusTotal before publication, and each installer's SHA-256 is published in the release notes:

https://github.com/OpsMaxx/ShellPilot/releases/tag/v0.28.2

The `InstallerSha256` in this manifest was verified by downloading the published file and hashing it, not merely copied from the notes.

- Installer type: `nullsoft` (electron-builder NSIS, `perMachine: false`, hence `Scope: user`)
- Architecture: x64

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431465)