### PR TITLE
PauloCabral.TucanoProxy.CLI version 0.2.8

### DIFF
--- a/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.installer.yaml
+++ b/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.installer.yaml
@@ -1,0 +1,19 @@
+# Created by scripts/package-managers.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PauloCabral.TucanoProxy.CLI
+PackageVersion: "0.2.8"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: tucano-proxy.exe
+  PortableCommandAlias: tucano-proxy
+UpgradeBehavior: uninstallPrevious
+Commands:
+- tucano-proxy
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/plscabral/tucano-proxy/releases/download/v0.2.8/tucano-proxy-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 585BF8FDA3E8C37F914CF28083FE228BB6D37905F1D8124A34BF71019587A61A
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.locale.en-US.yaml
+++ b/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created by scripts/package-managers.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultlocale.1.10.0.schema.json
+
+PackageIdentifier: PauloCabral.TucanoProxy.CLI
+PackageVersion: "0.2.8"
+PackageLocale: en-US
+Publisher: Paulo Cabral
+PublisherUrl: https://github.com/plscabral
+PublisherSupportUrl: https://github.com/plscabral/tucano-proxy/issues
+Author: Paulo Cabral
+PackageName: Tucano Proxy CLI
+PackageUrl: https://github.com/plscabral/tucano-proxy
+License: MIT
+LicenseUrl: https://github.com/plscabral/tucano-proxy/blob/v0.2.8/LICENSE
+Copyright: Copyright (c) 2026 Paulo Cabral
+ShortDescription: Local HTTP(S) inspection for terminals, browsers and coding agents.
+Description: |-
+  Standalone native HTTP(S) inspection proxy with a terminal UI, local web
+  inspector, named sessions, request replay and coding-agent integrations.
+  This package installs the command-line application, not the desktop app.
+Moniker: tucano-proxy
+Tags:
+- cli
+- developer-tools
+- http
+- https
+- proxy
+- tui
+ReleaseNotesUrl: https://github.com/plscabral/tucano-proxy/releases/tag/v0.2.8
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.yaml
+++ b/manifests/p/PauloCabral/TucanoProxy/CLI/0.2.8/PauloCabral.TucanoProxy.CLI.yaml
@@ -1,0 +1,8 @@
+# Created by scripts/package-managers.py
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PauloCabral.TucanoProxy.CLI
+PackageVersion: "0.2.8"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds the standalone Tucano Proxy CLI 0.2.8 (not the desktop application).

Release: https://github.com/plscabral/tucano-proxy/releases/tag/v0.2.8

The x64 portable ZIP is the same native release artifact used by the standalone installer; its SHA-256 is verified by scripts/package-managers.py before manifest generation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432131)