### PR TITLE
New version: Modrexio.Modrex version 0.15.0

### DIFF
--- a/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.installer.yaml
+++ b/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.installer.yaml
@@ -1,0 +1,28 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Modrexio.Modrex
+PackageVersion: 0.15.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+ProductCode: Modrex
+ReleaseDate: 2026-09-09
+AppsAndFeaturesEntries:
+- ProductCode: Modrex
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Modrex'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/modrexio/modrex/releases/download/v0.15.0/modrex_x86_64.exe
+  InstallerSha256: 00317A55D3FC4BAF2690F178D1C9B6CE69222C3E39457E0D15D83253E26DF2FC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.installer.yaml
+++ b/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.installer.yaml
@@ -11,9 +11,6 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-Dependencies:
-  PackageDependencies:
-  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 ProductCode: Modrex
 ReleaseDate: 2026-09-09
 AppsAndFeaturesEntries:

--- a/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.locale.en-US.yaml
+++ b/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Modrexio.Modrex
+PackageVersion: 0.15.0
+PackageLocale: en-US
+Publisher: modrex
+PublisherUrl: https://modrex.net/
+PublisherSupportUrl: https://github.com/modrexio/modrex/issues
+PrivacyUrl: https://modrex.net/privacy/
+Author: Oleh Shulha
+PackageName: Modrex
+PackageUrl: https://modrex.net/
+License: MIT
+LicenseUrl: https://github.com/modrexio/modrex/blob/HEAD/LICENSE
+Copyright: Copyright (c) 2026 Oleh Shulha
+ShortDescription: A desktop mod manager for games supported by ModWorkshop.
+Description: |-
+  Modrex is a free, open-source desktop mod manager for PAYDAY 3, PAYDAY 2,
+  PAYDAY: The Heist, and Crime Boss: Rockay City. Browse, install, organize,
+  update, enable, and disable mods from ModWorkshop, then launch each game
+  modded or vanilla directly from the app.
+Moniker: modrex
+Tags:
+- game
+- gaming
+- mod-manager
+- modding
+- modworkshop
+- payday
+ReleaseNotes: |-
+  Added
+  - Added Italian as a language option for the app's interface.
+  - Added Simplified Chinese as a language option for the app's interface.
+  - Added a viewer for browsing the contents of installed Unreal Engine pak mods.
+  - Added an optional Windows setting to start SISR before games launched from Modrex, with setup and launch-failure warnings.
+  - Added a setting to choose the app's accent color.
+  - Modrex now names which UE4SS release is installed, and can replace it with another or remove it. Both say what they change and what they keep first.
+  Changed
+  - Startup no longer runs the Microsoft Store lookup for a game more than once at a time.
+  - The game picker no longer changes which copy of a game is selected while working out which games are installed.
+  - PAYDAY 3 no longer asks for the -fileopenlog launch option, which the game stopped reading in Update 3.8.
+  Fixed
+  - Fixed installing a file from the Manage Files list picking the wrong one when a mod's archive holds two files with the same name in different folders.
+  - Fixed installing the wrong file from an archive that contains two entries whose names look the same, such as a mod packaged with both forward and back slashes in its paths. Each entry you pick now installs its own contents.
+  - Fixed Nexus Mods sign-in and website mod downloads not reaching Modrex on Linux.
+  - Fixed enabling or disabling a mod being reported as done when its files could not be moved, such as while the game is running.
+  - Fixed a mod being left split between folders when its .ucas or .utoc file could not be moved with its pak.
+  - Fixed mod folders and load order being lost when Modrex could not read its saved mod list.
+  - Fixed dragging a mod's archive onto Modrex moving that mod out of the folder it was filed in, unlike installing it from its page.
+  - Fixed uninstalling a PAYDAY 3 mod deleting another mod's files.
+  - Fixed one UE4SS release reading as installed on another release's page, leaving no way to switch between them.
+  - Fixed installing UE4SS leaving an older one hooked into the game beside it.
+  - Fixed your own Lua mods being left in the old folder when a UE4SS update moves where the loader reads them.
+  Security
+  - Opening the log from Settings now opens the log file itself instead of writing a copy to a predictable name in the system temporary folder, which another program could have redirected at one of your own files.
+  - Cleanup after installing a .pdmod file or a loose non-archive file can no longer reach outside the files Modrex staged, and refuses a link rather than following it out of the temporary folder.
+  - Archives waiting on a choice, such as picking which files to install, are now tracked by Modrex itself rather than by a file path passed back from the interface, so only the archive Modrex staged can be opened or removed.
+ReleaseNotesUrl: https://github.com/modrexio/modrex/releases/tag/v0.15.0
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://modrex.net/docs/
+- DocumentLabel: Installation
+  DocumentUrl: https://modrex.net/docs/getting-started/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.yaml
+++ b/manifests/m/Modrexio/Modrex/0.15.0/Modrexio.Modrex.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Modrexio.Modrex
+PackageVersion: 0.15.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Manifests for Modrex 0.15.0.

- Installer: https://github.com/modrexio/modrex/releases/download/v0.15.0/modrex_x86_64.exe
- SHA256 verified against the published release asset.
- Declares Microsoft.EdgeWebView2Runtime as a package dependency, which the previous submission lacked.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431700)