### PR TITLE
Update: Grifnas.OrizontRSS to 1.5.4

### DIFF
--- a/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.installer.yaml
+++ b/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Grifnas.OrizontRSS
+PackageVersion: 1.5.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Orizont.exe
+  PortableCommandAlias: orizont-rss
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/grifnas/OrizontRSS/releases/download/v1.5.3/Orizont-RSS-1.5.3-win-x64.zip
+  InstallerSha256: 7536070499680C2C2859C69C181BB8B6689EFA510E51C8E61E01DBD4EB48F6EB
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.locale.en-US.yaml
+++ b/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.10.0.schema.json
+PackageIdentifier: Grifnas.OrizontRSS
+PackageVersion: 1.5.3
+PackageLocale: en-US
+Publisher: Grifnas
+PublisherUrl: https://github.com/grifnas
+PublisherSupportUrl: https://github.com/grifnas/OrizontRSS/issues
+Author: Grigore Frișan
+PackageName: Orizont RSS
+PackageUrl: https://grifnas.github.io/OrizontRSS/index.en.html
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/grifnas/OrizontRSS/blob/main/LICENSE
+ShortDescription: Accessible RSS reader for Windows, designed for keyboard and screen-reader use.
+Description: Orizont RSS organizes feeds and articles in folders and provides accessible reading, search, favorites, optional DeepL translation and Gemini features.
+Tags:
+- rss
+- accessibility
+- screen-reader
+- jaws
+- nvda
+- windows
+- wpf
+ReleaseNotesUrl: https://github.com/grifnas/OrizontRSS/releases/tag/v1.5.3
+ManifestType: locale
+ManifestVersion: 1.10.0

--- a/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.locale.ro-RO.yaml
+++ b/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.locale.ro-RO.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Grifnas.OrizontRSS
+PackageVersion: 1.5.3
+PackageLocale: ro-RO
+Publisher: Grifnas
+PublisherUrl: https://github.com/grifnas
+PublisherSupportUrl: https://github.com/grifnas/OrizontRSS/issues
+Author: Grigore Frișan
+PackageName: Orizont RSS
+PackageUrl: https://grifnas.github.io/OrizontRSS/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/grifnas/OrizontRSS/blob/main/LICENSE
+ShortDescription: Cititor RSS accesibil pentru Windows, proiectat pentru tastatură și cititoare de ecran.
+Description: Orizont RSS organizează feeduri și articole în foldere, oferă citire accesibilă, căutare, favorite, traducere DeepL și funcții Gemini opționale.
+Moniker: orizont-rss
+Tags:
+- rss
+- accessibility
+- screen-reader
+- jaws
+- nvda
+- windows
+- wpf
+- romanian
+ReleaseNotesUrl: https://github.com/grifnas/OrizontRSS/releases/tag/v1.5.3
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.yaml
+++ b/manifests/g/Grifnas/OrizontRSS/1.5.3/Grifnas.OrizontRSS.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Grifnas.OrizontRSS
+PackageVersion: 1.5.3
+DefaultLocale: ro-RO
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates the Orizont RSS package submission from 1.5.3 to 1.5.4. The four 1.5.4 manifests passed winget validate; the archive URL and SHA-256 match the published release. CLA signed. The install-manifest test was not run.