### PR TITLE
New version: Dell.CommandUpdate.Universal version 5.7.1

### DIFF
--- a/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.installer.yaml
+++ b/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.installer.yaml
@@ -1,0 +1,38 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS0.CRLF.7-6-3.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.Universal
+PackageVersion: 5.7.1
+InstallerLocale: en-US
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /passthrough /S /V/quiet /V/norestart
+  SilentWithProgress: /passthrough /S /V/quiet /V/norestart
+  Interactive: /passthrough
+  InstallLocation: /V"COMMANDUPDATE1=\"<INSTALLPATH>\""
+  Log: /V"/log \"<LOGPATH>\""
+InstallerSuccessCodes:
+- 2
+ExpectedReturnCodes:
+- InstallerReturnCode: 6
+  ReturnResponse: rebootInitiated
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+ReleaseDate: 2026-08-03
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.dell.com/FOLDER14847331M/2/Dell-Command-Update-Windows-Universal-Application_P0P70_WIN64_5.7.1_A00.EXE
+  InstallerSha256: D4ABF200D97F248CED288733CADDCE2FB4B5BB05DD38EF35B2DD0A3A34E6F15A
+  ProductCode: '{CF8E6E00-9C03-4440-81C0-21FACB921A6B}'
+- Architecture: arm64
+  InstallerUrl: https://downloads.dell.com/FOLDER14847475M/2/Dell-Command-Update-Windows-Universal-Application_44XRV_WINARM64_5.7.1_A00.EXE
+  InstallerSha256: 0A00EB5DFA9AB43035DA3F16EC74BBF26B29A938703AD6FE67F9872EA529C146
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.locale.en-US.yaml
+++ b/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS0.CRLF.7-6-3.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.Universal
+PackageVersion: 5.7.1
+PackageLocale: en-US
+Publisher: Dell Inc.
+PublisherUrl: https://www.dell.com/
+PublisherSupportUrl: https://www.dell.com/support/home/en-us/
+PrivacyUrl: https://www.dell.com/en-us/lp/legal/policies-privacy
+Author: Dell Inc.
+PackageName: Dell Command | Update for Windows Universal
+# PackageUrl:
+License: Proprietary
+LicenseUrl: https://www.dell.com/en-us/lp/legal/terms-of-sale
+Copyright: Copyright (C) 2020 - 2026 Dell Inc.or its subsidiaries. All rights reserved
+CopyrightUrl: https://www.dell.com/en-us/lp/legal/trademarks-us
+ShortDescription: Dell Command Update is a stand-alone application for systems that provides updates for system software that is released by Dell. This application simplifies the BIOS, firmware, driver, and application update experience for Dell client hardware.
+# Description:
+Moniker: dellcommandupdate-universal
+Tags:
+  - alienware
+  - bios
+  - dell
+  - device
+  - driver
+  - firmware
+  - inspiron
+  - latitude
+  - optiplex
+  - precision
+  - update
+  - vostro
+  - xps
+ReleaseNotes: |-
+  Fixes:
+  - This release contains security updates as disclosed in the Dell Security Advisory DSA-2026-309. The DSA details are published on the <a href="https://www.dell.com/support/security" target=_"blank">Security Advisories, Notices, and Resources</a>Security Advisories, Notices, and Resources page, once they are publicly available. For more information about the release schedule, <a href="https://www.dell.com/support/kbdoc/000197092/dell-drivers-and-downloads-update-release-schedule" target=_"blank">Dell Client Drivers and Downloads Update Release Schedule.</a>
+
+  Enhancements:
+  - Added the option to bypass the Out of Box Experience (OOBE) through the command line to install the Dell Command Update application.
+  - Improved the performance of the application.
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.locale.zh-CN.yaml
+++ b/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.locale.zh-CN.yaml
@@ -1,0 +1,42 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS0.CRLF.7-6-3.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.Universal
+PackageVersion: 5.7.1
+PackageLocale: zh-CN
+Publisher: Dell Inc.
+PublisherUrl: https://www.dell.com/zh-cn
+PublisherSupportUrl: https://www.dell.com/support/home/zh-cn
+PrivacyUrl: https://www.dell.com/zh-cn/lp/legal/policies-privacy
+Author: Dell Inc.
+PackageName: Dell Command | Update for Windows Universal
+# PackageUrl:
+License: 专有软件
+LicenseUrl: https://www.dell.com/learn/cn/zh/cncorp1/terms-of-sale
+Copyright: Copyright (C) 2020 - 2026 Dell Inc.or its subsidiaries. All rights reserved
+CopyrightUrl: https://www.dell.com/zh-cn/lp/legal/site-terms-of-use-copyright
+ShortDescription: Dell Command Update 是适用于系统的独立应用程序，可为戴尔发布的系统软件提供更新。此应用程序可简化适用于戴尔客户端硬件的 BIOS、固件、驱动程序和应用程序更新体验。
+# Description:
+# Moniker:
+Tags:
+- bios
+- latitude
+- optiplex
+- precision
+- xps
+- 升级
+- 固件
+- 外星人
+- 成就
+- 戴尔
+- 灵越
+- 设备
+- 驱动
+- 驱动程序
+# ReleaseNotes:
+# ReleaseNotesUrl:
+# PurchaseUrl:
+# InstallationNotes:
+# Documentations:
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.yaml
+++ b/manifests/d/Dell/CommandUpdate/Universal/5.7.1/Dell.CommandUpdate.Universal.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 v2.8.0 $debug=NVS0.CRLF.7-6-3.Win32NT
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.Universal
+PackageVersion: 5.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds Dell Command | Update Windows Universal Application 5.7.1 with both x64 and native ARM64 installers.

Based on #417054 by @AllwaysHyPe (locale/version manifests and installer metadata carried over unchanged); the only addition is the ARM64 installer ([driver 44XRV](https://www.dell.com/support/home/en-us/drivers/driversdetails?driverid=44XRV)). #425151 covers the same version and is flagged `Possible-Duplicate`.

| Arch | SHA256 |
|---|---|
| x64 | `D4ABF200D97F248CED288733CADDCE2FB4B5BB05DD38EF35B2DD0A3A34E6F15A` |
| arm64 | `0A00EB5DFA9AB43035DA3F16EC74BBF26B29A938703AD6FE67F9872EA529C146` |

Both are Authenticode-signed by Dell Technologies Inc. and report 5.7.1, A00. No `ProductCode` is set on the ARM64 entry — I could not read it without ARM hardware and would rather omit it than guess.

Note: `Installers Scan` fails here with 403, as it does on #417054 and #425151. Dell is blocking the validation service by IP — both `dl.dell.com` and `downloads.dell.com` return 403 to it while serving fine elsewhere. This likely needs manual verification.

- [x] CLA signed
- [x] `winget validate` passes
- [ ] `winget install` not tested — ARM64 installer on x64 hardware
