### PR TITLE
Update version: CerberAuth.openapi-oathkeeper version 0.8.0

### DIFF
--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.installer.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.8.0
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: openapi-oathkeeper.exe
+  PortableCommandAlias: openapi-oathkeeper
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-09-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/cerberauth/openapi-oathkeeper/releases/download/v0.8.0/openapi-oathkeeper_Windows_x86_64.zip
+  InstallerSha256: 81322394165BAE52707BC4F1C4E80771A47F81A8DFC44DB85561BA5ABFF0932A
+- Architecture: x86
+  InstallerUrl: https://github.com/cerberauth/openapi-oathkeeper/releases/download/v0.8.0/openapi-oathkeeper_Windows_i386.zip
+  InstallerSha256: D3FBAB60304CEA73A2D14466B2A51499AF453D11B22CFE1AB1D0A552D63FB3B1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.locale.en-US.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.8.0
+PackageLocale: en-US
+Publisher: CerberAuth
+PublisherUrl: https://cerberauth.com
+PackageName: openapi-oathkeeper
+PackageUrl: https://github.com/cerberauth/openapi-oathkeeper
+License: MIT
+LicenseUrl: https://github.com/cerberauth/openapi-oathkeeper/blob/main/LICENSE
+ShortDescription: Generate Ory Oathkeeper access rules from an OpenAPI 3 contract.
+Moniker: openapi-oathkeeper
+ReleaseNotes: "## What's Changed\r\n\r\n• Add integration tests by @emmanuelgautier in https://github.com/cerberauth/openapi-oathkeeper/pull/143\r\n• feat：update dependencies and image version by @emmanuelgautier in https://github.com/cerberauth/openapi-oathkeeper/pull/144\r\n• Capture array and object path params as explicit types by @emmanuelgautier in https://github.com/cerberauth/openapi-oathkeeper/pull/145\r\n\r\n\r\n**Full Changelog**：https://github.com/cerberauth/openapi-oathkeeper/compare/v0.7.19...v0.8.0"
+ReleaseNotesUrl: https://github.com/cerberauth/openapi-oathkeeper/releases/tag/v0.8.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.yaml
+++ b/manifests/c/CerberAuth/openapi-oathkeeper/0.8.0/CerberAuth.openapi-oathkeeper.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: CerberAuth.openapi-oathkeeper
+PackageVersion: 0.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update CerberAuth.openapi-oathkeeper to version 0.8.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432616)