### PR TITLE
Update: oPaozinh0.YTMDesktopAdblock to 2.1.1

### DIFF
--- a/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.installer.yaml
+++ b/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: oPaozinh0.YTMDesktopAdblock
+PackageVersion: 2.1.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: exe
+Scope: user
+InstallerSwitches:
+  Silent: --silent
+  SilentWithProgress: --silent
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+- DisplayName: YTMDesktop Adblock
+  Publisher: NovusTheory
+  ProductCode: ytmdesktop-adblock
+  InstallerType: exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oPaozinh0/ytmdesktop/releases/download/v2.1.1/YTMDesktop-Adblock-2.1.1-Setup.exe
+  InstallerSha256: F18700A698A781C94B3CA6473A173DDEF60FFB3E64415C4E95A2420075433FAE
+ManifestType: installer
+ManifestVersion: 1.12.0
+ReleaseDate: 2026-09-10

--- a/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.locale.en-US.yaml
+++ b/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: oPaozinh0.YTMDesktopAdblock
+PackageVersion: 2.1.1
+PackageLocale: en-US
+Publisher: oPaozinh0
+PublisherUrl: https://github.com/oPaozinh0
+PublisherSupportUrl: https://github.com/oPaozinh0/ytmdesktop/issues
+PackageName: YTMDesktop Adblock
+PackageUrl: https://github.com/oPaozinh0/ytmdesktop
+License: GPL-3.0-only
+LicenseUrl: https://github.com/oPaozinh0/ytmdesktop/blob/v2.1.1/LICENSE
+Copyright: Copyright (c) 2024 YTMDesktop Team
+ShortDescription: YouTube Music desktop player with built-in ad blocking and Chrome extension support
+Description: |-
+  A fork of YouTube Music Desktop App (YTM Desktop) that adds ad blocking.
+
+  The built-in blocker uses the EasyList and uBlock Origin filter lists and can also inject the
+  lists' scriptlets, which is what stops the ads YouTube Music plays between songs. Unpacked Chrome
+  extensions such as uBlock Origin can be loaded into the player as well.
+
+  Everything else comes from upstream YTM Desktop: global media shortcuts, Discord rich presence,
+  Last.fm scrobbling, custom CSS and the companion server API. It installs separately from upstream
+  YTM Desktop and keeps its own settings.
+Moniker: ytmdesktop-adblock
+Tags:
+- adblock
+- adblocker
+- audio
+- music
+- music-player
+- player
+- youtube
+- youtube-music
+ReleaseNotes: |-
+  Fixes YouTube Music failing to open (stuck on the loading screen) after YouTube removed the
+  player bar's playerApi property. Ports the upstream v2.0.12 fix and upgrades Electron to 44.
+
+  The built-in auto-update now points at this fork's releases instead of upstream's, so this one
+  update has to be installed manually (winget upgrade or the release Setup.exe).
+ReleaseNotesUrl: https://github.com/oPaozinh0/ytmdesktop/releases/tag/v2.1.1
+Documentations:
+- DocumentLabel: Ad blocking
+  DocumentUrl: https://github.com/oPaozinh0/ytmdesktop/blob/v2.1.1/README.md#ad-blocking
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.yaml
+++ b/manifests/o/oPaozinh0/YTMDesktopAdblock/2.1.1/oPaozinh0.YTMDesktopAdblock.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.12.13.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: oPaozinh0.YTMDesktopAdblock
+PackageVersion: 2.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Updates oPaozinh0.YTMDesktopAdblock to 2.1.1. This version fixes YouTube Music failing to open (stuck on the loading screen) after YouTube removed the player bar's playerApi property; it also points the in-app auto-updater at the fork's own releases.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432842)