### PR TITLE
New package: DLSLabs.Daylo version 1.1.1

### DIFF
--- a/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.installer.yaml
+++ b/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: DLSLabs.Daylo
+PackageVersion: 1.1.1
+InstallerType: nullsoft
+Scope: user
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-09-07"
+# Valores que el NSIS de tauri-bundler escribe en el registro de Agregar o quitar programas:
+# UNINSTKEY es Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}, y ahi deja
+# DisplayName=${PRODUCTNAME}, Publisher=${MANUFACTURER} y DisplayVersion=${VERSION}. Declararlos
+# permite que winget upgrade y uninstall correlacionen por registro y no por parecido de nombre.
+AppsAndFeaturesEntries:
+  - DisplayName: Daylo
+    Publisher: DLSLabs
+    DisplayVersion: 1.1.1
+    ProductCode: Daylo
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/henfrydls/daylo/releases/download/v1.1.1/Daylo-windows-x64-setup.exe
+    InstallerSha256: BBDB7A1006702A28596EAA56373D7DFADE080D163D6BAC667B7052179CDD6747
+  - Architecture: arm64
+    InstallerUrl: https://github.com/henfrydls/daylo/releases/download/v1.1.1/Daylo-windows-arm64-setup.exe
+    InstallerSha256: 17C56D17704B82CD76E832441618D6196B471AF26BF56822085D36C03BDE8963
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.locale.en-US.yaml
+++ b/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: DLSLabs.Daylo
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: DLSLabs
+PublisherUrl: https://henfrydls.com
+PublisherSupportUrl: https://github.com/henfrydls/daylo/issues
+Author: Henfry De Los Santos
+PackageName: Daylo
+PackageUrl: https://daylo.henfrydls.com
+License: MIT
+LicenseUrl: https://github.com/henfrydls/daylo/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Henfry De Los Santos
+CopyrightUrl: https://github.com/henfrydls/daylo/blob/main/LICENSE
+ShortDescription: Track your habits and watch your whole year fill in with color.
+Description: |-
+  Daylo is a habit tracker with a calendar you can read at a glance. Tick off what you did today and
+  the year fills in with color, so you can see a streak forming or a month you let slip without
+  reading a single number.
+
+  Everything stays on your device. There is no account to create, no server storing your days, and
+  nothing sent anywhere. You can export a backup whenever you want and import it on another machine.
+
+  Runs on Windows, Mac, Linux and Android. The first launch needs an internet connection if the
+  WebView2 runtime is not already installed, which it usually is on Windows 10 and 11.
+Moniker: daylo
+Tags:
+  - calendar
+  - habit
+  - habit-tracker
+  - heatmap
+  - local-first
+  - offline
+  - privacy
+  - productivity
+  - streaks
+  - tracker
+ReleaseNotesUrl: https://github.com/henfrydls/daylo/releases/tag/v1.1.1
+PrivacyUrl: https://daylo.henfrydls.com/privacy/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.yaml
+++ b/manifests/d/DLSLabs/Daylo/1.1.1/DLSLabs.Daylo.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: DLSLabs.Daylo
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **DLSLabs.Daylo** version **1.1.1**. Daylo is a free, open-source (MIT) habit tracker with a calendar heatmap. Everything stays on the user's device; there is no account and no telemetry. Installers are NSIS, per-user, for x64 and arm64, taken from the GitHub release `v1.1.1` of `henfrydls/daylo`.

- Homepage: https://daylo.henfrydls.com
- Release: https://github.com/henfrydls/daylo/releases/tag/v1.1.1

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

Notes: no Windows machine was available for `winget validate` / `winget install`. The three files were validated against the official 1.12.0 JSON schemas, the `InstallerSha256` values were computed from the published installers, and the `AppsAndFeaturesEntries` values match what the installer writes to `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Daylo` (DisplayName `Daylo`, Publisher `DLSLabs`, DisplayVersion `1.1.1`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431708)