### PR TITLE
Fix installer URL: OpenWhispr.OpenWhispr version 1.9.0

### DIFF
--- a/manifests/o/OpenWhispr/OpenWhispr/1.9.0/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.9.0/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: "{69B301D3-943A-521B-B7B8-A2661047B2D2}"
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.0/OpenWhispr-Setup-1.9.0.exe
   InstallerSha256: 11BACA44EAD34EBA3A7A4367BB5A136DBAF8E82474C29D3BFB274FAA22D0727E
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The `InstallerUrl` for this version points at GitHub's `latest` release alias combined with a version pinned filename:

```
https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
```

`/releases/latest/download/` resolves to whichever release is newest, so this path returns 404 once the publisher ships any later version. Reported downstream as OpenWhispr/openwhispr#1909 and OpenWhispr/openwhispr#1355.

### Change

One line, `InstallerUrl` only:

```diff
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.9.0/OpenWhispr-Setup-1.9.0.exe
```

No other field changes. The installer binary is identical, only its address is corrected, so the existing `InstallerSha256` still applies. I confirmed it matches the asset at the pinned URL using the GitHub releases API `digest` field, and that the pinned URL returns a successful response.

I do not have a Windows machine available, so this has not been run through `winget validate` or an end to end `winget install --manifest` locally.

### Notes

This replaces #431910, which incorrectly bundled several versions into a single pull request. Versions 1.7.5, 1.8.3, 1.9.0, 1.9.1 and 1.9.2 all carry the same defect and are being submitted separately.

The publisher is adding a release workflow that submits future versions through WinGet Releaser, so installer URLs will be taken from the release assets and pinned to the tag going forward: OpenWhispr/openwhispr#2089.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431920)