### PR TITLE
New package: relmer.Casso version 1.23.2

### DIFF
--- a/manifests/r/relmer/Casso/1.23.2/relmer.Casso.installer.yaml
+++ b/manifests/r/relmer/Casso/1.23.2/relmer.Casso.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.23.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-09-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/relmer/Casso/releases/download/v1.23.2/Casso-1.23.2-x64.zip
+  InstallerSha256: 590A639D9A5756629D1AA5E2269255A0B243B549062BB9A490AC29DE9A771A61
+  NestedInstallerFiles:
+  - RelativeFilePath: Casso-x64\Casso.exe
+    PortableCommandAlias: Casso
+  - RelativeFilePath: Casso-x64\CassoCli.exe
+    PortableCommandAlias: CassoCli
+- Architecture: arm64
+  InstallerUrl: https://github.com/relmer/Casso/releases/download/v1.23.2/Casso-1.23.2-ARM64.zip
+  InstallerSha256: B8826EBA7C60B38E183788572E94FD0DCA6E2B63AF00ED9BE437A749C79F3FDD
+  NestedInstallerFiles:
+  - RelativeFilePath: Casso-ARM64\Casso.exe
+    PortableCommandAlias: Casso
+  - RelativeFilePath: Casso-ARM64\CassoCli.exe
+    PortableCommandAlias: CassoCli
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/relmer/Casso/1.23.2/relmer.Casso.locale.en-US.yaml
+++ b/manifests/r/relmer/Casso/1.23.2/relmer.Casso.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.23.2
+PackageLocale: en-US
+Publisher: Robert Elmer
+PublisherUrl: https://github.com/relmer
+PublisherSupportUrl: https://github.com/relmer/Casso/issues
+Author: Robert Elmer
+PackageName: Casso
+PackageUrl: https://github.com/relmer/Casso
+License: MIT
+LicenseUrl: https://github.com/relmer/Casso/blob/master/LICENSE
+Copyright: Copyright (c) 2024-2026 Robert Elmer
+CopyrightUrl: https://github.com/relmer/Casso/blob/master/LICENSE
+ShortDescription: An Apple II family emulator with a built-in, fully AS65-compatible assembler.
+Description: |-
+  Casso is a retro platform emulator, 6502/65C02 assembler, and disk manager,
+  written in C++ with hardware-accelerated DirectX rendering and a multithreaded
+  core. It emulates the Apple ][, ][+, //e, //e Enhanced and //c.
+
+  The bundled CassoCli covers the retro development loop without third-party
+  tools: a from-scratch AS65-compatible assembler that also assembles Merlin,
+  disk management across .woz, .dsk, .do, .po, .nib and .nb2 images, headless
+  6502 execution, and launching the emulator with a machine and disks already
+  selected.
+Moniker: casso
+Tags:
+- 6502
+- 65c02
+- apple-ii
+- apple2
+- apple2c
+- apple2e
+- assembler
+- emulator
+- retro
+ReleaseNotesUrl: https://github.com/relmer/Casso/releases/tag/v1.23.2
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/relmer/Casso/blob/master/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/relmer/Casso/1.23.2/relmer.Casso.yaml
+++ b/manifests/r/relmer/Casso/1.23.2/relmer.Casso.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.23.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Casso 1.23.2. Portable zip installer with nested Casso.exe and CassoCli.exe for x64 and arm64. Binaries are signed with Azure Artifact Signing.

Supersedes #430776, which was closed because 1.23.1 is now out of date.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431697)