### PR TITLE
New version: RedEyeNetworks.HopMatrix version 1.19.0

### DIFF
--- a/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.installer.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.19.0
+InstallerType: inno
+Scope: machine
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  Custom: /NORESTART
+UpgradeBehavior: install
+Commands:
+- HopMatrix
+Installers:
+- Architecture: x64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.19.0/HopMatrix-win-x64-setup.exe
+  InstallerSha256: CC8A0E0EB9748BAB84C2930C53E76CD60E1E6B725CE806833E9A8B3E6180E67D
+- Architecture: x64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.19.0/HopMatrix-win-x64-machine-setup.exe
+  InstallerSha256: D582DB8B2862D43F15A7388C1BE682A24158650F99E22C4F99F07D37ECC7F946
+- Architecture: arm64
+  Scope: user
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.19.0/HopMatrix-win-arm64-setup.exe
+  InstallerSha256: 00886C4A016F4A662EB8E985E5DC600AD9BC8DB1E2949DC02E2D2E8C321CBB08
+- Architecture: arm64
+  Scope: machine
+  ElevationRequirement: elevatesSelf
+  InstallerUrl: https://download.redeyenetworks.com/hopmatrix/releases/1.19.0/HopMatrix-win-arm64-machine-setup.exe
+  InstallerSha256: 92D5FC835CD9A0357A67B144014F6631F3E623D044E86A7DD9C13A18DDB8153A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.locale.en-US.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.19.0
+PackageLocale: en-US
+Publisher: RedEye Network Solutions LLC
+PublisherUrl: https://redeyenetworks.com
+PublisherSupportUrl: https://redeyenetworks.com/support
+Author: RedEye Network Solutions LLC
+PackageName: HopMatrix
+PackageUrl: https://redeyenetworks.com
+License: Proprietary
+Copyright: Copyright 2025-2026 RedEye Network Solutions LLC. All rights reserved.
+ShortDescription: Visual multi-path traceroute, network monitoring, and analysis platform
+Description: |-
+  HopMatrix is a portable, single-executable, cross-platform network analysis platform
+  with eight operational modes: Trace, Monitor, iPerf, OUI/MAC Lookup, Routing Analyzer,
+  SNMP, Multicast and L2 Inspector, plus Quick Tools, a Tools menu of utility dialogs that open over
+  whichever mode is on screen. Features continuous multi-path traceroute with real-time
+  topology visualization, 256-endpoint fleet monitoring, iperf3-compatible bandwidth
+  testing, SNMP v1/v2c/v3 discovery, and multicast/CDP/LLDP analysis.
+Moniker: hopmatrix
+Tags:
+- traceroute
+- network
+- monitoring
+- bandwidth
+- iperf
+- snmp
+- multicast
+- network-analysis
+- pathping
+- topology
+- cdp
+- lldp
+- nmap
+- oui
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.yaml
+++ b/manifests/r/RedEyeNetworks/HopMatrix/1.19.0/RedEyeNetworks.HopMatrix.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RedEyeNetworks.HopMatrix
+PackageVersion: 1.19.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
HopMatrix v1.19.0 ships two distinct installers per architecture (user-scope + machine-scope), matching the Microsoft.PowerToys + Notepad++.Notepad++ convention. Each (architecture, scope) tuple maps to a unique Inno Setup EXE with a single, deterministic `PrivilegesRequired` value, so Microsoft's dynamic-scan validation has unambiguous install behavior to verify per installer entry.

Manifest construction is now done in HopMatrix's release.yml as a hand-built heredoc (not `wingetcreate update`) so the 4-entry shape is locked from version 1 — the previous wingetcreate-based flow inherited shape from the latest published manifest, which couldn't grow installer-entry count cleanly.

The manifests are composed and SHA256-pinned by the release pipeline from the same artifacts published to the download host; the pipeline runs on Linux and does not run `winget validate`, so validation is deferred to this repository's own checks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432282)