### PR TITLE
New package: BroadfieldNetworks.Maxisnap version 2.5.2

### DIFF
--- a/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.installer.yaml
+++ b/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BroadfieldNetworks.Maxisnap
+PackageVersion: 2.5.0
+MinimumOSVersion: 10.0.18362.0
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{A3F8B7C1-5E2D-4A9F-B8C3-7D1E6F4A2B90}_is1'
+ReleaseDate: 2026-09-02
+Installers:
+- Architecture: x64
+  InstallerUrl: https://maxisnap.com/download/Maxisnap-v2.5.0-Setup.exe
+  InstallerSha256: EF95007DB992E4C95014D5D4B4F411F7A9D8D51595FE7A59641E278BF3EE5882
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.locale.en-US.yaml
+++ b/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.locale.en-US.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BroadfieldNetworks.Maxisnap
+PackageVersion: 2.5.0
+PackageLocale: en-US
+Publisher: Broadfield Networks LLC
+PublisherUrl: https://maxisnap.com/
+PublisherSupportUrl: https://maxisnap.com/contact/
+PrivacyUrl: https://maxisnap.com/privacy/
+Author: Broadfield Networks LLC
+PackageName: Maxisnap
+PackageUrl: https://maxisnap.com/
+License: Proprietary
+LicenseUrl: https://maxisnap.com/terms/
+Copyright: Copyright (c) 2026 Broadfield Networks LLC
+ShortDescription: Screenshot and screen-recording tool for Windows with annotation, OCR, and sharing
+Description: |-
+  Maxisnap is a screenshot and screen-recording tool for Windows 10 and 11. It captures a
+  region, a window, or the full screen, and takes scrolling screenshots of pages taller than
+  the display. Recording covers a region or the full screen with system audio and microphone,
+  exporting to MP4, GIF, or WebM.
+  The editor provides 12 annotation tools, including arrows, shapes, text, step numbering, a
+  freehand pen, and blur for masking sensitive details before sharing. On-device OCR extracts
+  text from a capture.
+  Captures can be copied to the clipboard, saved locally, or uploaded for a share link. Local
+  capture, annotation, recording, and saving work without an account. Optional self-hosted
+  destinations include SFTP, FTP/FTPS, S3-compatible storage, and HTTP POST.
+Moniker: maxisnap
+Tags:
+- annotate
+- annotation
+- blur
+- capture
+- ocr
+- record
+- recorder
+- region-capture
+- screen-capture
+- screen-recorder
+- screenshot
+- scrolling-screenshot
+- share
+- upload
+ReleaseNotes: |-
+  - NEW: Redesigned Settings adds searchable hotkeys, clearer account, privacy, upload, and video controls, and crisp display-aware graphics.
+  - NEW: Region screenshot, scrolling, upload, and video actions can use standard Middle, Back, or Forward mouse buttons with click-to-activate and an experimental one-click hold-and-drag mode.
+  - IMPROVED: A dedicated Windows mouse-hook thread keeps assigned auxiliary-button capture responsive and prevents the window under the pointer from being activated before the screen freezes.
+  - FIXED: Multiple hotkey edits now persist in one Settings session; tray double-click opens Settings only, Quit closes idle windows, and secondary windows stay safely on-screen.
+  - FIXED: Self-hosted HTTP tests and saved dashboard credentials remain valid across edits, while modal capture cancellation, Account controls, and editor icons behave cleanly at scaled displays.
+ReleaseNotesUrl: https://maxisnap.com/releases/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.yaml
+++ b/manifests/b/BroadfieldNetworks/Maxisnap/2.5.0/BroadfieldNetworks.Maxisnap.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BroadfieldNetworks.Maxisnap
+PackageVersion: 2.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New package: **BroadfieldNetworks.Maxisnap** version **2.5.2** — the current canonical public release of the Windows screenshot and screen-recording app.

- Publisher: Broadfield Networks LLC
- Publisher website: https://maxisnap.com/
- Release notes: https://maxisnap.com/releases/
- Installer: Inno Setup, x64, per-machine.
- The installer is Authenticode-signed by Broadfield Networks LLC and RFC-3161 timestamped.
- `InstallerUrl` is the version-pinned `Maxisnap-v2.5.2-Setup.exe` URL, not the mutable latest-download alias.
- `InstallerSha256` was recomputed from the exact approved release artifact and matches the live release API and GitHub Release digest.
- `ProductCode` is the stable Inno Setup ARP key used across Maxisnap versions.

This PR was initially opened with v2.5.0. Before merge, the manifest was updated to v2.5.2 so the first catalog entry is the current public release rather than an obsolete version.

## Checklist

- [x] Checked that there are no other open pull requests for the same package
- [x] This PR modifies one package and one version
- [x] Validated locally with `winget validate --manifest packaging\winget\2.5.2`
- [ ] Tested locally with `winget install --manifest <path>`

The only available Windows machine contains newer/current Maxisnap state, so no local install was run. The manifest, installer URL, hash, signature, version, scope, and ProductCode were independently verified; the repository validation pipeline will perform its isolated installation and metadata checks.