### PR TITLE
New package: Tegrona.TegronaLite version 1.0.1

### DIFF
--- a/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.installer.yaml
+++ b/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tegrona.TegronaLite
+PackageVersion: 1.0.1
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+MinimumOSVersion: 10.0.14393.0
+UpgradeBehavior: install
+FileExtensions:
+- solar
+ProductCode: '{06D2AF9E-F574-4984-AF1A-EE3A8B247250}_is1'
+ReleaseDate: 2026-08-27
+AppsAndFeaturesEntries:
+- DisplayName: Tegrona Lite
+  Publisher: Tegrona
+  DisplayVersion: 1.0.1
+  ProductCode: '{06D2AF9E-F574-4984-AF1A-EE3A8B247250}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://tegrona.com/Tegrona-Lite-1.0.1-win-x64-setup.exe
+  InstallerSha256: 94A3CEF089DC312238526D2348A1516BB1F04465A886953C57A3EF1EB464CBAA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.locale.en-US.yaml
+++ b/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tegrona.TegronaLite
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: Tegrona
+PublisherUrl: https://tegrona.com/
+PublisherSupportUrl: https://tegrona.com/lite/
+PrivacyUrl: https://api.tegrona.com/privacy
+Author: Michael Scherer
+PackageName: Tegrona Lite
+PackageUrl: https://tegrona.com/lite/
+License: Proprietary
+Copyright: Copyright (c) 2026 Michael Scherer
+ShortDescription: Solar panel layout from a roof photo, with the scale and perspective read from the roof tiles.
+Description: |-
+  Tegrona Lite turns a photograph of a roof into a solar panel layout with real dimensions. You mark one roof face on a drone shot, an aerial view or a plan, and the app removes the perspective and reads the scale from the roof tile courses themselves, so no tape measure, site survey or address lookup is needed.
+  Auto-fill places the modules around chimneys, dormers and skylights drawn as exclusion zones, with the edge setback set in centimetres, and reports module count, system power in kWp, covered area and the mid and end clamp counts. The result exports as an A4 spec sheet in PNG or PDF with the layout drawn over the original photograph; projects are saved as .solar files that also open in the macOS and browser versions.
+  It is layout software, not a full PV design suite: there is no 3D model, no yield simulation, no string design and no bill of materials.
+  Free, with no account, no trial timer and no module limit. The photograph never leaves the machine; the app sends anonymous usage statistics that can be switched off in the settings.
+Moniker: tegrona-lite
+Tags:
+- photovoltaic
+- pv
+- roof
+- solar
+- solar-panels
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.yaml
+++ b/manifests/t/Tegrona/TegronaLite/1.0.1/Tegrona.TegronaLite.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tegrona.TegronaLite
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package **Tegrona.TegronaLite** version **1.0.1**.

Tegrona Lite is a free desktop app that turns a photograph of a roof into a solar panel layout with real dimensions: the scale and perspective are read from the roof tile courses in the photo, and the app reports module count, kWp, covered area and clamp counts. Inno Setup 6 installer, per-user (`PrivilegesRequired=lowest`), x64, registers the `.solar` project file type. Homepage: https://tegrona.com/lite/

Notes for validation:
- The installer is not Authenticode-signed.
- The `[Run]` entry carries `skipifsilent`, so nothing is launched during a silent install.
- The app sends anonymous usage statistics (opt-out in settings); `PrivacyUrl` is set accordingly.
- Submitted by the developer.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — will complete when the CLA bot prompts
- [ ] Linked to an issue (if applicable) — none

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — not possible: the manifest was authored on macOS. All three files were validated against the official 1.12.0 JSON schemas instead, and the installer URL/SHA256 were verified against the live download.
- [ ] Tested manifest locally with `winget install --manifest <path>` — not possible on macOS; relying on the pipeline's installation test.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432403)