### PR TITLE
New version: ZeroC.IceServices version 3.8.3

### DIFF
--- a/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.installer.yaml
+++ b/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.installer.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ZeroC.IceServices
+PackageVersion: 3.8.3
+InstallerType: burn
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.zeroc.com/ice/3.8/Ice-Services-3.8.3.exe
+  InstallerSha256: 2B24254EB36663952FA7483238087DD43FD16F06E37713465849D4294673FA81
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.locale.en-US.yaml
+++ b/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ZeroC.IceServices
+PackageVersion: 3.8.3
+PackageLocale: en-US
+Publisher: ZeroC, Inc.
+PublisherUrl: https://zeroc.com
+PackageName: Ice Services
+PackageUrl: https://zeroc.com/ice
+License: GPL-2.0-only
+LicenseUrl: https://github.com/zeroc-ice/ice/blob/main/LICENSE
+Copyright: Copyright (c) ZeroC, Inc. All rights reserved.
+ShortDescription: IceGrid, IceStorm, and Glacier2 services for the Ice RPC framework
+Description: Ice Services provides the server-side services for the Ice RPC framework, including IceGrid for location and deployment, IceStorm for publish-subscribe messaging, and Glacier2 for firewall traversal.
+Tags:
+- ice
+- rpc
+- zeroc
+- icegrid
+- icestorm
+- glacier2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.yaml
+++ b/manifests/z/ZeroC/IceServices/3.8.3/ZeroC.IceServices.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ZeroC.IceServices
+PackageVersion: 3.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds manifests for ZeroC.IceServices 3.8.3.

- Installer: https://download.zeroc.com/ice/3.8/Ice-Services-3.8.3.exe
- SHA256: `2B24254EB36663952FA7483238087DD43FD16F06E37713465849D4294673FA81`

The manifests were generated and validated with wingetcreate 1.12.13 from the release publishing workflow.

Note on the version: earlier submissions used a 4-part PackageVersion (3.8.1.0, 3.8.2.0). This one uses 3.8.3, matching the product version. The installer registers as 3.8.3.0 in Apps & Features, which WinGet compares as equal to 3.8.3 since trailing zero parts are trimmed, so upgrades from 3.8.2.0 and later upgrade detection are unaffected.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (not applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest with WinGet manifest validation (via wingetcreate) ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432500)
