### PR TITLE
Update version: OpenJS.Electron.42 version 42.11.3

### DIFF
--- a/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.installer.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.3
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: electron.exe
+  PortableCommandAlias: electron
+UpgradeBehavior: install
+ReleaseDate: 2026-09-08
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.3/electron-v42.11.3-win32-ia32.zip
+  InstallerSha256: BD7458D2EB4BEF90E09597667B99376E37E8BE212722C5762114E189FF82F9C2
+- Architecture: x64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.3/electron-v42.11.3-win32-x64.zip
+  InstallerSha256: 336993FD3FE7423B1DC8C15DB6659AB6F6F07778CC3DE49A295910CF56D6F37E
+- Architecture: arm64
+  InstallerUrl: https://github.com/electron/electron/releases/download/v42.11.3/electron-v42.11.3-win32-arm64.zip
+  InstallerSha256: 0D7745D9983124DC9296E1423F4D3932869D479322540F8511D4762A3E617E8C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.locale.en-US.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.3
+PackageLocale: en-US
+Publisher: OpenJS Foundation
+PublisherUrl: https://openjsf.org/
+PublisherSupportUrl: https://github.com/electron/electron/issues
+PrivacyUrl: https://privacy-policy.openjsf.org/
+PackageName: Electron
+PackageUrl: https://www.electronjs.org/
+License: MIT
+LicenseUrl: https://github.com/electron/electron/blob/HEAD/LICENSE
+ShortDescription: Build cross-platform desktop apps with JavaScript, HTML, and CSS.
+Moniker: electron
+Tags:
+- c-plus-plus
+- chrome
+- css
+- electron
+- html
+- javascript
+- nodejs
+- v8
+- works-with-codespaces
+ReleaseNotes: |-
+  # Release Notes for v42.11.3
+
+  ## Fixes
+
+  • File System Access permission requests and the `file-system-access-restricted` event are scoped to the requesting document, grants are reset when the origin's last page closes, and write access works in in-memory sessions. [#53695](https://github.com/electron/electron/pull/53695) <sup>(Also in [43](https://github.com/electron/electron/pull/53694), [44](https://github.com/electron/electron/pull/53691), [45](https://github.com/electron/electron/pull/53690))</sup>
+  • Fixed `session.setPermissionCheckHandler` receiving the top-level origin and a null `webContents` for `hid` and `usb` checks made from a subframe. [#53736](https://github.com/electron/electron/pull/53736) <sup>(Also in [43](https://github.com/electron/electron/pull/53689), [44](https://github.com/electron/electron/pull/53688), [45](https://github.com/electron/electron/pull/53679))</sup>
+  • Fixed `webContents.on()`, `removeListener()` and `removeAllListeners()` throwing "Object has been destroyed" for `console-message` listeners after the WebContents was destroyed. [#53497](https://github.com/electron/electron/pull/53497) <sup>(Also in [43](https://github.com/electron/electron/pull/53496), [44](https://github.com/electron/electron/pull/53494), [45](https://github.com/electron/electron/pull/53495))</sup>
+  • Fixed a crash on Linux when `process.env` was written while another thread was reading the environment, and a memory leak when a worker thread exits. [#53511](https://github.com/electron/electron/pull/53511) <sup>(Also in [43](https://github.com/electron/electron/pull/53510), [44](https://github.com/electron/electron/pull/53509), [45](https://github.com/electron/electron/pull/53508))</sup>
+  • Fixed a possible crash on Windows when a file dialog was shown for a window that was being closed at the same time. [#53585](https://github.com/electron/electron/pull/53585) <sup>(Also in [43](https://github.com/electron/electron/pull/53584), [44](https://github.com/electron/electron/pull/53583), [45](https://github.com/electron/electron/pull/53586))</sup>
+  • Fixed a renderer crash when the main process sent IPC to, or a page navigated, a same-process `window.open()` child whose `contextIsolation` differed from its opener's. [#53541](https://github.com/electron/electron/pull/53541) <sup>(Also in [43](https://github.com/electron/electron/pull/53540), [44](https://github.com/electron/electron/pull/53539), [45](https://github.com/electron/electron/pull/53538))</sup>
+  • Fixed crashes in `setDisplayMediaRequestHandler` when the granted frame had been destroyed or another tab was granted by id. [#53674](https://github.com/electron/electron/pull/53674) <sup>(Also in [43](https://github.com/electron/electron/pull/53671), [44](https://github.com/electron/electron/pull/53672), [45](https://github.com/electron/electron/pull/53673))</sup>
+  • Internal `<webview>`, `window.close()` and `executeJavaScript` reply IPCs are validated against the sending frame. [#53727](https://github.com/electron/electron/pull/53727) <sup>(Also in [43](https://github.com/electron/electron/pull/53726), [44](https://github.com/electron/electron/pull/53723), [45](https://github.com/electron/electron/pull/53724))</sup>
+  • `<webview>` without `allowpopups` also blocks links opened into a new window by modifier-click, and such windows navigate as the clicking document rather than as a browser-initiated load. [#53719](https://github.com/electron/electron/pull/53719) <sup>(Also in [43](https://github.com/electron/electron/pull/53718), [44](https://github.com/electron/electron/pull/53721), [45](https://github.com/electron/electron/pull/53717))</sup>
+  • `getUserMedia` with `chromeMediaSource：'desktop'` no longer accepts WebContents source ids; use `chromeMediaSource: 'tab'` with `webContents.getMediaSourceId()` or `setDisplayMediaRequestHandler` to capture a WebContents. [#53710](https://github.com/electron/electron/pull/53710) <sup>(Also in [43](https://github.com/electron/electron/pull/53707), [44](https://github.com/electron/electron/pull/53709), [45](https://github.com/electron/electron/pull/53708))</sup>
+  • `nodeIntegrationInWorker` now applies only to workers created by frames that themselves have Node integration; enable `nodeIntegrationInSubFrames` to keep Node in workers created by subframes. [#53713](https://github.com/electron/electron/pull/53713) <sup>(Also in [43](https://github.com/electron/electron/pull/53712), [44](https://github.com/electron/electron/pull/53711), [45](https://github.com/electron/electron/pull/53706))</sup>
+  • `openExternal` permission requests started by a frame that has since gone away are attributed to that frame's origin rather than to the navigating page. [#53697](https://github.com/electron/electron/pull/53697) <sup>(Also in [43](https://github.com/electron/electron/pull/53698), [44](https://github.com/electron/electron/pull/53699), [45](https://github.com/electron/electron/pull/53696))</sup>
+  • `pointerLock` and `keyboardLock` permission requests now report the requesting frame, and `execCommand('paste')` requires user activation in the frame that calls it. [#53702](https://github.com/electron/electron/pull/53702) <sup>(Also in [43](https://github.com/electron/electron/pull/53701), [44](https://github.com/electron/electron/pull/53693), [45](https://github.com/electron/electron/pull/53692))</sup>
+ReleaseNotesUrl: https://github.com/electron/electron/releases/tag/v42.11.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.yaml
+++ b/manifests/o/OpenJS/Electron/42/42.11.3/OpenJS.Electron.42.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: OpenJS.Electron.42
+PackageVersion: 42.11.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update OpenJS.Electron.42 to version 42.11.3.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432048)