### PR TITLE
Add OMP Switch 0.6.0

### DIFF
--- a/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.installer.yaml
+++ b/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: skh2945932142.OMPSwitch
+PackageVersion: 0.6.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+# Per-user NSIS install: OMP Switch stores credentials with the Windows user's DPAPI key, so a
+# per-machine install would produce a vault the other accounts on the box cannot read.
+Scope: user
+ReleaseDate: 2026-09-10
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/skh2945932142/omp-switch/releases/download/v0.6.0/OMP-Switch-Setup-0.6.0.exe
+    InstallerSha256: 8fb8c741e7e1c31c19e49ab9ad08a8599389c9c9f6a92c0f7cf103b549b946f1
+    InstallerSwitches:
+      Silent: /S
+      SilentWithProgress: /S
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.locale.en-US.yaml
+++ b/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: skh2945932142.OMPSwitch
+PackageVersion: 0.6.0
+PackageLocale: en-US
+Publisher: OMP Switch contributors
+PublisherUrl: https://github.com/skh2945932142
+PublisherSupportUrl: https://github.com/skh2945932142/omp-switch/issues
+PackageName: OMP Switch
+PackageUrl: https://github.com/skh2945932142/omp-switch
+License: MIT
+LicenseUrl: https://github.com/skh2945932142/omp-switch/blob/main/LICENSE
+ShortDescription: Desktop companion for managing Oh My Pi model providers
+Description: |-
+  OMP Switch edits the Oh My Pi configuration files you already own (~/.omp/agent/models.yml and
+  config.yml). Writes are hash-guarded against external edits, YAML comments and unknown fields are
+  preserved, and a snapshot is taken before every commit. API keys are never written into the
+  configuration: they are encrypted with the Windows user's DPAPI key and referenced by command.
+  Unknown Oh My Pi schema versions are opened read-only rather than migrated.
+Moniker: omp-switch
+Tags:
+  - ai
+  - cli
+  - configuration
+  - llm
+  - oh-my-pi
+ReleaseNotesUrl: https://github.com/skh2945932142/omp-switch/releases/tag/v0.6.0
+Documentations:
+  - DocumentLabel: Installation and downloads
+    DocumentUrl: https://github.com/skh2945932142/omp-switch/blob/main/docs/install.md
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.yaml
+++ b/manifests/s/skh2945932142/OMPSwitch/0.6.0/skh2945932142.OMPSwitch.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Submitted to microsoft/winget-pkgs. `scripts/render-packaging.ps1` fills the version and hash from
+# a built release before submission; the committed values are the last released ones.
+PackageIdentifier: skh2945932142.OMPSwitch
+PackageVersion: 0.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version: skh2945932142.OMPSwitch 0.6.0

#### What's new in 0.6.0

- **Linux support for the desktop app** (AppImage/deb), a terminal UI, and the credential vault (libsecret primary, age fallback)
- Windows behavior unchanged; installer remains the per-user NSIS build
- Full notes: https://github.com/skh2945932142/omp-switch/releases/tag/v0.6.0

#### Package maintenance

- Publisher: skh2945932142 (package owner, same as 0.3.0)
- Installer SHA256 matches the published release asset (SHA256SUMS.txt):
  `8fb8c741e7e1c31c19e49ab9ad08a8599389c9c9f6a92c0f7cf103b549b946f1`
- Manifests rendered from the repository's packaging templates (`scripts/render-packaging.mjs`) against the published assets

#### Checklist

- [x] Manifests are in the correct `manifests/<first letter>/<Publisher>/<Package>/<Version>` layout
- [x] PackageVersion matches the release tag (0.6.0)
- [x] InstallerSha256 matches the published installer
- [x] ReleaseNotesUrl points at the v0.6.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432139)