### PR TITLE
New package: Nonary.Vibepollo version 1.18.4-stable.4

### DIFF
--- a/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.installer.yaml
+++ b/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nonary.Vibepollo
+PackageVersion: 1.18.4-stable.4
+InstallerLocale: en-US
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /qn /norestart
+  SilentWithProgress: /passive /norestart
+  InstallLocation: INSTALL_ROOT="<INSTALLPATH>"
+ExpectedReturnCodes:
+- InstallerReturnCode: 3010
+  ReturnResponse: rebootRequiredToFinish
+- InstallerReturnCode: 3017
+  ReturnResponse: rebootRequiredForInstall
+UpgradeBehavior: install
+ProductCode: Vibepollo
+ReleaseDate: 2026-09-10
+ElevationRequirement: elevationRequired
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Nonary/Vibepollo/releases/download/1.18.4-stable.4/VibepolloSetup-v1.18.4-stable.4.exe
+  InstallerSha256: A5481BD17C799F1BEC2C122A0FAFC0B40978DD08F7FD8211E0567441312736FD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.locale.en-US.yaml
+++ b/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nonary.Vibepollo
+PackageVersion: 1.18.4-stable.4
+PackageLocale: en-US
+Publisher: Nonary
+PublisherUrl: https://github.com/Nonary
+PublisherSupportUrl: https://github.com/Nonary/Vibepollo/issues
+PackageName: Vibepollo
+PackageUrl: https://github.com/Nonary/Vibepollo
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Nonary/Vibepollo/blob/1.18.4-stable.4/LICENSE
+ShortDescription: Self-hosted game streaming host for Moonlight.
+Description: Vibepollo is a fork of Apollo and Sunshine for streaming games and desktops to Moonlight clients, with display automation, virtual display support, and Playnite integration.
+Moniker: vibepollo
+Tags:
+- game-streaming
+- gaming
+- moonlight
+- remote-desktop
+- streaming
+- sunshine
+ReleaseNotesUrl: https://github.com/Nonary/Vibepollo/releases/tag/1.18.4-stable.4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.yaml
+++ b/manifests/n/Nonary/Vibepollo/1.18.4-stable.4/Nonary.Vibepollo.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nonary.Vibepollo
+PackageVersion: 1.18.4-stable.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the new package `Nonary.Vibepollo`, version `1.18.4-stable.4`, using the official Windows x64 release installer.

The EXE is a custom .NET bootstrapper embedding a WiX MSI. The manifest specifies its supported unattended switches and correlates with the visible `Vibepollo` uninstall registry entry. The embedded MSI's registration is hidden, and its numeric version differs from the visible application version.

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Checked for existing package manifests and other submissions for Vibepollo; none found
- [x] This PR modifies one package version only, represented by three manifest files
- [x] Validated locally with `winget validate --manifest <path>` using WinGet v1.29.290
- [x] Tested locally with `winget install --manifest <path>`
- [x] Manifest conforms to schema 1.12.0

## Validation

- Downloaded the official release EXE and calculated SHA-256 `A5481BD17C799F1BEC2C122A0FAFC0B40978DD08F7FD8211E0567441312736FD`, matching the release asset digest.
- Windows Authenticode verification returned `Valid` for the SignPath Foundation signature.
- Read the embedded MSI without running the installer. Confirmed x64 architecture, machine scope, publisher `Nonary`, visible name `Vibepollo`, visible version `1.18.4-stable.4`, and uninstall key `Vibepollo`.
- Checked installer switches against release source commit `e3ebca75ec06f975699bf38f46012b96db9c3e44`.
- Direct EXE installation with `/qn /norestart` completed successfully with exit code 0 on Windows 11 Pro x64, migrating Apollo 0.4.6 to Vibepollo 1.18.4-stable.4. The installed executable and application registration report the expected version, the automatic service is running, and the local web UI and streaming discovery endpoint return HTTP 200. The existing `apps.json`, `sunshine.conf`, and `sunshine_state.json` files were preserved byte for byte. Client reconnection verification is pending. This was a direct installer test, not `winget install --manifest`; uninstallation was not tested because Vibepollo is being retained. Microsoft automated installation/security validation and repository review remain outstanding.

Release: https://github.com/Nonary/Vibepollo/releases/tag/1.18.4-stable.4

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432720)