### PR TITLE
New package: KoukeNeko.TaigaCLI version 0.6.0

### DIFF
--- a/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.installer.yaml
+++ b/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.TaigaCLI
+PackageVersion: 0.6.0
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/KoukeNeko/taiga-cli/releases/download/v0.6.0/taiga_0.6.0_windows_amd64.zip
+  InstallerSha256: FB03C313CC0AAC40F6E9610DA592D5A0C2EBDBE0C805931D5C64AEAE2D91CB41
+  NestedInstallerFiles:
+  - RelativeFilePath: taiga_0.6.0_windows_amd64\taiga.exe
+    PortableCommandAlias: taiga
+- Architecture: arm64
+  InstallerUrl: https://github.com/KoukeNeko/taiga-cli/releases/download/v0.6.0/taiga_0.6.0_windows_arm64.zip
+  InstallerSha256: 9D0EF627CD3ECE400773122EAA62A0D597FF9931F6543C0251E1D959591AED59
+  NestedInstallerFiles:
+  - RelativeFilePath: taiga_0.6.0_windows_arm64\taiga.exe
+    PortableCommandAlias: taiga
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.locale.en-US.yaml
+++ b/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.TaigaCLI
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: KoukeNeko
+PublisherUrl: https://github.com/KoukeNeko
+PublisherSupportUrl: https://github.com/KoukeNeko/taiga-cli/issues
+PackageName: Taiga CLI
+PackageUrl: https://github.com/KoukeNeko/taiga-cli
+License: MIT
+LicenseUrl: https://github.com/KoukeNeko/taiga-cli/blob/main/LICENSE
+Copyright: Copyright (c) KoukeNeko
+ShortDescription: Independent command-line client for Taiga
+Description: |-
+  Taiga CLI drives Taiga 6 projects, agile boards and wikis from the terminal.
+  The same command serves a person and a program: it prints aligned tables, and
+  with --json it answers with a versioned contract that shell scripts, CI jobs
+  and agents can be pointed at. Tokens are kept in the operating system
+  credential store rather than a configuration file.
+
+  Taiga is a trademark of its respective owners. This is an independent client,
+  not affiliated with or endorsed by the Taiga project.
+Moniker: taiga
+Tags:
+- agile
+- cli
+- issue-tracker
+- kanban
+- project-management
+- scrum
+- taiga
+ReleaseNotesUrl: https://github.com/KoukeNeko/taiga-cli/releases/tag/v0.6.0
+Documentations:
+- DocumentLabel: Manual
+  DocumentUrl: https://github.com/KoukeNeko/taiga-cli/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.locale.zh-TW.yaml
+++ b/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.locale.zh-TW.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.TaigaCLI
+PackageVersion: 0.6.0
+PackageLocale: zh-TW
+Publisher: KoukeNeko
+PackageName: Taiga CLI
+License: MIT
+ShortDescription: 獨立的 Taiga 命令列客戶端
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.yaml
+++ b/manifests/k/KoukeNeko/TaigaCLI/0.6.0/KoukeNeko.TaigaCLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KoukeNeko.TaigaCLI
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

New package `KoukeNeko.TaigaCLI` version 0.6.0 — a portable (zip) Windows package for x64 and arm64. Installer URLs point at the signed v0.6.0 GitHub release, and each `InstallerSha256` is taken from the release `SHA256SUMS`.

This supersedes #431282: the project was renamed from Aihki back to Taiga CLI, so the earlier `KoukeNeko.Aihki` submission was closed.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431917)
