### PR TITLE
New version: FreedomTerminal.Koegaki version 1.4.0

### DIFF
--- a/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.installer.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.4.0
+InstallerType: nullsoft
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://koegaki.com/downloads/Koegaki-1.4.0-setup.exe
+    InstallerSha256: 812FFEB966C75FA4DAA5C321DFB023200FF23CA25DB4F9BEEEED223D1FDBB980
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.locale.en-US.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Freedom Terminal
+PublisherUrl: https://freedom-terminal.com
+PackageName: Koegaki
+PackageUrl: https://koegaki.com
+License: Proprietary
+Copyright: Copyright Vishut Dhar
+ShortDescription: Private push-to-talk dictation that runs entirely on your machine.
+Description: Koegaki is push-to-talk dictation for Windows. Hold a key, speak, and your words appear wherever you are typing. The speech model runs entirely on-device, so audio and text never leave your machine. No account, no cloud, no subscription. 30-day free trial, then a one-time purchase covers Mac and Windows.
+Moniker: koegaki
+Tags:
+  - dictation
+  - speech-to-text
+  - voice-typing
+  - offline
+  - privacy
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.yaml
+++ b/manifests/f/FreedomTerminal/Koegaki/1.4.0/FreedomTerminal.Koegaki.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FreedomTerminal.Koegaki
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

New version: FreedomTerminal.Koegaki version 1.4.0.

Same package as 1.2.1 (merged in #415017), new installer. This version adds an optional on-device text cleanup pass; the speech model and everything else still run entirely on the machine.

Notes for reviewers:
- The installer is not code signed, as with 1.2.1. It is served as a static file from the publisher's site (the URL in the manifest) and the SHA-256 in the manifest was verified against the served bytes.
- `winget validate --manifest` and `winget install --manifest` were both run on Windows 11 before submission ("Successfully verified installer hash", "Successfully installed", exit 0).

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432151)