### PR TITLE
New package: Pesch.RouteConverter version 3.6

### DIFF
--- a/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.installer.yaml
+++ b/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Pesch.RouteConverter
+PackageVersion: "3.6"
+InstallerType: portable
+Commands:
+  - RouteConverter
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://releases.routeconverter.com/previous-releases/3.6/RouteConverterWindows.exe
+    InstallerSha256: 6F2BDD28EE1B412A4E70812D6D001E888FCA4C9856566D0012B0C610E4BE586F
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.locale.en-US.yaml
+++ b/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Pesch.RouteConverter
+PackageVersion: "3.6"
+PackageLocale: en-US
+Publisher: Christian Pesch
+PublisherUrl: https://www.routeconverter.com/
+PublisherSupportUrl: https://forum.routeconverter.com/
+PackageName: RouteConverter
+PackageUrl: https://www.routeconverter.com/
+License: GPL-2.0-only
+LicenseUrl: https://github.com/cpesch/RouteConverter/blob/master/LICENSE-GPL.txt
+ShortDescription: Convert, edit and visualize GPS routes, tracks and waypoints
+Description: >-
+  RouteConverter reads, converts, edits and writes routes, tracks and
+  waypoints between over 100 GPS data formats (GPX, KML, TCX, OVL, NMEA and
+  more). It shows routes on offline maps as well as online map services and
+  lets you edit positions, elevations and descriptions directly on the map.
+Moniker: routeconverter
+Tags:
+  - gps
+  - gpx
+  - routing
+  - maps
+  - navigation
+  - outdoor
+ReleaseNotesUrl: https://github.com/cpesch/RouteConverter/releases/tag/3.6
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.yaml
+++ b/manifests/p/Pesch/RouteConverter/3.6/Pesch.RouteConverter.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Pesch.RouteConverter
+PackageVersion: "3.6"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
RouteConverter converts, edits and visualizes GPS routes, tracks and waypoints between over 100 formats (GPX, KML, TCX, OVL, NMEA, and more). It shows routes on offline maps and online map services and lets you edit positions, elevations and descriptions directly on the map.

- Homepage: https://www.routeconverter.com/
- Source: https://github.com/cpesch/RouteConverter
- License: GPL-2.0-only

The Windows distribution (`RouteConverterWindows.exe`) is a self-extracting NSIS launcher that unpacks a bundled JRE + jar into `%LocalAppData%` and runs it directly — it never writes an Add/Remove Programs entry or registers an uninstaller, so `InstallerType: portable` is used rather than `nsis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432401)