### PR TITLE
New package: FujifilmBusinessInnovation.DocuWorksViewerLight version 10.1.1

### DIFF
--- a/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.installer.yaml
+++ b/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FujifilmBusinessInnovation.DocuWorksViewerLight
+PackageVersion: 10.1.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: msi
+NestedInstallerFiles:
+- RelativeFilePath: dwvlt10_1_1\DWVLT\dwvlt10.msi
+Scope: machine
+ElevationRequirement: elevationRequired
+UpgradeBehavior: install
+ProductCode: '{EC5F2861-DED6-4345-A7B4-916F872E3987}'
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+Installers:
+- Architecture: x64
+  InstallerUrl: https://asset-fb.fujifilm.com/www/fb/files/2026-08/d77fc2ddb6eac43768819868bb2a7444/dwvlt10_1_1.zip
+  InstallerSha256: 4ACB51A35C97F22AB31E58F642B593E5661FA3EE7151E6C203A4300F5D09C7D9
+  AppsAndFeaturesEntries:
+  - DisplayName: FUJIFILM DocuWorks Viewer Light 10
+    Publisher: FUJIFILM Business Innovation Corp.
+    ProductCode: '{EC5F2861-DED6-4345-A7B4-916F872E3987}'
+    UpgradeCode: '{E4DD08F0-F3CF-40AD-8527-C148CAAC8D4C}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.locale.en-US.yaml
+++ b/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FujifilmBusinessInnovation.DocuWorksViewerLight
+PackageVersion: 10.1.1
+PackageLocale: en-US
+Publisher: FUJIFILM Business Innovation Corp.
+PublisherUrl: https://www.fujifilm.com/fb/
+PublisherSupportUrl: https://www.fujifilm.com/fb/ja/support/software/document-management/docuworks
+PackageName: DocuWorks Viewer Light
+PackageUrl: https://www.fujifilm.com/fb/ja/support/software/document-management/docuworks/download/101
+License: Proprietary
+LicenseUrl: https://www.fujifilm.com/fb/ja/support/software/document-management/docuworks/download/101
+Copyright: Copyright FUJIFILM Business Innovation Corp.
+ShortDescription: Free viewer for DocuWorks documents (.xdw, .xbd).
+Description: |-
+  DocuWorks Viewer Light opens and prints DocuWorks documents (.xdw) and binders (.xbd) without a DocuWorks licence.
+
+  It renders annotations and attachments, follows links, searches text, extracts original data from documents that carry it, and can save a copy. A bundled ActiveX control lets DocuWorks files be displayed inside a browser, with byte serving so large documents load a page at a time.
+Tags:
+- docuworks
+- document
+- viewer
+- xbd
+- xdw
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.yaml
+++ b/manifests/f/FujifilmBusinessInnovation/DocuWorksViewerLight/10.1.1/FujifilmBusinessInnovation.DocuWorksViewerLight.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FujifilmBusinessInnovation.DocuWorksViewerLight
+PackageVersion: 10.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: FujifilmBusinessInnovation.DocuWorksViewerLight version 10.1.1 (DocuWorks Viewer Light).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431781)