### PR TITLE
New version: DonislawDev.BeanNetworkTester version 0.6.0

### DIFF
--- a/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.installer.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.installer.yaml
@@ -1,0 +1,28 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# Submitted as manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.installer.yaml
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.6.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: BeanNetworkTester/BeanNetworkTester.exe
+# 🔴 Load-bearing. The default for a portable inside an archive is a SYMLINK in the
+# links folder, and this exe cannot be reached through one: it needs its sibling
+# _internal directory, which the symlink leaves behind. Setting this skips the
+# symlink and puts the directory holding the nested file on PATH instead - verified
+# in winget's own source (PortableInstaller.cpp takes the parent of the nested
+# file's path), not inferred from the field's description, which says only
+# "install location".
+ArchiveBinariesDependOnPath: true
+# The program asks for elevation itself when it needs to capture. Saying so here
+# stops winget from running the whole install elevated.
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-09-04
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/donislawdev/BeanNetworkTester/releases/download/v0.6.0/BeanNetworkTester-v0.6.0-windows-x64.zip
+  InstallerSha256: 3D6A17AE8880A675F0FC23EEB1F5520A638FB1433AE9EA6EF77CA4DF85CBED1A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: DonislawDev
+PublisherUrl: https://github.com/donislawdev/BeanNetworkTester
+PublisherSupportUrl: https://github.com/donislawdev/BeanNetworkTester/issues
+PackageName: Bean Network Tester
+PackageUrl: https://beannetworktester.donislawdev.com
+License: GNU General Public License v3.0
+LicenseUrl: https://github.com/donislawdev/BeanNetworkTester/blob/master/LICENSE
+Copyright: Copyright (C) 2026 DonislawDev
+ShortDescription: Simulate a bad network on Windows
+Description: >-
+  Free Windows tool that adds lag, packet loss and speed limits to one app, so you can test how it behaves on a bad connection.
+  It adds latency, jitter, packet loss, corruption, duplication and bandwidth limits
+  to the traffic of a chosen application, and reports every outcome as an exit code
+  so it can run from a pipeline. It needs Administrator rights to capture traffic and
+  asks for them itself. Profiles, window state and CSV exports are kept in
+  %LOCALAPPDATA%\BeanNetworkTester, so upgrading the package leaves them alone.
+Moniker: bean-network-tester
+Tags:
+- bandwidth
+- latency
+- network
+- packet-loss
+- qa
+- testing
+- windivert
+ReleaseNotesUrl: https://github.com/donislawdev/BeanNetworkTester/releases/tag/v0.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.yaml
+++ b/manifests/d/DonislawDev/BeanNetworkTester/0.6.0/DonislawDev.BeanNetworkTester.yaml
@@ -1,0 +1,8 @@
+# Rendered by tools/build_packages.py - do not edit the generated copy.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DonislawDev.BeanNetworkTester
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds version 0.6.0 of `DonislawDev.BeanNetworkTester`. Version 0.5.0 of this package is already published here.

The manifests are generated from the release's own `SHA256SUMS.txt`, so the installer URL and checksum come from a single source rather than being typed in.

### Verification

- `winget validate --manifest` passes.
- Installer SHA256 computed independently from the downloaded archive and matched against the release checksum file: `3D6A17AE8880A675F0FC23EEB1F5520A638FB1433AE9EA6EF77CA4DF85CBED1A`.
- Every URL in the manifests answers HTTP 200.
- Installed and upgraded from 0.5.0 to 0.6.0 on Windows 11 and on Windows Server 2025. The upgrade replaces the package directory in place, leaving one entry at 0.6.0.
- The nested executable keeps its sibling `_internal` directory after the upgrade, and no symlink is created in the links folder, which is what `ArchiveBinariesDependOnPath: true` is there for.
- The installed build was driven after upgrading: it resolves its bundled language tables and runs all eight bundled scenarios.

### Notes

- `InstallerType: zip` with `NestedInstallerType: portable`. The executable cannot be reached through a symlink because it needs its sibling `_internal` directory, hence `ArchiveBinariesDependOnPath: true`.
- `ElevationRequirement: elevatesSelf`: the application requests elevation itself when it needs to capture traffic, so the install does not need to run elevated.
- User data is kept in `%LOCALAPPDATA%`, not in the package directory, so an upgrade that replaces the unpacked directory cannot take it along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/431950)