### PR TITLE
New package: spacebub.qzdl version 4.3.2

### DIFF
--- a/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.installer.yaml
+++ b/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: spacebub.qzdl
+PackageVersion: 4.3.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{08129329-D9FB-4306-B325-52658A31E56F}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/spacebub/qzdl/releases/download/4.3.2/ZDL4-v4.3.2-win-x64-setup.exe
+  InstallerSha256: F1604414CD82C6F1614536BA39AD18FE0480D32EB6E0E86CF35FC2704C83DE1F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.locale.en-US.yaml
+++ b/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: spacebub.qzdl
+PackageVersion: 4.3.2
+PackageLocale: en-US
+Publisher: spacebub
+PublisherUrl: https://github.com/spacebub
+PublisherSupportUrl: https://github.com/spacebub/qzdl/issues
+PackageName: ZDL4
+PackageUrl: https://github.com/spacebub/qzdl
+License: GPL-3.0-only
+LicenseUrl: https://github.com/spacebub/qzdl/blob/master/LICENSE
+Copyright: Copyright (C) 2007-2010 Cody Harris, 2018-2019 Lcferrum, 2023-2026 spacebub
+ShortDescription: Launcher for Doom engine source ports
+Description: >-
+  ZDL4 is a launcher for Doom engine source ports. Pick a port, pick a game, add
+  PWADs, patches or unpacked mod folders on top, and launch.
+
+  Profiles keep each setup together with its own port config, saves and demo
+  recordings. ZDL4 can also fetch and install supported source ports for you,
+  among them GZDoom, Zandronum, DSDA-Doom, Woof!, Nugget Doom, Chocolate Doom
+  and Crispy Doom.
+
+  ZDL4 is only the launcher. The source port and the game data are yours to get
+  separately.
+Moniker: zdl4
+Tags:
+- doom
+- zdl
+- launcher
+- source-port
+- modding
+- wad
+- iwad
+- pwad
+- uzdoom
+- gzdoom
+- zdoom
+- zandronum
+- dsda-doom
+- chocolate-doom
+- prboom
+- boom
+ReleaseNotesUrl: https://github.com/spacebub/qzdl/blob/master/CHANGELOG
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.yaml
+++ b/manifests/s/spacebub/qzdl/4.3.2/spacebub.qzdl.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: spacebub.qzdl
+PackageVersion: 4.3.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
This PR is for adding the spacebub.qzdl version 4.3.2 package to winget.

ZDL4 is a launcher for Doom engine source ports, it was forked from lcferrum/qzdl but then became its own thing. Future releases will go through the CI pipeline in spacebub/qzdl.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432130)