### PR TITLE
New version: gohide.gohide version 5.2.2

### DIFF
--- a/manifests/g/gohide/gohide/5.2.2/gohide.gohide.installer.yaml
+++ b/manifests/g/gohide/gohide/5.2.2/gohide.gohide.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.2
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.19041.0
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/gohide/GoHide/releases/download/v5.2.2/gohide-5.2.2-win-Setup.exe
+  InstallerSha256: 185826409BB3702AA2138F1D8FB7D02D3224C32866ADF866DD3325029F19EFE3
+  AppsAndFeaturesEntries:
+  - DisplayName: gohide
+    Publisher: Xianwei Zhu
+    DisplayVersion: 5.2.2
+    ProductCode: gohide
+    InstallerType: exe
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
+++ b/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.2
+PackageLocale: en-US
+Publisher: Xianwei Zhu
+PublisherUrl: https://gohide.net
+PublisherSupportUrl: https://gohide.net/en/docs/troubleshooting
+PrivacyUrl: https://gohide.net/en/legal/privacy
+Author: Xianwei Zhu
+PackageName: gohide
+PackageUrl: https://gohide.net
+License: Proprietary
+LicenseUrl: https://gohide.net/en/legal/terms
+Copyright: Copyright (c) 2026 Xianwei Zhu
+ShortDescription: Hide app windows, taskbar buttons and tray icons on Windows with one hotkey.
+Description: |-
+  gohide hides the running applications you choose - their windows, taskbar buttons and even their
+  system-tray icons - with a single global hotkey, then restores everything exactly where it was.
+  Most classic window hiders stopped working on the redesigned Windows 11 notification area; gohide
+  still hides tray icons there. It can also mute an app while hidden, or suspend it entirely so a
+  hidden game stops using CPU and GPU. Everything is fully reversible, works offline, and needs no
+  account and no telemetry. Free for up to 5 managed apps; an optional Pro tier is a one-time
+  perpetual purchase with no subscription.
+Moniker: gohide
+Tags:
+- boss-key
+- desktop
+- focus
+- hide
+- hotkey
+- privacy
+- productivity
+- system-tray
+- taskbar
+- window-management
+ReleaseNotesUrl: https://github.com/gohide/GoHide/releases/tag/v5.2.2
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://gohide.net/en/docs
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/gohide/gohide/5.2.2/gohide.gohide.yaml
+++ b/manifests/g/gohide/gohide/5.2.2/gohide.gohide.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: gohide.gohide
+PackageVersion: 5.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### New version of an existing package

- **Package**: gohide.gohide 5.2.2
- **Installer**: https://github.com/gohide/GoHide/releases/download/v5.2.2/gohide-5.2.2-win-Setup.exe
- **SHA256**: taken from the release's own published `.sha256` file

Manifest is the merged 5.2.1 manifest with only `PackageVersion`, `InstallerUrl`,
`InstallerSha256`, `DisplayVersion`, `ReleaseDate` and `ReleaseNotesUrl` updated.

What's new in 5.2.2: dialogs no longer clip their own buttons — the hotkey capture dialog
pinned a fixed height, cutting off its OK/Cancel row; dialogs now size to their content, and
every window is capped to the monitor's work area so high display scaling can't push a
window's Close button off-screen.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [ ] Have you validated your manifest locally with `winget validate --manifest <path>`? — not run: authored from macOS. The manifest is a minimal diff of the already-merged 5.2.1 manifest, so I'm relying on the pipeline's validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432536)