### PR TITLE
New package: PlummersSoftware.TMOG version 0.1.3

### DIFF
--- a/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.installer.yaml
+++ b/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PlummersSoftware.TMOG
+PackageVersion: 0.1.3
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{A6C8E313-D89B-4913-BD80-249F5A7575C8}_is1'
+ReleaseDate: 2026-09-07
+AppsAndFeaturesEntries:
+- DisplayName: Task Manager TMOG
+  Publisher: Plummer's Software LLC
+  DisplayVersion: 0.1.3.0
+  ProductCode: '{A6C8E313-D89B-4913-BD80-249F5A7575C8}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.tmog.org/downloads/TMOG-Task-Manager-Setup.exe
+  InstallerSha256: 8E233A31283D907E101E81D54492214C541078EE8C01EC3F15522ACEB0001501
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.locale.en-US.yaml
+++ b/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PlummersSoftware.TMOG
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: Plummer's Software LLC
+PublisherUrl: https://www.tmog.org/
+PublisherSupportUrl: https://www.tmog.org/feedback.html
+PrivacyUrl: https://www.tmog.org/privacy.html
+Author: Dave W. Plummer
+PackageName: Task Manager TMOG
+PackageUrl: https://www.tmog.org/
+License: Proprietary
+Copyright: Copyright (c) 2026 Plummer's Software LLC
+ShortDescription: Native Win32 task manager with live CPU, memory, disk, network, energy, and process views.
+Description: |-
+  TMOG (Task Manager OG) is a native Win32 system monitor for Windows 11.
+  It shows live CPU, memory, disk, network, energy, and process activity in one view so you can identify which process or resource is responsible for a slowdown.
+Moniker: tmog
+Tags:
+- diagnostics
+- process
+- system-monitor
+- task-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.yaml
+++ b/manifests/p/PlummersSoftware/TMOG/0.1.3/PlummersSoftware.TMOG.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PlummersSoftware.TMOG
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
Adds Task Manager TMOG 0.1.3 from https://www.tmog.org/ as a new WinGet package (`PlummersSoftware.TMOG`).

## Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - Resolves #[Issue Number]

## Manifest Checklist
- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

## Test plan
- [x] `winget validate --manifest manifests/p/PlummersSoftware/TMOG/0.1.3` succeeded
- [x] Silent Inno install (`/VERYSILENT /CURRENTUSER`) succeeded; ARP `DisplayName` Task Manager TMOG, `DisplayVersion` 0.1.3.0, `Publisher` Plummer's Software LLC, `ProductCode` `{A6C8E313-D89B-4913-BD80-249F5A7575C8}_is1`
- [x] Installed payload is x64 (`Task Manager.exe`)
- [x] Silent uninstall succeeded
- Windows Sandbox was not available on this machine (`WindowsSandbox.exe` not present)

Note: https://github.com/microsoft/winget-pkgs/pull/423415 adds the same identifier at 0.1.1.0. This PR is the current 0.1.3 Windows installer from tmog.org.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431818)