### PR TITLE
New package: MangoDisk.MangoDisk version 1.1.3

### DIFF
--- a/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.installer.yaml
+++ b/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MangoDisk.MangoDisk
+PackageVersion: 1.1.0
+InstallerType: nullsoft
+Scope: user
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+ProductCode: MangoDisk
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/harry0703/MangoDisk/releases/download/v1.1.0/MangoDisk-1.1.0-windows.exe
+  InstallerSha256: E7679D6EB5540BDE4A8DF1FB6B67B8EEFA0663E4385418EC99DA78A23AE867E3
+ReleaseDate: 2026-09-09
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.locale.en-US.yaml
+++ b/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MangoDisk.MangoDisk
+PackageVersion: 1.1.0
+PackageLocale: en-US
+Publisher: MangoDisk
+PublisherUrl: https://mangodisk.app/
+PublisherSupportUrl: https://github.com/harry0703/MangoDisk/issues
+Author: Harry0703
+PackageName: MangoDisk
+PackageUrl: https://mangodisk.app/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/harry0703/MangoDisk/blob/main/LICENSE
+ShortDescription: Disk analysis and cleanup for Windows and macOS
+Description: MangoDisk is a desktop application for analyzing disk usage, finding large and duplicate files, cleaning unnecessary data, uninstalling applications, and managing startup items. Preview scan results and choose what to clean before making changes.
+Moniker: mangodisk-gui
+Tags:
+- cleaner
+- cleanup
+- disk
+- duplicate-files
+- storage
+ReleaseNotesUrl: https://github.com/harry0703/MangoDisk/releases/tag/v1.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.yaml
+++ b/manifests/m/MangoDisk/MangoDisk/1.1.0/MangoDisk.MangoDisk.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MangoDisk.MangoDisk
+PackageVersion: 1.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update this initial desktop package submission to MangoDisk 1.1.3. Only the latest version manifests are retained.

Release: https://github.com/harry0703/MangoDisk/releases/tag/v1.1.3

## Validation

- [x] winget validate --manifest passed.
- [x] Installed the local manifest in a Windows 11 interactive standard-user session without hash or signature bypasses.
- [x] Verified version 1.1.3 and valid Apowersoft Ltd Authenticode signature.
- [x] Verified silent installation, uninstall registration, and GUI window startup.
- [x] Declared WebView2 Runtime dependency (minimum 111.0.1661.62).
- [x] Restored LocalManifestFiles to its original setting after testing.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com).
- Linked issue: not applicable to this version update.

## 📦 Manifest Checklist

- [x] Checked for other open pull requests for this package and version.
- [x] This PR modifies one package manifest set for one version only.
- [x] Validated locally with winget validate --manifest.
- [x] Tested locally with winget install --manifest.
- [x] Manifests conform to schema 1.12.0.
