### PR TITLE
New package: ruslanlap.DefinitionForCommandPalette version 1.0.4.0

### DIFF
--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
@@ -2,12 +2,14 @@
 PackageIdentifier: ruslanlap.DefinitionForCommandPalette
 PackageVersion: 1.0.4.0
 InstallerType: msix
+PackageFamilyName: ruslanlap.DefinitionforCommandPalette_kkk6yee1n3hkw
+MinimumOSVersion: 10.0.19041.0
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
   InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
 - Architecture: arm64
   InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
-  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285d621d7ab3a3a7e0413963e3c5c6b61e57a
+  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: ruslanlap.DefinitionForCommandPalette
 PackageVersion: 1.0.4.0
+MinimumOSVersion: 10.0.19041.0
 InstallerType: msix
 PackageFamilyName: ruslanlap.DefinitionforCommandPalette_fykabapldzs6k
 Installers:

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
@@ -4,13 +4,8 @@ PackageVersion: 1.0.4.0
 InstallerType: msix
 PackageFamilyName: ruslanlap.DefinitionforCommandPalette_fykabapldzs6k
 Installers:
-- Architecture: x64
+- Architecture: neutral
   InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
   InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
-  SignatureSha256: F9CF2149E64E3E1DDF0AD9A333289F521719B5A5A4D04969766FB00839F10829
-- Architecture: arm64
-  InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
-  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
-  SignatureSha256: F9CF2149E64E3E1DDF0AD9A333289F521719B5A5A4D04969766FB00839F10829
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ruslanlap.DefinitionForCommandPalette
+PackageVersion: 1.0.4.0
+InstallerType: msix
+PackageFamilyName: ruslanlap.DefinitionforCommandPalette_fykabapldzs6k
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
+  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
+  SignatureSha256: F9CF2149E64E3E1DDF0AD9A333289F521719B5A5A4D04969766FB00839F10829
+- Architecture: arm64
+  InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
+  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
+  SignatureSha256: F9CF2149E64E3E1DDF0AD9A333289F521719B5A5A4D04969766FB00839F10829
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.installer.yaml
@@ -1,12 +1,13 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: ruslanlap.DefinitionForCommandPalette
 PackageVersion: 1.0.4.0
-MinimumOSVersion: 10.0.19041.0
 InstallerType: msix
-PackageFamilyName: ruslanlap.DefinitionforCommandPalette_fykabapldzs6k
 Installers:
-- Architecture: neutral
+- Architecture: x64
   InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
   InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A
+- Architecture: arm64
+  InstallerUrl: https://github.com/ruslanlap/CmdPal-Definition/releases/download/v1.0.4/DefinitionForCommandPalette.msixbundle
+  InstallerSha256: C2A1EF958A8FAEE721E1B1CF8CF285d621d7ab3a3a7e0413963e3c5c6b61e57a
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.locale.en-US.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ruslanlap.DefinitionForCommandPalette
+PackageVersion: 1.0.4.0
+PackageLocale: en-US
+Publisher: ruslanlap
+PublisherUrl: https://github.com/ruslanlap
+PublisherSupportUrl: https://github.com/ruslanlap/CmdPal-Definition/issues
+PackageName: Definition for Command Palette
+PackageUrl: https://github.com/ruslanlap/CmdPal-Definition
+License: MIT
+LicenseUrl: https://github.com/ruslanlap/CmdPal-Definition/blob/master/LICENSE
+ShortDescription: Dictionary lookup extension for Microsoft PowerToys Command Palette
+Description: A Command Palette extension that provides dictionary definitions lookup. Search for word definitions directly from the PowerToys Command Palette.
+Tags:
+- command-palette
+- dictionary
+- definition
+- powertoys
+- extension
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.locale.fr-FR.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.locale.fr-FR.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: ruslanlap.DefinitionForCommandPalette
+PackageVersion: 1.0.4.0
+PackageLocale: fr-FR
+Publisher: ruslanlap
+PublisherUrl: https://github.com/ruslanlap
+PublisherSupportUrl: https://github.com/ruslanlap/CmdPal-Definition/issues
+PackageName: Définition pour Command Palette
+PackageUrl: https://github.com/ruslanlap/CmdPal-Definition
+License: MIT
+LicenseUrl: https://github.com/ruslanlap/CmdPal-Definition/blob/master/LICENSE
+ShortDescription: Extension de recherche de définitions pour Microsoft PowerToys Command Palette
+Description: |-
+  Une extension Command Palette qui fournit des définitions de mots instantanées, la phonétique, les synonymes, les antonymes et des exemples d'utilisation directement depuis PowerToys Command Palette.
+
+  IMPORTANT : Il s'agit d'une extension pour Microsoft PowerToys Command Palette. Elle nécessite Microsoft PowerToys (v0.70.0 ou ultérieur) installé et la fonctionnalité Command Palette activée. Cette application ne fonctionne pas de manière autonome.
+
+  v1.0.4 : bascule du dictionnaire anglais sur Free Dictionary API avec Datamuse en secours (l'ancien endpoint dictionaryapi.dev est mort).
+Tags:
+- command-palette
+- dictionnaire
+- définition
+- powertoys
+- extension
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.yaml
+++ b/manifests/r/ruslanlap/DefinitionForCommandPalette/1.0.4.0/ruslanlap.DefinitionForCommandPalette.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ruslanlap.DefinitionForCommandPalette
+PackageVersion: 1.0.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

Add the new package `ruslanlap.DefinitionForCommandPalette` at version `1.0.4.0` to the Windows Package Manager repository.

This is the **initial submission** for the package — there is no previous version in `manifests/r/ruslanlap/DefinitionForCommandPalette/`.

## Package details

- **Publisher**: ruslanlap
- **Package name**: Definition for Command Palette
- **Version**: 1.0.4.0
- **Installer type**: msix (PowerToys Command Palette extension)
- **Architectures**: x64, arm64 (both delivered via the single `DefinitionForCommandPalette.msixbundle` MSIX bundle)
- **MSIX bundle SHA256**: `C2A1EF958A8FAEE721E1B1CF8CF285D621D7AB3A3A7E0413963E3C5C6B61E57A`
- **Signature SHA256 (bundle)**: `F9CF2149E64E3E1DDF0AD9A333289F521719B5A5A4D04969766FB00839F10829`
- **PackageFamilyName**: `ruslanlap.DefinitionforCommandPalette_fykabapldzs6k` (computed from MSIX publisher `CN=11D55891-40B3-4190-95B7-CDE591AABEA5`)

## Why this package type is unusual

`Definition for Command Palette` is an **MSIX plugin** that installs into an existing Microsoft PowerToys Command Palette install. It is **not a standalone executable** and ships no primary `.exe` payload. Expected validation labels for this package type:

- `Validation-Executable-Error`
- `Validation-No-Executables`

Both are routine for MSIX-only plugins. The install path for the plugin payload is `Plugins\\DefinitionForCommandPalette\\` under the PowerToys install directory, and the host executable (which the plugin relies on) is the PowerToys main binary. The plugin does not function standalone.

## What's new in 1.0.4.0

- English dictionary endpoint migrated from `dictionaryapi.dev` (dead) to `freedictionaryapi.dev` with `api.datamuse.com` as a fallback for synonyms / antonyms.
- Settings now auto-migrate any user-configured custom endpoint to a normalized form.
- Version bump to align with the Microsoft Store release v1.0.4.

## Manifest files

- `ruslanlap.DefinitionForCommandPalette.yaml` (version manifest)
- `ruslanlap.DefinitionForCommandPalette.installer.yaml` (installer manifest)
- `ruslanlap.DefinitionForCommandPalette.locale.en-US.yaml` (default locale)
- `ruslanlap.DefinitionForCommandPalette.locale.fr-FR.yaml` (French locale)

All manifests use `ManifestVersion: 1.12.0` per the current schema requirements.

## Note on the previous PR (#431788)

PR #431788 was closed: a follow-up commit broke the tree structure when trying to update only the installer manifest. This is a clean re-submission with all four files in a single commit and a corrected `PackageFamilyName` / `SignatureSha256`.

cc @microsoft/winget-pkgs-reviewers — happy to address any validation feedback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431811)