### PR TITLE
Update version: AES256Afro.VideoKidnapper version 1.8.3

### DIFF
--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.installer.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.3
+InstallerLocale: en-US
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: "{8C8E1A2F-5D4B-4E6A-9F32-7C1A5B2D6E84}_is1"
+ReleaseDate: 2026-09-08
+AppsAndFeaturesEntries:
+- ProductCode: "{8C8E1A2F-5D4B-4E6A-9F32-7C1A5B2D6E84}_is1"
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://github.com/AES256Afro/VideoKidnapper/releases/download/v1.8.3/VideoKidnapper-Setup-1.8.3.exe
+  InstallerSha256: 7D1FCFB413C4F55953D9C660654FA158F9615B09A0D1E930D39D6CC1E58D737A
+  InstallerSwitches:
+    Custom: /CURRENTUSER
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://github.com/AES256Afro/VideoKidnapper/releases/download/v1.8.3/VideoKidnapper-Setup-1.8.3.exe
+  InstallerSha256: 7D1FCFB413C4F55953D9C660654FA158F9615B09A0D1E930D39D6CC1E58D737A
+  InstallerSwitches:
+    Custom: /ALLUSERS
+  InstallationMetadata:
+    DefaultInstallLocation: "%ProgramFiles%\\VideoKidnapper"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.locale.en-US.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.3
+PackageLocale: en-US
+Publisher: AES256Afro
+PublisherUrl: https://github.com/AES256Afro
+PublisherSupportUrl: https://github.com/AES256Afro/VideoKidnapper/issues
+Author: AES256Afro
+PackageName: VideoKidnapper
+PackageUrl: https://github.com/AES256Afro/VideoKidnapper
+License: Apache-2.0
+LicenseUrl: https://github.com/AES256Afro/VideoKidnapper/blob/HEAD/LICENSE
+ShortDescription: Open-source desktop app to trim, caption, GIF, and download videos from multiple platforms using yt-dlp and FFmpeg.
+Description: VideoKidnapper is a free, open-source desktop app for grabbing and editing video. Paste a link to download clips from multiple platforms via yt-dlp, then trim to a range, add captions, and export as a video or an animated GIF — all locally with the full FFmpeg toolchain, so nothing is blocked or watermarked. Runs on Windows, macOS, and Linux and is released under the Apache-2.0 license.
+Tags:
+- customtkinter
+- desktop-app
+- ffmpeg
+- gif
+- python
+- screen-recorder
+- tkinter
+- video
+- video-editor
+- yt-dlp
+ReleaseNotes: |-
+  Published to PyPI：https://pypi.org/project/videokidnapper/1.8.3/
+
+  **macOS:** `*-macos-arm64.dmg` (Apple Silicon) · `*-macos-x86_64.dmg` (Intel). Signed and notarized by Apple; FFmpeg bundled.
+
+  ---
+
+  > **Fixes exports that came out cut off or at an odd aspect ratio.** Portrait phone video was being handled as landscape, and aspect presets did not produce their exact ratio.
+
+  ### Fixed
+
+  • **Phone videos were treated as landscape.** Footage from a phone is stored sideways with a rotation flag that players honour; the app read the stored size and ignored the flag, so a portrait clip was handled as 1920×1080. The picture itself exported the right way up, but every decision based on the size was wrong：choosing the 9:16 preset on a clip that was already 9:16 computed a crop wider than the frame and produced a mangled 720×1284 file — "cut off", with an odd aspect ratio. Dimensions now follow the rotation flag, matching what the preview and the export actually show.
+  • **Aspect presets now produce exact sizes.** Cropping a 16:9 source to 9:16 gives a 607-pixel-wide frame, and scaling that landed on 720×1284 (720×1282 with blur fill) instead of 720×1280, because the crop and the scale each rounded on their own. Exports with an aspect preset now scale to the canonical box for the quality setting：720×1280, 720×720, 1080×1920. Exports whose source already matches the preset are unchanged.
+ReleaseNotesUrl: https://github.com/AES256Afro/VideoKidnapper/releases/tag/v1.8.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.yaml
+++ b/manifests/a/AES256Afro/VideoKidnapper/1.8.3/AES256Afro.VideoKidnapper.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: AES256Afro.VideoKidnapper
+PackageVersion: 1.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update AES256Afro.VideoKidnapper to version 1.8.3.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431924)