### PR TITLE
New package: jelllove.ParallelAgents version 0.1.9

### DIFF
--- a/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.installer.yaml
+++ b/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: jelllove.ParallelAgents
+PackageVersion: 0.1.9
+InstallerType: nullsoft
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-09-09
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jelllove/Parallel-Agents/releases/download/v0.1.9/Parallel.Agents.Setup.0.1.9.exe
+    InstallerSha256: 27E0F47CF4298E80E46A1D1DD7D54133E975F7250EE7D9BB84C2ED0F63C100C1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.locale.en-US.yaml
+++ b/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: jelllove.ParallelAgents
+PackageVersion: 0.1.9
+PackageLocale: en-US
+Publisher: jelllove
+PublisherUrl: https://www.jelllove.com/
+PublisherSupportUrl: https://github.com/jelllove/Parallel-Agents/issues
+Author: jelllove
+PackageName: Parallel Agents
+PackageUrl: https://www.jelllove.com/products/parallel-agents.html
+License: MIT
+LicenseUrl: https://github.com/jelllove/Parallel-Agents/blob/v0.1.9/LICENSE
+Copyright: Copyright (c) 2026 jelllove
+ShortDescription: Run multiple CLI coding agents side by side in one Windows workspace.
+Description: |-
+  Parallel Agents is a Windows desktop workspace for CLI coding assistants, including Claude Code, Codex, GitHub Copilot, and Gemini CLI.
+  Organize sessions by project, use multiple terminal tabs, browse project files, and work with Git.
+  Install and authenticate the coding assistants separately. Their account, subscription, and network requirements apply.
+Tags:
+  - ai
+  - coding
+  - developer-tools
+  - terminal
+ReleaseNotesUrl: https://github.com/jelllove/Parallel-Agents/releases/tag/v0.1.9
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.yaml
+++ b/manifests/j/jelllove/ParallelAgents/0.1.9/jelllove.ParallelAgents.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: jelllove.ParallelAgents
+PackageVersion: 0.1.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description
New package submission by the publisher: **Parallel Agents 0.1.9** (`jelllove.ParallelAgents`).

- Product: https://www.jelllove.com/products/parallel-agents.html
- Source and MIT license: https://github.com/jelllove/Parallel-Agents/tree/v0.1.9
- Official release: https://github.com/jelllove/Parallel-Agents/releases/tag/v0.1.9

## Validation performed
- [x] Checked for an existing package and open PR with the same package name.
- [x] This PR adds only one package/version, with its three manifest files.
- [x] `winget validate --manifest <directory> --disable-interactivity` succeeded using WinGet v1.29.290.
- [x] Downloaded the original release asset and verified SHA-256.
- [x] Read PE metadata: ProductName `Parallel Agents`, ProductVersion/FileVersion `0.1.9`, CompanyName `jelllove`.
- [x] Confirmed the release-tag electron-builder configuration uses an x64 NSIS installer, with its default per-user installation.
- [ ] Tested unattended install/uninstall in Windows Sandbox. Not performed on the shared workstation.
- [ ] Contributor License Agreement, if requested by the CLA bot, must be completed personally by the publisher.

## Review notes
The installer is **not digitally signed**. No claim of Authenticode verification is made. Coding assistants must be installed and authenticated separately; their subscription requirements apply.

This PR is a draft pending installation testing and any required publisher verification. Please do not interpret manifest schema validation as an installation test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432025)