### PR TITLE
New version: aahepburn.RAGAssistantForZotero version 0.5.2

### DIFF
--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.installer.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.installer.yaml
@@ -1,0 +1,25 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.5.2
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ProductCode: e8528705-bc8e-5d08-a5f0-e8670566b2dd
+ReleaseDate: 2026-09-09
+AppsAndFeaturesEntries:
+- DisplayName: RAG Assistant 0.5.2
+  ProductCode: e8528705-bc8e-5d08-a5f0-e8670566b2dd
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Quiet-Signals-Lab/RAG-Assistant-for-Zotero/releases/download/v0.5.2/RAG.Assistant-0.5.2-win-x64.exe
+  InstallerSha256: 386D4B621005D7A00B36B243BC21249066B6A3636F88E99263AC964EC817C2D3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.locale.en-US.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.locale.en-US.yaml
@@ -1,0 +1,58 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.5.2
+PackageLocale: en-US
+Publisher: Alexander Hepburn
+PublisherUrl: https://github.com/aahepburn
+PublisherSupportUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero/issues
+PackageName: RAG Assistant for Zotero
+PackageUrl: https://github.com/aahepburn/RAG-Assistant-for-Zotero
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Quiet-Signals-Lab/RAG-Assistant-for-Zotero/blob/HEAD/LICENSE
+ShortDescription: AI-powered research assistant for your Zotero library
+Description: |-
+  RAG Assistant for Zotero is an AI-powered research assistant that lets you
+  chat with your Zotero library using natural language. It uses retrieval-
+  augmented generation (RAG) to provide cited answers from your research
+  papers and documents, and works with local models (Ollama) or cloud APIs
+  (OpenAI, Anthropic, Google, Mistral, and others).
+Tags:
+- ai
+- assistant
+- llm
+- productivity
+- rag
+- research
+- zotero
+ReleaseNotes: |-
+  RAG Assistant for Zotero v0.5.2
+  - Now licensed under GPLv3. The project has moved from Apache 2.0 to the GNU
+    General Public License v3.0 or later. Releases up to v0.5.1 remain Apache 2.0.
+  - Fixed: indexing crashed on non-English Windows systems. Indexing could fail
+    with a 'charmap' codec can't encode character error. The backend now runs
+    fully in UTF-8, so libraries with accented, CJK or otherwise non-Latin text
+    index normally. (#79, reported by @cemalkoraybingol)
+  - Fixed: Scope filtering by Collection returned far too many items. Selecting
+    a collection also matched every collection whose name merely contained it —
+    picking "NLP" pulled in everything filed under "NLP Interpretability" too.
+    Collections and tags are now matched exactly. (#75, reported by @santiagobaraona)
+  - Fixed: Scope filtering by Tag returned nothing. The item counter used a
+    case-sensitive comparison that a search elsewhere in the app didn't, so a valid
+    tag could report "0 items in scope". (#75)
+  - The Scope panel now explains itself. It no longer leaves a stale count on
+    screen when something goes wrong, and tells you when a filter matches nothing
+    because the tag or collection was changed in Zotero after indexing — in which
+    case, sync metadata in Settings.
+  - macOS 12 or later is now correctly stated as the requirement. The app has
+    needed macOS 12 since v0.5.0 but advertised macOS 11, so it could be installed
+    on macOS 11 and then fail to launch. Nothing changes for macOS 12+ users.
+  - Security: 39 of 41 outstanding dependency advisories resolved, including 3
+    critical and 17 high. This included removing an unused build dependency that
+    accounted for 9 of them, several with no upstream fix available.
+  - Updating is automatic — the app will offer v0.5.2 on next launch. Homebrew users
+    can run brew upgrade --cask rag-assistant-for-zotero.
+ReleaseNotesUrl: https://github.com/Quiet-Signals-Lab/RAG-Assistant-for-Zotero/releases/tag/v0.5.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.yaml
+++ b/manifests/a/aahepburn/RAGAssistantForZotero/0.5.2/aahepburn.RAGAssistantForZotero.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: aahepburn.RAGAssistantForZotero
+PackageVersion: 0.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Manifests generated by [komac](https://github.com/russellbanks/Komac) v2.16.0 via WinGet Releaser and submitted manually, as the automated submission step could not create the branch.

- Installer: single `nullsoft` x64 entry, SHA256 verified against the published release asset.
- License updated to `GPL-3.0-or-later` — the project relicensed from Apache-2.0 in this version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432197)