### PR TITLE
New version: Dell.CommandUpdate version 5.7.1

### DIFF
--- a/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.installer.yaml
+++ b/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.installer.yaml
@@ -1,0 +1,40 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate
+PackageVersion: 5.7.1
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /passthrough /S /V/quiet /V/norestart
+  SilentWithProgress: /passthrough /V/passive /V/norestart
+  Interactive: /passthrough
+  InstallLocation: /V"DELL_COMMAND_UPDATE=\"<INSTALLPATH>\""
+  Log: /V"/log \"<LOGPATH>\""
+ExpectedReturnCodes:
+- InstallerReturnCode: 2
+  ReturnResponse: rebootRequiredToFinish
+- InstallerReturnCode: 6
+  ReturnResponse: rebootInitiated
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ProductCode: '{9F3A7C1E-8B52-4D9F-A6C7-1E2B9D4F5A08}'
+ReleaseDate: 2026-08-03
+AppsAndFeaturesEntries:
+- UpgradeCode: '{E9D40AD1-4E1D-46F2-B44A-F7E98338FCC7}'
+  InstallerType: msi
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.dell.com/FOLDER14847382M/2/Dell-Command-Update-for-Win32_6JGR0_WIN64_5.7.1_A00.EXE
+  InstallerSha256: B0F0BBE25549585C8D5E52D14DB73D16876E13DBEC3512522A031425FE515F41
+- Architecture: arm64
+  InstallerUrl: https://downloads.dell.com/FOLDER14847416M/2/Dell-Command-Update_8CKMK_WINARM64_5.7.1_A00.EXE
+  InstallerSha256: E91B85EF818BA2C086039032FA7F1F20924BF9EAC2E1C04793E85416A7F0F4A2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.locale.en-US.yaml
+++ b/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate
+PackageVersion: 5.7.1
+PackageLocale: en-US
+Publisher: Dell Inc.
+PublisherUrl: https://www.dell.com/
+PublisherSupportUrl: https://www.dell.com/support/home/en-us
+PrivacyUrl: https://www.dell.com/learn/us/en/uscorp1/policies-privacy
+Author: Dell Inc.
+PackageName: Dell Command | Update
+License: Proprietary
+LicenseUrl: https://www.dell.com/learn/us/en/uscorp1/terms-of-sale
+Copyright: Copyright (C) 2020 - 2026 Dell Inc.or its subsidiaries. All rights reserved
+CopyrightUrl: https://www.dell.com/learn/us/en/uscorp1/terms-conditions/trademarks-us
+ShortDescription: Dell Command Update is a stand-alone application for systems that provides updates for system software that is released by Dell. This application simplifies the BIOS, firmware, driver, and application update experience for Dell client hardware.
+Moniker: dellcommandupdate
+Tags:
+- alienware
+- bios
+- dell
+- dellinstrumentation.inf
+- device
+- driver
+- firmware
+- inspiron
+- latitude
+- optiplex
+- precision
+- update
+- vostro
+- xps
+ReleaseNotes: |-
+  Fixes:
+  - This release contains security updates as disclosed in the Dell Security Advisory DSA-2026-309. The DSA details are published on the <a href=https://www.dell.com/support/security target=_"blank">Security Advisories, Notices, and Resources</a> page, once they are publicly available. For more information about the release schedule, see <a href=https://www.dell.com/support/kbdoc/000197092/dell-drivers-and-downloads-update-release-schedule target=_"blank">Dell Client Drivers and Downloads Update Release Schedule.</a>
+
+  Enhancements:
+  - Added the option to bypass the Out of Box Experience (OOBE) through the command line to install the Dell Command Update application.
+  - Improved the performance of the application.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.locale.zh-CN.yaml
+++ b/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.locale.zh-CN.yaml
@@ -1,0 +1,34 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate
+PackageVersion: 5.7.1
+PackageLocale: zh-CN
+Publisher: Dell Inc.
+PublisherUrl: https://www.dell.com/zh-cn
+PublisherSupportUrl: https://www.dell.com/support/home/zh-cn
+PrivacyUrl: https://www.dell.com/zh-cn/lp/legal/policies-privacy
+Author: Dell Inc.
+PackageName: Dell Command | Update
+License: 专有软件
+LicenseUrl: https://www.dell.com/zh-cn/lp/legal/terms-of-sale
+Copyright: Copyright (C) 2020 - 2026 Dell Inc.or its subsidiaries. All rights reserved
+CopyrightUrl: https://www.dell.com/zh-cn/lp/legal/site-terms-of-use-copyright
+ShortDescription: Dell Command Update 是适用于系统的独立应用程序，可为戴尔发布的系统软件提供更新。此应用程序可简化适用于戴尔客户端硬件的 BIOS、固件、驱动程序和应用程序更新体验。
+Tags:
+- bios
+- latitude
+- optiplex
+- precision
+- xps
+- 升级
+- 固件
+- 外星人
+- 成就
+- 戴尔
+- 灵越
+- 设备
+- 驱动
+- 驱动程序
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.yaml
+++ b/manifests/d/Dell/CommandUpdate/5.7.1/Dell.CommandUpdate.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate
+PackageVersion: 5.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Dell Command | Update 5.7.1 with both x64 and native ARM64 installers.

Based on #424545 by @SpecterShell (locale/version manifests carried over unchanged), with three changes:

- Adds the ARM64 installer ([driver 8CKMK](https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=8ckmk))
- `Microsoft.DotNet.DesktopRuntime.8` → `.10` — Dell states 5.7.1 requires .NET Desktop Runtime 10.0.8+ and the installer terminates without it
- `ReleaseDate` 2026-04-28 → 2026-08-03 (both builds released 03 Aug 2026)

| Arch | SHA256 |
|---|---|
| x64 | `B0F0BBE25549585C8D5E52D14DB73D16876E13DBEC3512522A031425FE515F41` |
| arm64 | `E91B85EF818BA2C086039032FA7F1F20924BF9EAC2E1C04793E85416A7F0F4A2` |

Both are Authenticode-signed by Dell Technologies Inc. and report 5.7.1, A00.

Note: `Installers Scan` fails here with 403, as it does on #424545. Dell is blocking the validation service by IP — both `dl.dell.com` and `downloads.dell.com` return 403 to it, while both serve fine elsewhere. This likely needs manual verification.

- [x] CLA signed
- [x] `winget validate` passes
- [ ] `winget install` not tested — ARM64 installer on x64 hardware
