### PR TITLE
Fix installer URL: OpenWhispr.OpenWhispr version 1.7.5

### DIFF
--- a/manifests/o/OpenWhispr/OpenWhispr/1.7.5/OpenWhispr.OpenWhispr.installer.yaml
+++ b/manifests/o/OpenWhispr/OpenWhispr/1.7.5/OpenWhispr.OpenWhispr.installer.yaml
@@ -15,7 +15,7 @@ AppsAndFeaturesEntries:
   ProductCode: 69b301d3-943a-521b-b7b8-a2661047b2d2
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.7.5.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.5/OpenWhispr-Setup-1.7.5.exe
   InstallerSha256: D46FD21920AD83A8A4BFC71431C01049CF3F2BB7FC7657D6C0A718D3C268DAEA
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The `InstallerUrl` for this version points at GitHub's `latest` release alias combined with a version pinned filename:

```
https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.7.5.exe
```

`/releases/latest/download/` resolves to whichever release is newest, so this path returns 404 once the publisher ships any later version. It has been returning 404 since v1.7.6 was published. Reported downstream as OpenWhispr/openwhispr#1355 and OpenWhispr/openwhispr#1909.

### Change

One line, `InstallerUrl` only:

```diff
-  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.7.5.exe
+  InstallerUrl: https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.5/OpenWhispr-Setup-1.7.5.exe
```

No other field changes. The installer binary is identical, only its address is corrected, so the existing `InstallerSha256` still applies. I confirmed it matches the asset at the pinned URL using the GitHub releases API `digest` field, and that the pinned URL returns a successful response.

I do not have a Windows machine available, so this has not been run through `winget validate` or an end to end `winget install --manifest` locally.

### Notes

This is the last of five versions carrying the same defect. The other four are #431918 (1.9.2), #431919 (1.9.1), #431920 (1.9.0) and #431921 (1.8.3). Version 1.7.3 already uses the pinned form and needs no change.

The publisher is adding a release workflow that submits future versions through WinGet Releaser, so installer URLs will be taken from the release assets and pinned to the tag going forward: OpenWhispr/openwhispr#2089.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431930)