### PR TITLE
New version: TheSaltyKorean.MarkdownStudio version 1.0.21

### DIFF
--- a/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.installer.yaml
+++ b/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.installer.yaml
@@ -1,0 +1,25 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: TheSaltyKorean.MarkdownStudio
+PackageVersion: 1.0.21
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+UpgradeBehavior: install
+ProductCode: '{7A0F9668-F02E-4586-9687-C43BD1DA3A12}'
+ReleaseDate: 2026-09-09
+AppsAndFeaturesEntries:
+- ProductCode: '{7A0F9668-F02E-4586-9687-C43BD1DA3A12}'
+  UpgradeCode: '{D4A5C1F2-7B3E-4A86-9D2C-1E8F0B6A7C53}'
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Programs\Markdown Studio'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/TheSaltyKorean/md/releases/download/v1.0.21/markdown-studio-windows-x64.msi
+  InstallerSha256: 1DC539E3CBB32B4EC5A2A31E47095DFB83430AA42BAECF98A84F469516FBBEE4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.locale.en-US.yaml
+++ b/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.locale.en-US.yaml
@@ -1,0 +1,66 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: TheSaltyKorean.MarkdownStudio
+PackageVersion: 1.0.21
+PackageLocale: en-US
+Publisher: Markdown Studio
+PublisherUrl: https://github.com/TheSaltyKorean/md
+PublisherSupportUrl: https://github.com/TheSaltyKorean/md/issues
+PackageName: Markdown Studio
+PackageUrl: https://github.com/TheSaltyKorean/md
+License: PolyForm Noncommercial 1.0.0
+LicenseUrl: https://github.com/TheSaltyKorean/md/blob/HEAD/LICENSE.md
+ShortDescription: Markdown viewer, WYSIWYG editor and PDF/print studio.
+Description: |-
+  Cross-platform Markdown editor with a Notion-style WYSIWYG mode, split
+  source/live-preview, find & replace, and themeable print/PDF export with
+  per-document branding profiles — including court-filing (legal) formatting
+  with 12pt double-spaced text that flows continuously across pages,
+  fill-in blanks, signature lines and forced page breaks.
+Moniker: markdown-studio
+Tags:
+- editor
+- markdown
+- md
+- pdf
+- wysiwyg
+ReleaseNotes: |-
+  Install
+  Windows — pick one: markdown-studio-windows-x64.msi
+  (Windows Installer, per-user — no admin prompt: installs to
+  %LocalAppData%\Programs, Start Menu, Add/Remove Programs,
+  in-place upgrades; silent-deployable with msiexec /i … /qn), or
+  markdown-studio-windows-x64-setup.exe (same result via Inno
+  Setup, plus an optional desktop icon), or the portable
+  markdown-studio-windows-x64-portable.zip (extract and run
+  markdown_studio.exe). SmartScreen may warn on unsigned builds:
+  More info → Run anyway. Upgrading from a pre-1.0.9 build (which
+  installed to Program Files)? Uninstall that one once first — it's
+  a different install location.
+  Linux — easiest (Debian/Ubuntu):
+  sudo apt install ./markdown-studio-linux-amd64.deb — desktop
+  entry, markdown-studio on PATH, and .md file association
+  included. Portable alternative for any distro:
+  mkdir -p ~/.local/opt/markdown-studio
+  tar -xzf markdown-studio-linux-x64-portable.tar.gz -C ~/.local/opt/markdown-studio
+  ~/.local/opt/markdown-studio/markdown_studio
+  Requires GTK 3. Built on Ubuntu 22.04, so it runs on any distro
+  with glibc 2.35+ (2022 or newer).
+  Android — download the .apk on the device and open it (allow
+  "install unknown apps" for your browser/file manager when prompted).
+  The .aab is the Play-Store upload artifact, not for direct
+  install. Android files appear only on signed releases (the
+  repo's keystore secrets configured); unsigned Android builds are
+  never published because their per-build certificate would break
+  in-place updates between releases.
+  macOS — download markdown-studio-macos.zip, unzip, drag the app to
+  Applications. The build is unsigned: on first launch right-click →
+  Open, or clear quarantine with
+  xattr -dr com.apple.quarantine "/Applications/markdown_studio.app".
+  iOS — markdown-studio-ios-unsigned.ipa is unsigned (no App Store yet):
+  install it with a sideloading tool that re-signs with your Apple ID
+  (AltStore, Sideloadly) or via Xcode with your own provisioning.
+ReleaseNotesUrl: https://github.com/TheSaltyKorean/md/releases/tag/v1.0.21
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.yaml
+++ b/manifests/t/TheSaltyKorean/MarkdownStudio/1.0.21/TheSaltyKorean.MarkdownStudio.yaml
@@ -1,0 +1,8 @@
+# Created with WinGet Releaser using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: TheSaltyKorean.MarkdownStudio
+PackageVersion: 1.0.21
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### Pull request has been automatically created using [WinGet Releaser](https://github.com/vedantmgoyal9/winget-releaser)? No — submitted manually by the package owner.

The CI job that normally opens this PR (winget-releaser + komac v2.16.0) failed on `CreateRef` due to a credential problem on our side. These manifests are exactly the ones komac generated for release v1.0.21; only the submission step was done by hand.

- **Package:** TheSaltyKorean.MarkdownStudio 1.0.21
- **Installer:** https://github.com/TheSaltyKorean/md/releases/download/v1.0.21/markdown-studio-windows-x64.msi
- **SHA256:** 1DC539E3CBB32B4EC5A2A31E47095DFB83430AA42BAECF98A84F469516FBBEE4 (verified against the published asset)
- **UpgradeCode** is unchanged from 1.0.19/1.0.20; only ProductCode, version, URL, hash and ReleaseDate differ.

---
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432543)