### PR TITLE
New version: Unity.CLI version 1.0.0.20009

### DIFF
--- a/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.installer.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20009
+InstallerLocale: en-US
+InstallerType: msix
+MinimumOSVersion: 10.0.17763.0
+PackageFamilyName: UnityTechnologies.UnityCLI_2vrhnee42bhxm
+Commands:
+- unity
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.9/unity-windows-x64.msix
+  InstallerSha256: 08DC6B675F6C852FF19DDA1E6D4BF4BF5875320B5A6613BF59929B943DB84483
+  SignatureSha256: 163C803DB3C83E7C9DA98B66EAC07F82403F693ADD641B9EB3BE5B3B500B5158
+- Architecture: arm64
+  InstallerUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.9/unity-windows-arm64.msix
+  InstallerSha256: F26DD26ABEA7CA37840AF6E5AE8A8D6DA417209F854B83AE626415ED554EF9F4
+  SignatureSha256: D21D468FB916C902A4F03450EBD97332ADCE41BC717096453D779CC5FD8D02DF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.locale.en-US.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20009
+PackageLocale: en-US
+Publisher: Unity Technologies Inc.
+PublisherUrl: https://unity.com/
+PublisherSupportUrl: https://support.unity.com/
+PrivacyUrl: https://unity.com/legal/privacy-policy
+Author: Unity Technologies Inc.
+PackageName: Unity CLI
+PackageUrl: https://unity.com/unity-hub
+License: Proprietary
+LicenseUrl: https://unity.com/legal/terms-of-service
+Copyright: Copyright © 2026 Unity Technologies Inc.
+CopyrightUrl: https://unity.com/legal/trademarks
+ShortDescription: Command-line interface for installing Unity Editors and creating, opening, and building Unity projects.
+Description: The Unity CLI (invoked as "unity") manages Unity Editor installations and modules, creates and opens projects, runs builds and Editor commands, and manages licenses and cloud sign-in from the terminal. This build reports its version as 1.0.0-beta.9; MSIX package versions encode the prerelease channel in the fourth (revision) field.
+Moniker: unity-cli
+Tags:
+- cli
+- command-line
+- unity
+- unity3d
+ReleaseNotes: |-
+  Highlights of 1.0.0-beta.9 (full notes at the release notes URL):
+  - unity version is a new command that prints the CLI's version, release channel, commit, platform and runtime in any output format, and unity --version now honors --format.
+  - unity test --affected --since <ref> runs only the tests a change can reach, taken from unity vcs affected's guid impact graph rather than a hand-written filter.
+  - unity config get|set|list|unset <key> reads and writes the CLI's persistent settings by key, instead of a separate command per setting.
+  - A --color auto|always|never global flag, with --no-color as shorthand, controls colored output on every command and takes precedence over NO_COLOR and FORCE_COLOR.
+  - The auth broker's token store is now sealed to the machine that wrote it — TPM on Windows and Linux, Keychain on macOS — so the file on disk is worthless anywhere else.
+  - unity plugin changelog <id> shows a managed tool's own release notes, and unity doctor now lists the CLI's bundled third-party components with their SPDX licenses.
+  - Module options are renamed for consistency: unity install --list-components is now --list-modules, and --childModules is now --child-modules. The old spellings keep working.
+  - On Windows, unity pipeline list and unity status no longer report that no Editor is running when one is, and now say when they could not check. unity doctor no longer hangs on macOS when the keychain wants to ask you something.
+ReleaseNotesUrl: https://public-cdn.cloud.unity3d.com/hub/prod/cli/1.0.0-beta.9/CHANGELOG.md
+Documentations:
+- DocumentLabel: Unity CLI Manual
+  DocumentUrl: https://docs.unity.com/unity-cli
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.yaml
+++ b/manifests/u/Unity/CLI/1.0.0.20009/Unity.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Unity.CLI
+PackageVersion: 1.0.0.20009
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Unity CLI 1.0.0-beta.9 as `Unity.CLI` version `1.0.0.20009`.

- InstallerSha256 values cross-checked against the vendor's published SHA256SUMS for the release (both agree).
- SignatureSha256 values computed from each downloaded `.msix`'s embedded `AppxSignature.p7x`.
- `PackageVersion` matches the 4-part MSIX encoding of the semver (`1.0.0-beta.9` → `1.0.0.20009`); `unity --version` reports the semver form.
- `ReleaseDate` taken from the release's publish date (2026-09-08).
- `PackageFamilyName` unchanged from the previous revision (`UnityTechnologies.UnityCLI_2vrhnee42bhxm`) — same signing identity.
- `ReleaseNotes` hand-condensed from the shipped changelog section; `ReleaseNotesUrl` points at the full notes.

Local validation on Windows: `winget validate` succeeded, and a `winget install --manifest` / `winget uninstall` round-trip installed and removed both cleanly, with `unity --version` reporting `1.0.0-beta.9` while installed (the app-displayed semver for `PackageVersion 1.0.0.20009`).

## ✅ Checklist

- [ ] Signed the Contributor License Agreement.
- [x] Linked to an issue (if applicable) — not applicable, this is a routine version bump.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change.
- [x] This PR only modifies one (1) manifest.
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the 1.12 schema.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431619)