### PR TITLE
New package: Klaavi.Klaavi version 1.2.18

### DIFF
--- a/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.installer.yaml
+++ b/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.installer.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: "Klaavi.Klaavi"
+PackageVersion: "1.2.18"
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Protocols:
+  - klaavi
+ReleaseDate: "2026-09-04"
+Installers:
+  - Architecture: x64
+    Scope: user
+    InstallerUrl: "https://assets.klaavi.app/releases/klaavi-win32-x64/1.2.18/e84823f777533bbe38f441bbeb2f086a200acab5d4ca289bda327f87ba738947/Klaavi-Setup-1.2.18.exe"
+    InstallerSha256: E84823F777533BBE38F441BBEB2F086A200ACAB5D4CA289BDA327F87BA738947
+    ProductCode: "fb7cbddb-af24-58f1-952b-c07c06fd794d"
+    InstallerSwitches:
+      Custom: "/currentuser"
+    ElevationRequirement: elevatesSelf
+    AppsAndFeaturesEntries:
+      - ProductCode: "fb7cbddb-af24-58f1-952b-c07c06fd794d"
+  - Architecture: x64
+    Scope: machine
+    InstallerUrl: "https://assets.klaavi.app/releases/klaavi-win32-x64/1.2.18/e84823f777533bbe38f441bbeb2f086a200acab5d4ca289bda327f87ba738947/Klaavi-Setup-1.2.18.exe"
+    InstallerSha256: E84823F777533BBE38F441BBEB2F086A200ACAB5D4CA289BDA327F87BA738947
+    ProductCode: "fb7cbddb-af24-58f1-952b-c07c06fd794d"
+    InstallerSwitches:
+      Custom: "/allusers"
+    ElevationRequirement: elevationRequired
+    AppsAndFeaturesEntries:
+      - ProductCode: "fb7cbddb-af24-58f1-952b-c07c06fd794d"
+ManifestType: installer
+ManifestVersion: "1.12.0"

--- a/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.locale.en-US.yaml
+++ b/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: "Klaavi.Klaavi"
+PackageVersion: "1.2.18"
+PackageLocale: en-US
+Publisher: "Klaavi P.S.A."
+PublisherUrl: "https://klaavi.app"
+PublisherSupportUrl: "https://klaavi.app"
+PrivacyUrl: "https://klaavi.app/privacy-policy"
+PackageName: "Klaavi"
+PackageUrl: "https://klaavi.app"
+License: "Proprietary"
+ShortDescription: "Adaptive on-screen keyboard with local word prediction."
+Description: "Klaavi is an adaptive on-screen keyboard designed to support accessible text input. Word prediction runs locally on the device and typed text is not sent to Klaavi servers. An internet connection may be required for downloads, updates, trial activation and PRO licensing."
+Moniker: klaavi
+Tags:
+  - accessibility
+  - assistive-technology
+  - keyboard
+  - on-screen-keyboard
+  - word-prediction
+ManifestType: defaultLocale
+ManifestVersion: "1.12.0"

--- a/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.yaml
+++ b/manifests/k/Klaavi/Klaavi/1.2.18/Klaavi.Klaavi.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: "Klaavi.Klaavi"
+PackageVersion: "1.2.18"
+DefaultLocale: "en-US"
+ManifestType: version
+ManifestVersion: "1.12.0"


### PR DESCRIPTION
## 📖 Description

Adds Klaavi.Klaavi version 1.2.18 to the Windows Package Manager community repository.

Klaavi uses an assisted NSIS installer supporting both per-user and per-machine installation scopes. Both installer variants use the same signed, version-specific installer artifact.

## ✅ Checklist

* [x] Signed the Contributor License Agreement
* [x] Checked that there aren't other open pull requests for the same manifest
* [x] This PR only modifies one manifest
* [x] Validated manifest locally with `winget validate --manifest <path>`
* [x] Tested manifest locally with `winget install --manifest <path>`
* [x] Manifest conforms to the 1.12 schema

Local installation was tested successfully for both `--scope user` and `--scope machine`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432652)