### PR TITLE
New package: from104.UNIM version 0.4.3

### DIFF
--- a/manifests/f/from104/UNIM/0.4.3/from104.UNIM.installer.yaml
+++ b/manifests/f/from104/UNIM/0.4.3/from104.UNIM.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: from104.UNIM
+PackageVersion: 0.4.3
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+ElevationRequirement: elevationRequired
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{9B5DD33F-E9C0-427B-897B-AAE0304F7257}'
+AppsAndFeaturesEntries:
+- DisplayName: UNIM Korean IME
+  Publisher: atit.org
+  ProductCode: '{9B5DD33F-E9C0-427B-897B-AAE0304F7257}'
+  UpgradeCode: '{4F1A2B3C-5D6E-7F80-9A1B-2C3D4E5F6A7B}'
+  InstallerType: wix
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/from104/unim/releases/download/v0.4.3/unim-0.4.3-x64.msi
+  InstallerSha256: BF7EDD575C9B87E5006AD6CEAD964F53BE8F1BDAF88D43E3476BDE3CB9FCC809
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/from104/UNIM/0.4.3/from104.UNIM.locale.en-US.yaml
+++ b/manifests/f/from104/UNIM/0.4.3/from104.UNIM.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: from104.UNIM
+PackageVersion: 0.4.3
+PackageLocale: en-US
+Publisher: Kihyun Seo
+PublisherUrl: https://github.com/from104
+PublisherSupportUrl: https://github.com/from104/unim/issues
+PackageName: UNIM
+PackageUrl: https://github.com/from104/unim
+License: MIT
+LicenseUrl: https://github.com/from104/unim/blob/main/LICENSE
+Copyright: Copyright (c) 2024-2026 from104
+ShortDescription: Korean input method (IME) with automatic Hangul/English typo correction
+Description: |-
+  UNIM is a Korean input method for Windows (TSF) and Linux built on one shared engine.
+  It automatically corrects Hangul/English mode typos (a mistyped "dkssud" becomes "안녕"), enters Hanja, symbols and emoji from a single key, and keeps composition rules, keyboard layouts and settings identical on both platforms.
+  Designed around minimizing keystrokes and letting the software fix mistakes instead of the user.
+Moniker: unim
+Tags:
+- accessibility
+- autocorrect
+- hangul
+- hanja
+- ime
+- input-method
+- keyboard
+- korean
+- tsf
+ReleaseNotesUrl: https://github.com/from104/unim/releases/tag/v0.4.3
+InstallationNotes: Sign out and back in (or restart) after installing so Windows registers the input method and its tray menu.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/from104/UNIM/0.4.3/from104.UNIM.locale.ko-KR.yaml
+++ b/manifests/f/from104/UNIM/0.4.3/from104.UNIM.locale.ko-KR.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: from104.UNIM
+PackageVersion: 0.4.3
+PackageLocale: ko-KR
+Publisher: 서기현
+PackageName: UNIM
+ShortDescription: 한/영 오타를 자동으로 되돌리는 한국어 입력기
+Description: |-
+  Windows(TSF)와 리눅스에서 같은 엔진으로 도는 한국어 입력기입니다.
+  한/영을 잘못 두고 친 글자를 자동으로 되돌리고("dkssud" → "안녕"), 키 하나로 한자·특수문자·이모지를 넣으며, 조합 규칙·자판·설정이 두 운영체제에서 동일합니다.
+  입력 횟수를 줄이고 실수는 프로그램이 수습한다는 원칙으로 만들었습니다.
+Tags:
+- 한국어
+- 한글
+- 한자
+- 입력기
+- 접근성
+- 오타교정
+InstallationNotes: 설치 후 로그아웃했다가 다시 로그인(또는 재시작)해야 Windows 가 입력기와 트레이 메뉴를 등록합니다.
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/f/from104/UNIM/0.4.3/from104.UNIM.yaml
+++ b/manifests/f/from104/UNIM/0.4.3/from104.UNIM.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: from104.UNIM
+PackageVersion: 0.4.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **from104.UNIM** version **0.4.3** — a Korean input method (IME) for Windows (TSF) with automatic Hangul/English typo correction. MIT-licensed, open source: https://github.com/from104/unim

Installer: WiX MSI (per-machine, x64). Supersedes #432087 (0.4.2), whose dynamic validation failed with `Validation-Shell-Execute` because that MSI launched a resident helper process right after install even under `/qn`. 0.4.3 fixes the installer: silent installs launch nothing. The manifest declares `ElevationRequirement: elevationRequired` (per-machine MSI) and a dependency on `Microsoft.VCRedist.2015+.x64` (binaries link the VC++ runtime dynamically). `ProductCode`/`UpgradeCode`/`AppsAndFeaturesEntries` are taken from the MSI Property table. Locales: en-US (default) and ko-KR.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change (#432087 for 0.4.2 is being closed in favor of this one)
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — authored on Linux; validated against the 1.12.0 JSON schemas instead
- [ ] Tested manifest locally with `winget install --manifest <path>` — see above; relying on the pipeline
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432347)