### PR TITLE
Update: MNardit.Beetroot to 1.6.7

### DIFF
--- a/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.installer.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.7
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/mnardit/beetroot-releases/releases/download/v1.6.7/Beetroot_1.6.7_x64-setup.exe
+    InstallerSha256: 1F2BA334EDC1FBAF89CB75DFE732799031FF1A187124B84BE5B2E48374ADAFB6
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.locale.en-US.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.7
+PackageLocale: en-US
+Publisher: MNardit
+PublisherUrl: https://github.com/mnardit
+Author: Max Nardit
+PackageName: Beetroot
+PackageUrl: https://github.com/mnardit/beetroot-releases
+License: Apache-2.0
+LicenseUrl: https://github.com/mnardit/beetroot-releases/blob/v1.6.7/LICENSE
+ShortDescription: Lightweight clipboard manager for Windows with AI-powered text transforms
+Description: |-
+  Beetroot is a modern clipboard manager for Windows that runs in the system tray.
+  Features:
+  - Unlimited clipboard history (text and images)
+  - Global hotkey (Ctrl+`) to instantly access history
+  - Fuzzy and regex search
+  - AI-powered text transforms via OpenAI (10 built-in + custom prompts)
+  - OCR text extraction from images (native Windows engine)
+  - Notes on clipboard items
+  - Pin window on top or follow cursor mode
+  - Multi-select batch operations
+  - 9 themes + custom accent color
+  - 26 languages
+  - Automatic database backup and recovery
+  - Customizable UI and code fonts
+  - Auto-update with option to disable for fully offline operation
+  - Plain text paste hotkey
+  - Non-QWERTY keyboard layout support (AZERTY, QWERTZ, AltGr) with instant layout detection
+ReleaseNotesUrl: https://github.com/mnardit/beetroot-releases/releases/tag/v1.6.7
+Tags:
+  - clipboard
+  - clipboard-manager
+  - productivity
+  - tauri
+  - windows
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.yaml
+++ b/manifests/m/MNardit/Beetroot/1.6.7/MNardit.Beetroot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MNardit.Beetroot
+PackageVersion: 1.6.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Update MNardit.Beetroot to 1.6.7, the published open-source release under Apache-2.0. The three manifests point to the immutable official NSIS installer and its verified SHA-256.

Release: https://github.com/mnardit/beetroot-releases/releases/tag/v1.6.7
Source manifest review: https://github.com/mnardit/beetroot-releases/pull/46

Known validation concern: Windows 11 Defender intelligence 1.459.123.0 detected the exact public installer as Program:Win32/Wacapew.A!ml, blocking a Chocolatey 1.6.6-to-1.6.7 upgrade. Reading a separate copy reproduced the detection. Microsoft Security Intelligence analysis has been requested; an incorrect detection is not yet confirmed. No protection settings were changed. The maintainer requested submitting this update while that investigation is pending; please retain the normal security and installation validation checks.

## Checklist

- [ ] Contributor License Agreement status to be verified by the repository's CLA check
- [x] Checked for another open PR for the same package version
- [x] Only one package/version is changed (three manifest files)
- [x] Local `winget validate --manifest packaging/winget` succeeds
- [ ] Native `winget install --manifest` acceptance completed (not reached because of the shared installer detection)

The existing 1.6.0 manifest schema is retained. No new issue is linked and no validation result is represented as passing when it did not run.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431827)