### PR TITLE
New package: QymIsTech.QymCAD version 0.1.0-dev.20260910

### DIFF
--- a/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.installer.yaml
+++ b/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# THE PRODUCT CODE IS WHAT LETS WINGET RECOGNISE WHAT IT INSTALLED. Without it "winget upgrade" cannot tell
+# that the QymCAD in "Apps & features" is the one it put there, and the package looks permanently
+# up-to-date or permanently missing. It is computed from the version by packaging/win/build-msi.ps1 and
+# written into this file by packaging/winget/update-manifests.sh.
+PackageIdentifier: QymIsTech.QymCAD
+PackageVersion: "0.1.0-dev.20260910"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: "1933FFB6-CFA9-5EAE-B9EF-271E135EFDE0"
+ReleaseDate: "2026-09-10"
+Installers:
+  - Architecture: x64
+    InstallerUrl: "https://github.com/QymIs-Tech/QymCAD/releases/download/v0.1.0-dev.20260910/qymcad-0.1.0-dev.20260910-x64.msi"
+    InstallerSha256: "0d0b812844a75292bbfc8bbdf1a8f36da38d7aa9149df24459c5c0e26bcc6f27"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.locale.en-US.yaml
+++ b/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: QymIsTech.QymCAD
+PackageVersion: "0.1.0-dev.20260910"
+PackageLocale: en-US
+Publisher: QymIsTech
+PublisherUrl: https://github.com/QymIs-Tech
+PackageName: QymCAD
+PackageUrl: https://github.com/QymIs-Tech/QymCAD
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/QymIs-Tech/QymCAD/blob/main/LICENSE
+ShortDescription: Parametric associative B-rep CAD/CAM
+Description: >-
+  A desktop CAD with a parametric sketcher, a feature timeline, assemblies with joints, and CAM.
+  Sketches, features and assemblies stay associative: a dimension changed in the middle of the
+  timeline rebuilds everything that stands on it.
+Tags:
+  - cad
+  - cam
+  - cnc
+  - 3d
+  - modeling
+  - parametric
+  - b-rep
+  - engineering
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.yaml
+++ b/manifests/q/QymIsTech/QymCAD/0.1.0-dev.20260910/QymIsTech.QymCAD.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#
+# The version file of the winget manifest. Three files make one manifest: this, the default locale, and the
+# installer. They are copied into microsoft/winget-pkgs under
+# manifests/q/QymIsTech/QymCAD/<PackageVersion>/ and submitted as a pull request.
+PackageIdentifier: QymIsTech.QymCAD
+PackageVersion: "0.1.0-dev.20260910"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **QymIsTech.QymCAD** version **0.1.0-dev.20260910**.

QymCAD is a parametric CAD with a constraint sketcher, a feature timeline, assemblies with joints and CAM. The installer is an MSI built with WiX and published as an asset of the upstream GitHub release.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable) — N/A, this is a new package

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` — not run before submission; the three files were validated against the published 1.12.0 JSON schemas instead
- [ ] Tested manifest locally with `winget install --manifest <path>` — not run before submission
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432424)