### PR TITLE
New package: SimpleToolsIndia.Koda version 0.1.0

### DIFF
--- a/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.installer.yaml
+++ b/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# The release zip holds koda.exe at its root (Compress-Archive -Path dist/$staging/*),
+# so the nested path is the bare file name. Installed as a portable package:
+# winget puts it in its own links directory and adds that to PATH, which is why
+# there is no installer to run and nothing to uninstall but a file.
+PackageIdentifier: SimpleToolsIndia.Koda
+PackageVersion: 0.1.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: koda.exe
+    PortableCommandAlias: koda
+Commands:
+  - koda
+ReleaseDate: 2026-09-05
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/simpletoolsindia/koda/releases/download/v0.1.0/koda-0.1.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 3FBABEE4EEBD9856930362E680C58C1CA83D5F3227622F61AD606A777CC0EEB4
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.locale.en-US.yaml
+++ b/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# `Moniker: koda` is the line that makes `winget install koda` resolve to this
+# package rather than needing the full SimpleToolsIndia.Koda identifier.
+PackageIdentifier: SimpleToolsIndia.Koda
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Simple Tools India
+PublisherUrl: https://github.com/simpletoolsindia
+PublisherSupportUrl: https://github.com/simpletoolsindia/koda/issues
+PackageName: koda
+PackageUrl: https://github.com/simpletoolsindia/koda
+License: MIT
+LicenseUrl: https://github.com/simpletoolsindia/koda/blob/master/LICENSE
+Copyright: Copyright (c) Simple Tools India
+ShortDescription: Terminal coding agent that drives local LLMs and never leaves your machine
+Description: |-
+  koda is a single-binary terminal coding agent that drives the model you already
+  run locally - Ollama, LM Studio, llama.cpp, vLLM, MLX - and any other server
+  speaking the OpenAI chat API. It reads and edits your code, runs your tests,
+  and shows you a diff before it changes anything.
+Moniker: koda
+Tags:
+  - ai
+  - agent
+  - cli
+  - coding-assistant
+  - developer-tools
+  - llm
+  - local-llm
+  - ollama
+  - terminal
+ReleaseNotesUrl: https://github.com/simpletoolsindia/koda/releases/tag/v0.1.0
+Documentation:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://simpletoolsindia.github.io/koda/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.yaml
+++ b/manifests/s/SimpleToolsIndia/Koda/0.1.0/SimpleToolsIndia.Koda.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: SimpleToolsIndia.Koda
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `SimpleToolsIndia.Koda` version `0.1.0`

koda is a single-binary terminal coding agent that drives a model server you run
yourself (Ollama, LM Studio, llama.cpp, vLLM, MLX, or anything else speaking the
OpenAI chat API). It reads and edits code, runs commands, and shows a diff before
it changes anything.

- Homepage: https://github.com/simpletoolsindia/koda
- Documentation: https://simpletoolsindia.github.io/koda/
- License: MIT

#### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

#### Notes

Installed as a portable package: the release zip contains `koda.exe` at its root,
so `NestedInstallerFiles.RelativeFilePath` is the bare file name and
`PortableCommandAlias` is `koda`. `InstallerSha256` was verified against the
published release asset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432036)