### PR TITLE
Add Harness Lens 0.0.5

### DIFF
--- a/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.installer.yaml
+++ b/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.installer.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright © 2026 Cristian Camargo Filho
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HarnessLens.HarnessLens
+PackageVersion: 0.0.5
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: harness-lens.exe
+    PortableCommandAlias: harness-lens
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/harness-lens/cli/releases/download/v0.0.5/harness-lens-v0.0.5-x86_64-pc-windows-msvc.zip
+    InstallerSha256: "2830583FDA59D682B9559B9484A4CC57F31089303EFACFEF95157B517740B7B5"
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.locale.en-US.yaml
+++ b/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright © 2026 Cristian Camargo Filho
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HarnessLens.HarnessLens
+PackageVersion: 0.0.5
+PackageLocale: en-US
+Publisher: Harness Lens
+PublisherUrl: https://github.com/harness-lens
+PublisherSupportUrl: https://github.com/harness-lens/cli/issues
+PackageName: Harness Lens
+PackageUrl: https://github.com/harness-lens/cli
+License: MPL-2.0
+LicenseUrl: https://github.com/harness-lens/cli/blob/v0.0.5/LICENSE
+ShortDescription: Evidence-backed local analysis of coding-agent harnesses
+Tags:
+  - agent
+  - cli
+  - harness
+  - scanner
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.yaml
+++ b/manifests/h/HarnessLens/HarnessLens/0.0.5/HarnessLens.HarnessLens.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright © 2026 Cristian Camargo Filho
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HarnessLens.HarnessLens
+PackageVersion: 0.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- Add the Harness Lens `0.0.5` multi-file manifest.
- Publish the Windows x64 portable CLI from the official Harness Lens GitHub release.
- Keep the product license as `MPL-2.0` with the versioned license URL.

## Validation

- Installer URL downloaded successfully.
- SHA256 verified against the manifest: `2830583fda59d682b9559b9484a4cc57f31089303efacfef95157b517740b7b5`.
- YAML parsed successfully.
- Manifest contains only one package version and the required three files.
- Windows `winget validate` and local install testing remain to be run on Windows; the PR validation pipeline should perform repository checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432837)