### PR TITLE
New package: from104.QCalc version 0.13.2

### DIFF
--- a/manifests/f/from104/QCalc/0.13.2/from104.QCalc.installer.yaml
+++ b/manifests/f/from104/QCalc/0.13.2/from104.QCalc.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: from104.QCalc
+PackageVersion: 0.13.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/from104/qcalc/releases/download/v0.13.2/QCalc_0.13.2_x64-setup.exe
+  InstallerSha256: 26CA93F3B2DF6463EF4D801099406B757E0E8841D762867D9A156A762520A981
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/f/from104/QCalc/0.13.2/from104.QCalc.locale.en-US.yaml
+++ b/manifests/f/from104/QCalc/0.13.2/from104.QCalc.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: from104.QCalc
+PackageVersion: 0.13.2
+PackageLocale: en-US
+Publisher: Kihyun Seo
+PublisherUrl: https://github.com/from104
+PublisherSupportUrl: https://github.com/from104/qcalc/issues
+PackageName: QCalc
+PackageUrl: https://github.com/from104/qcalc
+License: MIT
+LicenseUrl: https://github.com/from104/qcalc/blob/main/LICENSE
+Copyright: Copyright (c) 2022 Seo KiHyun
+ShortDescription: A multi-purpose calculator for productivity and accessibility
+Description: QCalc packs five specialized calculators (Standard, Unit, Currency, Radix, Formula) and 10 languages into one keyboard-friendly, screen-reader-accessible app.
+Moniker: qcalc
+Tags:
+- accessibility
+- calculator
+- converter
+- currency
+- radix
+- screen-reader
+- unit
+ReleaseNotesUrl: https://github.com/from104/qcalc/releases/tag/v0.13.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/f/from104/QCalc/0.13.2/from104.QCalc.locale.ko-KR.yaml
+++ b/manifests/f/from104/QCalc/0.13.2/from104.QCalc.locale.ko-KR.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: from104.QCalc
+PackageVersion: 0.13.2
+PackageLocale: ko-KR
+Publisher: 서기현
+PackageName: QCalc
+ShortDescription: 생산성과 접근성을 위한 다목적 계산기
+Description: 기본·단위·환율·진법·수식 계산기 5종과 10개 언어를 담은, 키보드와 스크린리더에 친화적인 계산기.
+Tags:
+- 계산기
+- 접근성
+- 단위변환
+- 환율
+- 진법
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/f/from104/QCalc/0.13.2/from104.QCalc.yaml
+++ b/manifests/f/from104/QCalc/0.13.2/from104.QCalc.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: from104.QCalc
+PackageVersion: 0.13.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#validation) your manifest locally with `winget validate --manifest <path>`? (authored on Linux — relying on the pipeline validation)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (same; the installer itself is the released 0.13.2 setup)
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

QCalc — a multi-purpose calculator (standard, unit, currency, radix, formula) with 10 languages and screen-reader support. MIT, open source: https://github.com/from104/qcalc

Installer is the NSIS per-user setup published on GitHub Releases (`Scope: user`, silent `/S` supported).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432041)