### PR TITLE
New version: OpsMaxx.OpsMaxx version 0.29.0

### DIFF
--- a/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.installer.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.29.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-09-09"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/OpsMaxx/OpsMaxx/releases/download/v0.29.0/OpsMaxx-0.29.0-setup.exe
+    InstallerSha256: 90C7F043BAB851BC4A42879A10AD44B7BDEA477C60838A02FF40FE8D5910F21D
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.locale.en-US.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.29.0
+PackageLocale: en-US
+Publisher: OpsMaxx
+PublisherUrl: https://opsmaxx.dev/
+PublisherSupportUrl: https://github.com/OpsMaxx/OpsMaxx/issues
+PackageName: OpsMaxx
+PackageUrl: https://opsmaxx.dev/
+License: MIT
+LicenseUrl: https://github.com/OpsMaxx/OpsMaxx/blob/main/LICENSE
+Copyright: Copyright (c) OpsMaxx
+ShortDescription: SSH client, SFTP browser, database manager, secrets vault and MCP gateway for AI agents.
+Description: |-
+  OpsMaxx is a free, open-source desktop application that keeps an SSH terminal, an SFTP
+  browser, a remote desktop client, five database engines, SSH tunnels and VPN, an encrypted
+  secrets vault and fleet operations in one window, all sharing a single credential store.
+
+  It also exposes a policy-scoped MCP bridge, so Claude Code, Codex, Gemini CLI and other
+  MCP clients can operate servers by friendly name without ever receiving an SSH password,
+  a private key, a database credential or a hostname. Every capability is ALLOW, ASK or DENY
+  per access group, sensitive actions wait for approval, and every action is written to an
+  audit log.
+Moniker: opsmaxx
+Tags:
+  - ssh
+  - ssh-client
+  - sftp
+  - terminal
+  - database
+  - devops
+  - mcp
+  - vault
+  - tunnel
+  - vpn
+  - rdp
+  - remote-desktop
+ReleaseNotesUrl: https://github.com/OpsMaxx/OpsMaxx/releases/tag/v0.29.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.yaml
+++ b/manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.29.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following manifest

- `manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.yaml`
- `manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.installer.yaml`
- `manifests/o/OpsMaxx/OpsMaxx/0.29.0/OpsMaxx.OpsMaxx.locale.en-US.yaml`

#### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? — the CLA bot's check is authoritative here; signing will be completed if it is not already on file.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — **not run.** This was prepared on macOS, where `winget` is unavailable. The three manifests were instead validated programmatically against the published v1.6.0 `manifest.installer`, `manifest.version` and `manifest.defaultLocale` JSON schemas, all passing.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — **not run**, same reason.
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Notes

Publisher submission. Upstream release: https://github.com/OpsMaxx/OpsMaxx/releases/tag/v0.29.0

`InstallerSha256` is `90C7F043BAB851BC4A42879A10AD44B7BDEA477C60838A02FF40FE8D5910F21D`, taken from the release notes' checksum table and independently verified against a fresh download of the published asset.

`InstallerType: nullsoft` is the NSIS installer produced by electron-builder, and `Scope: user` because it is a per-user install (`nsis.perMachine: false`).

The previous manifest in this repository is 0.28.2 — 0.28.3 was not submitted, so this update moves winget users forward two versions.

Happy to run the `winget` validation and an install test on a Windows machine if the automated validation does not cover it.