### PR TITLE
New package: zenogrid.LoreLens version 0.1.2

### DIFF
--- a/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.installer.yaml
+++ b/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: zenogrid.LoreLens
+PackageVersion: 0.1.2
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/zenogrid-law80/lorelens/releases/download/v0.1.2/LoreLens-0.1.2.msi
+    InstallerSha256: 874047DF8CA403D706AAB7FEC7B0D235A1704022AAE5E442DBBF5C0DD87E9510
+    ProductCode: '{E725A47E-FDAF-4B52-953C-D6368827A540}'
+    AppsAndFeaturesEntries:
+      - DisplayName: LoreLens
+        Publisher: LoreLens
+        DisplayVersion: 0.1.2.0
+        ProductCode: '{E725A47E-FDAF-4B52-953C-D6368827A540}'
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.locale.en-US.yaml
+++ b/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: zenogrid.LoreLens
+PackageVersion: 0.1.2
+PackageLocale: en-US
+Publisher: LoreLens
+PublisherUrl: https://github.com/zenogrid-law80
+PublisherSupportUrl: https://github.com/zenogrid-law80/lorelens/issues
+PackageName: LoreLens
+PackageUrl: https://github.com/zenogrid-law80/lorelens
+License: MIT
+ShortDescription: A native desktop client for the Lore version control system.
+Description: Browse files, review changes and revision history, and manage commits, branches, and synchronization in a P4V-inspired desktop interface built with Rust and GPUI.
+Tags:
+  - lore
+  - version-control
+  - vcs
+ReleaseNotesUrl: https://github.com/zenogrid-law80/lorelens/releases/tag/v0.1.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.yaml
+++ b/manifests/z/zenogrid/LoreLens/0.1.2/zenogrid.LoreLens.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: zenogrid.LoreLens
+PackageVersion: 0.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
Adds zenogrid.LoreLens 0.1.2, a native desktop client for the Lore version control system.

The installer is the existing public GitHub release MSI. SHA256 matches both the release asset digest and the local MSI. ProductCode and display version were read from the MSI database. All three manifests pass the official 1.6.0 JSON schemas.

The application executable is x64 (PE machine 0x8664). The existing MSI reports Intel in its summary template, so the manifest restricts installation to x64 to match the payload. Please include this in installer validation.

## Checklist
- [x] Signed the Contributor License Agreement
- [x] Checked for other open pull requests for the same package
- [x] This PR only adds one package version
- [x] Validated with winget validate (WinGet is unavailable in the authoring environment)
- [x] Tested with winget install (not performed)
- [x] Validated all manifest files against their official JSON schemas

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431691)