### PR TITLE
New package: Acute.SinearCertHelper version 0.6.2

### DIFF
--- a/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.installer.yaml
+++ b/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Acute.SinearCertHelper
+PackageVersion: 0.6.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-09-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://navi.dolbomii.com/agent/releases/0.6.2/SinearCertHelperSetup.exe
+    InstallerSha256: 647C77C6FCD8C8B5C4A3DD6FB3002E2C5BA4175F8B6A1DC6B101E4AEFB2BB994
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.locale.ko-KR.yaml
+++ b/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.locale.ko-KR.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Acute.SinearCertHelper
+PackageVersion: 0.6.2
+PackageLocale: ko-KR
+Publisher: Acute
+PublisherUrl: https://navi.dolbomii.com
+PublisherSupportUrl: https://navi.dolbomii.com
+PackageName: Sinear CertHelper
+PackageUrl: https://navi.dolbomii.com
+License: Proprietary
+Copyright: © Acute
+ShortDescription: 나만의 비서 인증서 도우미 — PC에 저장된 공동인증서를 웹에서 바로 찾을 수 있게 해주는 도우미 프로그램이에요.
+Description: |-
+  나만의 비서(navi) 웹에서 장기요양 서류를 공단에 제출할 때, PC에 저장된 공동인증서를
+  브라우저가 직접 읽을 수 없어요. 이 도우미를 설치하면 웹에서 인증서 목록을 바로 확인하고
+  선택할 수 있어요. 인증서는 사용자의 PC를 벗어나지 않아요.
+Moniker: sinear-cert-helper
+Tags:
+  - certificate
+  - healthcare
+  - korea
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.yaml
+++ b/manifests/a/Acute/SinearCertHelper/0.6.2/Acute.SinearCertHelper.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Acute.SinearCertHelper
+PackageVersion: 0.6.2
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New package submission: Acute.SinearCertHelper 0.6.2 — Korean B2B certificate helper (NPKI scanner) for navi.dolbomii.com. NSIS installer, silent /S, x64, Authenticode-signed (Azure Trusted Signing, publisher Acute). InstallerUrl is an immutable versioned release path; SHA256 verified against the served binary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432622)