### PR TITLE
New version: VisorCraft.Mongrel version 5.72.6

### DIFF
--- a/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.installer.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.6
+InstallerLocale: en-US
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/20c1f044-6c03-414a-8133-708c953fc356
+  InstallerSha256: C76EC74DBC238758C276F08B933C9EC518C173BF514F82D91511D0C5F56EABA2
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/39d2a990-3638-4020-aedb-3063998ac2f1
+  InstallerSha256: 40BA3A1AF28B6B6E8EA55E011229C8D758CF7BA449366D44138439A211319943
+- Architecture: arm64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/ddac71ca-51f8-449a-ad91-9c9f2c8f2ba9
+  InstallerSha256: AEEEEAB9DA765D35D9B10FCD88247ED8A7AF4051D7F115B29B0019A6A35B1FA0
+- Architecture: arm64
+  InstallerType: nullsoft
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/c7c08e05-93ed-4ec2-b888-a1b1f847d0c5
+  InstallerSha256: CED190F6D7BF7A304273EA150B045362DB47D27FA4DA735B65412926A40FD4F9
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.locale.en-US.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.6
+PackageLocale: en-US
+Publisher: VisorCraft
+PublisherUrl: https://www.visorcraft.com/
+PackageName: Mongrel
+PackageUrl: https://www.visorcraft.com/
+License: Proprietary
+ShortDescription: Database systems workbench for 30+ engines with terminals, SFTP, Docker, Kubernetes, and an API client
+Description: |-
+  Mongrel is a desktop database systems workbench covering 30+ database engines,
+  including MongoDB, PostgreSQL, MySQL, SQLite, Redis, DuckDB, and many more.
+  It also provides SSH, Mosh, Telnet, and Serial terminals, SFTP and SCP file
+  transfer, Docker, Podman, and Kubernetes integration, and an HTTP, GraphQL,
+  WebSocket, and gRPC API client. Mongrel is proprietary software with an annual
+  license and a 7-day free trial.
+Moniker: mongrel
+Tags:
+- database
+- database-client
+- mongodb
+- sql
+- ssh
+- sftp
+- docker
+- kubernetes
+- api-client
+- terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.6/VisorCraft.Mongrel.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: **Mongrel** version **5.72.6** by **VisorCraft** (`VisorCraft.Mongrel`).

This is a version update of the existing package. 5.72.6 is the latest VisorCraft-published Windows release (x64 + arm64, MSI and NSIS). Installers are served from the vendor's official downloads API as stable per-file links; each URL responds with the installer, its `Content-Disposition` filename, and an `x-release-sha256` header matching the `InstallerSha256` in the manifest.

This PR is submitted by the vendor (VisorCraft) on its own behalf.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `winget` validation/installation was not run locally because the manifest was authored on a Linux machine without access to `winget`; the schema, URLs, and hashes were verified against the downloads API and HTTP `x-release-sha256` headers instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432818)