### PR TITLE
New version: AurelioAvila.PCTweaker version 1.12.1

### DIFF
--- a/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.installer.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.installer.yaml
@@ -1,0 +1,27 @@
+# Updated by Aurelio Avila
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.12.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: /S
+UpgradeBehavior: install
+ProductCode: pc-tweaker-app
+ReleaseDate: 2026-09-10
+AppsAndFeaturesEntries:
+- DisplayName: pc-tweaker-app
+  ProductCode: pc-tweaker-app
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\pc-tweaker-app'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/download/v1.12.1/pc-tweaker-app_1.12.1_x64-setup.exe
+  InstallerSha256: 53E053190F083A00DE676AA87E53C1B8E82578865E3361CDBBDDC67DDB715305
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.locale.en-US.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# Updated by Aurelio Avila
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.12.1
+PackageLocale: en-US
+Publisher: Aurelio Avila
+PublisherUrl: https://github.com/AurelioAvila
+PublisherSupportUrl: https://github.com/AurelioAvila/pc-tweaker-app/issues
+PackageName: PC Tweaker
+PackageUrl: https://github.com/AurelioAvila/pc-tweaker-app
+License: Proprietary
+LicenseUrl: https://github.com/AurelioAvila/pc-tweaker-app/blob/HEAD/LICENSE
+ShortDescription: Windows tuning for performance, gaming and privacy, with recorded changes and restore tools for supported settings.
+Description: PC Tweaker provides 61 Windows tweaks, including 37 Free, plus hardware monitoring and maintenance tools. Review settings, save profiles and restore supported changes from recorded originals. Cleanup and repair operations have separate recovery limits. Version 1.9.0 adds five native AC power controls and digitally signed Windows installers from Aurelio Avila. Pro adds advanced tools and automatic game sessions; Lifetime includes profile comparison and portable tuning reports.
+Tags:
+- gaming
+- optimizer
+- performance
+- privacy
+- tweak
+- windows
+ReleaseNotes: |-
+  Signed licenses now include the paid-period expiry. Native Pro checks enforce that cutoff while offline, alongside the existing refresh limit. Lifetime and older signed-cache compatibility are preserved.
+  Windows installers and application files are digitally signed by Aurelio Avila and timestamped. Automatic updates also carry the separate updater signature.
+ReleaseNotesUrl: https://github.com/AurelioAvila/pc-tweaker-app/releases/tag/v1.12.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.yaml
+++ b/manifests/a/AurelioAvila/PCTweaker/1.12.1/AurelioAvila.PCTweaker.yaml
@@ -1,0 +1,8 @@
+# Updated by Aurelio Avila
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AurelioAvila.PCTweaker
+PackageVersion: 1.12.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
PC Tweaker 1.12.1. The Windows installer has verified Aurelio Avila Authenticode signing and a trusted timestamp. The manifest uses the SHA-256 of the published installer. Local winget manifest validation and isolated installer upgrade checks passed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432334)