### PR TITLE
New package: NoaSansH.Thermalyn version 1.1.1

### DIFF
--- a/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.installer.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.installer.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.1.1
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+UpgradeBehavior: install
+ProductCode: '{8F2C1D74-4E63-4A18-9E2B-5C7A0D3F1B96}_is1'
+ReleaseDate: 2026-09-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NoaSansH/Thermalyn/releases/download/v1.1.1/Thermalyn-Setup-1.1.1.exe
+  InstallerSha256: E9CEFD20AA4E71F577278698D9289B7F381FDA9778DB98171F7240FC94B37E6E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.locale.en-US.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.locale.en-US.yaml
@@ -1,0 +1,33 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.1.1
+PackageLocale: en-US
+Publisher: Thermalyn Project
+PublisherUrl: https://github.com/NoaSansH
+PublisherSupportUrl: https://github.com/NoaSansH/Thermalyn/issues
+PackageName: Thermalyn
+PackageUrl: https://github.com/NoaSansH/Thermalyn
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/NoaSansH/Thermalyn/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Thermalyn Project
+ShortDescription: Hardware monitor for Windows 11 with processor, graphics, memory and drive sensors.
+Description: |-
+  Thermalyn reads processor, graphics, memory and drive sensors and keeps a 15-minute history.
+  It offers Compact, Balanced and Detailed views that adapt to the window size, an English and
+  French interface, dark and light themes, and per-component warm and critical thresholds with a
+  history of every crossing.
+
+  Sensors are selected by exact name and never inferred, so a reading that cannot be identified is
+  reported as absent rather than approximated.
+
+  It runs entirely offline: no account, no telemetry and no background service.
+Moniker: thermalyn
+Tags:
+- hardware-monitor
+- temperature
+- cpu
+- gpu
+- sensors
+- system-monitor
+ReleaseNotesUrl: https://github.com/NoaSansH/Thermalyn/releases/tag/v1.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.1.1/NoaSansH.Thermalyn.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New package: `NoaSansH.Thermalyn` version 1.1.1

Thermalyn is an open-source (GPL-3.0-or-later) hardware monitor for Windows 11 that reads processor, graphics, memory and drive sensors. Repository: https://github.com/NoaSansH/Thermalyn

- Manifest validated locally with `winget validate` (winget v1.29.290): passed.
- `ProductCode` verified against the real uninstall registry key on a machine with 1.1.1 installed: `{8F2C1D74-4E63-4A18-9E2B-5C7A0D3F1B96}_is1`.
- `InstallerSha256` taken from `SHA256SUMS.txt` published with the release, and matches the asset served at the installer URL.
- The URL points at the version-stamped asset `Thermalyn-Setup-1.1.1.exe` rather than the release's rolling `Thermalyn-Setup.exe` alias, so it stays immutable.

Two things a reviewer may want to know up front:

**The installer is not code-signed.** The project is maintained by one person and has no certificate. Every release binary does carry a signed GitHub build provenance attestation, verifiable with `gh attestation verify Thermalyn-Setup-1.1.1.exe --repo NoaSansH/Thermalyn`, which proves it was built by the repository's workflow at that tag.

**The installer sets up a kernel driver.** Processor temperature and package power are not published by Windows and require reading the processor's MSRs. Thermalyn uses [PawnIO](https://pawnio.eu) for this — signed, open source, and the same driver LibreHardwareMonitor uses. It is optional: everything else works without it, and the uninstaller asks before removing it since other monitoring tools may depend on it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432525)