### PR TITLE
Fix stale installer URLs for OpenWhispr.OpenWhispr (1.7.5 - 1.9.2)

### DIFF
--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.5/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.5/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: 69b301d3-943a-521b-b7b8-a2661047b2d2
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.7.5.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.5/OpenWhispr-Setup-1.7.5.exe
   InstallerSha256: D46FD21920AD83A8A4BFC71431C01049CF3F2BB7FC7657D6C0A718D3C268DAEA
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.8.3/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.8.3/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: "{69B301D3-943A-521B-B7B8-A2661047B2D2}"
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.8.3.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.8.3/OpenWhispr-Setup-1.8.3.exe
   InstallerSha256: 6C8FB1473B3F7DF8F114976358871F078A855E6504ADEAAFB6F58D456882DBBD
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.9.0/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.9.0/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: "{69B301D3-943A-521B-B7B8-A2661047B2D2}"
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.0/OpenWhispr-Setup-1.9.0.exe
   InstallerSha256: 11BACA44EAD34EBA3A7A4367BB5A136DBAF8E82474C29D3BFB274FAA22D0727E
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.9.1/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.9.1/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: "{69B301D3-943A-521B-B7B8-A2661047B2D2}"
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.1.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.1/OpenWhispr-Setup-1.9.1.exe
   InstallerSha256: A0EC663603B8A36FD8E9332EBE3B2F967045DC015F2153DAB67C9A232600C5C7
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/o/OpenWhispr/OpenWhispr/1.9.2/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.9.2/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: "{69B301D3-943A-521B-B7B8-A2661047B2D2}"
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.2.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.2/OpenWhispr-Setup-1.9.2.exe
   InstallerSha256: 96E84935BB68BE2B45AA56B4C85D6CB9C0231EE0536BA365EED1DA9FA345F16B
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
All five of these manifests point at GitHub's `latest` release alias combined with a version-pinned filename:

```
https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
```

`/releases/latest/download/` resolves to whatever the newest release happens to be, so each manifest returns 404 as soon as the publisher ships the next version. Every version from 1.7.5 onward is affected; 1.7.3 already uses the correct pinned form and is untouched here.

This has been reported downstream twice: OpenWhispr/openwhispr#1909 and OpenWhispr/openwhispr#1355.

## Change

One line per manifest, `InstallerUrl` only:

```diff
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.0/OpenWhispr-Setup-1.9.0.exe
```

Nothing else is modified — no `InstallerSha256`, `ProductCode`, `ReleaseDate` or `ManifestVersion` changes, and the locale/version manifests are untouched (they contain no release URLs).

## Verification

The installer binary is unchanged; only its address is corrected. Each existing `InstallerSha256` already matches the asset at the pinned URL, confirmed against the GitHub releases API `digest` field:

| Version | Pinned URL | Manifest SHA256 == asset digest |
|---|---|---|
| 1.7.5 | 206 | yes |
| 1.8.3 | 206 | yes |
| 1.9.0 | 206 | yes |
| 1.9.1 | 206 | yes |
| 1.9.2 | 206 | yes |

Note that 1.9.2 currently resolves only because it is coincidentally the newest release; it will 404 the moment the next version ships, which is why it is included.

I do not have a Windows machine available, so these have not been run through `winget validate` or an end-to-end `winget install --manifest` locally. Happy to hold for the validation pipeline, and to make any changes moderators prefer.

## Upstream follow-up

The publisher is adding a release workflow that submits future versions via WinGet Releaser, so the URLs will be tag-pinned from the release assets going forward: OpenWhispr/openwhispr#2089.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431910)