### PR TITLE
Update version: LANCommander.Server version 2.1.15

### DIFF
--- a/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.installer.yaml
+++ b/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.15
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.15/LANCommander.Server-2.1.15-x64-Setup.exe
+  InstallerSha256: BF4CF5C4E9A2A3F38F7445596AF7EB819C90BB8CB7003C8B9EADBA86FFFD5550
+- Architecture: arm64
+  InstallerUrl: https://github.com/LANCommander/LANCommander/releases/download/v2.1.15/LANCommander.Server-2.1.15-arm64-Setup.exe
+  InstallerSha256: 6A57846F6ACB5D340B8C94EEDB1158C9A0EBCB0EB7027815EF313F405FEE7B5E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.locale.en-US.yaml
+++ b/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.15
+PackageLocale: en-US
+Publisher: LANCommander LLC
+PublisherUrl: https://github.com/LANCommander
+PublisherSupportUrl: https://github.com/LANCommander/LANCommander/issues
+Author: Pat Hartl
+PackageName: LANCommander Server
+PackageUrl: https://github.com/LANCommander/LANCommander
+License: MIT
+Copyright: Copyright (c) LANCommander LLC
+ShortDescription: |
+  LANCommander is a self-hosted game distribution platform designed for LAN parties and personal libraries.
+  This server software is your central repository for games, redistributables, saves, and users.
+ReleaseNotes: "View the full release notes over on the official documentation site:\r\nhttps://lancommander.app/Releases/2.1.15"
+ReleaseNotesUrl: https://github.com/LANCommander/LANCommander/releases/tag/v2.1.15
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.lancommander.app
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.yaml
+++ b/manifests/l/LANCommander/Server/2.1.15/LANCommander.Server.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: LANCommander.Server
+PackageVersion: 2.1.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update LANCommander.Server to version 2.1.15.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431832)