### PR TITLE
New package: AvendoApp.Avendo version 1.0.17

### DIFF
--- a/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.installer.yaml
+++ b/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.installer.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: AvendoApp.Avendo
+PackageVersion: 1.0.17
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+ElevationRequirement: elevationRequired
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/dima5163/avendo-downloads/releases/download/avendo-1.0.17-direct/Avendo-1.0.17-windows-x64-233a6366.msi
+  InstallerSha256: C44B139609152D6E597F548578102CA1156A6A595A8E3CC3A3D298B50E3B70F7
+  ProductCode: '{5405EE59-531A-4F38-830A-D777525B0A55}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Avendo
+    Publisher: avendoapp
+    DisplayVersion: 1.0.17
+    ProductCode: '{5405EE59-531A-4F38-830A-D777525B0A55}'
+    UpgradeCode: '{13303D07-2D19-51A2-BDAC-73D5F27BC54C}'
+- Architecture: arm64
+  InstallerUrl: https://github.com/dima5163/avendo-downloads/releases/download/avendo-1.0.17-direct/Avendo-1.0.17-windows-arm64-233a6366.msi
+  InstallerSha256: 791827298F6F7A2A3DC9B9AB73A493CE5F3F150A0BDDE1192B28BCC5183C4488
+  ProductCode: '{C7A708D3-3B60-44FF-84FD-AD26ED2CEB5E}'
+  AppsAndFeaturesEntries:
+  - DisplayName: Avendo
+    Publisher: avendoapp
+    DisplayVersion: 1.0.17
+    ProductCode: '{C7A708D3-3B60-44FF-84FD-AD26ED2CEB5E}'
+    UpgradeCode: '{13303D07-2D19-51A2-BDAC-73D5F27BC54C}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.locale.en-US.yaml
+++ b/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: AvendoApp.Avendo
+PackageVersion: 1.0.17
+PackageLocale: en-US
+Publisher: avendoapp
+PublisherUrl: https://avendo-app.com/
+PackageName: Avendo
+PackageUrl: https://avendo-app.com/en/download/
+License: Proprietary
+LicenseUrl: https://avendo-app.com/en/terms/
+Copyright: © 2026 Avendo
+ShortDescription: Lightweight business assistant
+Description: Avendo is a local-first business assistant for freelancers and small service businesses. It helps manage clients,
+  jobs, payments, tasks, reminders and bookings. Cloud sync and AI are optional upgrade paths.
+Moniker: avendo
+Tags:
+- bookings
+- business
+- clients
+- freelancers
+- offline
+- payments
+- tasks
+ReleaseNotesUrl: https://github.com/dima5163/avendo-downloads/releases/tag/avendo-1.0.17-direct
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.yaml
+++ b/manifests/a/AvendoApp/Avendo/1.0.17/AvendoApp.Avendo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: AvendoApp.Avendo
+PackageVersion: 1.0.17
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds Avendo 1.0.17 with the publisher's WiX MSI installers for x64 and ARM64.

Official download page: https://avendo-app.com/en/download/
Release: https://github.com/dima5163/avendo-downloads/releases/tag/avendo-1.0.17-direct

Publisher, version, architecture and product codes were read from the MSI databases. SHA256 values were independently computed and matched against the current release assets and published checksums. These per-machine MSI installers declare their elevation requirement.

Validation performed on macOS: all three manifests pass the official 1.12.0 JSON schemas; manifest paths, UTF-8/CRLF formatting, HTTPS download availability and MSI metadata were checked. Native `winget validate`, Windows installation and uninstallation were not available on this host and are not claimed. Prepared with AI assistance; post-submission installer/security validation is pending.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) (status to be checked by the CLA bot)
- [ ] Linked to an issue (not applicable: new manifest submission)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest set
- [ ] Validated manifest locally with `winget validate --manifest <path>` (Windows unavailable; JSON schemas validated)
- [ ] Tested manifest locally with `winget install --manifest <path>` (Windows unavailable)
- [x] Manifest conforms to the 1.12 schema

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432666)