### PR TITLE
New version: Coderise.OKF4net version 0.5.0

### DIFF
--- a/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.installer.yaml
+++ b/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Coderise.OKF4net
+PackageVersion: 0.5.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: okf.exe
+    PortableCommandAlias: okf
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/jchable/okf4net/releases/download/v0.5.0/okf-0.5.0-win-x64.zip
+    InstallerSha256: 5B7D7648D7FD24A7D6BDDE098A3D9F09C5A4CC5BD5FBC0522D95A6AE47A96717
+  - Architecture: arm64
+    InstallerUrl: https://github.com/jchable/okf4net/releases/download/v0.5.0/okf-0.5.0-win-arm64.zip
+    InstallerSha256: 1D251959BF023413DAA3343EE019B4834F2ED6BDD897892F7442D05635680399
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.locale.en-US.yaml
+++ b/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Coderise.OKF4net
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Coderise
+PublisherUrl: https://github.com/jchable
+PublisherSupportUrl: https://github.com/jchable/okf4net/issues
+Author: Julien CHABLE
+PackageName: OKF4net
+PackageUrl: https://github.com/jchable/okf4net
+License: LGPL-3.0-or-later
+LicenseUrl: https://github.com/jchable/okf4net/blob/main/LICENSE
+Copyright: Copyright 2026 Julien CHABLE
+ShortDescription: Zero-dependency .NET implementation of the Open Knowledge Format (OKF) v0.2 -- parse, validate, index, and graph OKF knowledge bundles.
+Moniker: okf
+Tags:
+  - okf
+  - open-knowledge-format
+  - knowledge
+  - markdown
+  - yaml
+  - frontmatter
+  - knowledge-graph
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.yaml
+++ b/manifests/c/Coderise/OKF4net/0.5.0/Coderise.OKF4net.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Coderise.OKF4net
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Update **Coderise.OKF4net** to **0.5.0** (previous published version: 0.2.0, #409311).

This resubmits #421329, which I have just closed in favour of this PR. #421329 carried these exact manifest bytes, passed the full validation pipeline on 2026-08-20 — all ten stages green, including *08. Installation Validation* — and was labelled `Validation-Completed` with no review comments. It was nevertheless labelled `New-Package` even though 0.2.0 had merged twelve minutes before it was opened, and it then sat three weeks awaiting moderator approval. This PR is branched from current `master`, which already contains `manifests/c/Coderise/OKF4net/0.2.0`, so it should classify as a version update rather than a new package.

Two things differ from the previous published version (0.2.0):

- The manifests target schema **1.12.0** instead of the deprecated 1.6.0 that was flagged on #409311.
- The version string reported by the binary is fixed. Manual validation of #409311 showed `okf --version` printing `okf 0.1.0-alpha.1` while the package version was 0.2.0 — a hardcoded constant in the source that had drifted from the build version. The 0.5.0 binary reports `okf 0.5.0 (OKF spec v0.2)`.

Installers are Native AOT `okf.exe` binaries (x64 and arm64) shipped as zips on the upstream GitHub release, installed as a portable package with the `okf` command alias — same shape as 0.2.0. Both `InstallerSha256` values match `checksums.txt` on the [v0.5.0 release](https://github.com/jchable/okf4net/releases/tag/v0.5.0).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change — #421329 was closed before this PR was opened
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — run against these exact bytes when they were submitted as #421329
- [ ] Tested manifest locally with `winget install --manifest <path>` — **not run**: `winget settings --enable LocalManifestFiles` requires an elevated shell that wasn't available. Verified the artifacts directly instead: downloaded `okf-0.5.0-win-x64.zip` from the release, confirmed its SHA256 matches `InstallerSha256` in the manifest, extracted it and ran `okf.exe --version` → `okf 0.5.0 (OKF spec v0.2)`. The arm64 hash comes from the release's `checksums.txt`, generated by the same workflow that built and uploaded the artifact. Note also that *08. Installation Validation* passed on these identical manifests on #421329.
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432603)