### PR TITLE
New package: NicholasReville.LightTable version 0.6.1

### DIFF
--- a/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.installer.yaml
+++ b/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: NicholasReville.LightTable
+PackageVersion: "0.6.1"
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+  Custom: /UPDATEOWNER=winget
+  InstallLocation: /D=<INSTALLPATH>
+UpgradeBehavior: install
+Commands:
+  - lighttable
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-setup.exe
+    InstallerSha256: "D5A4A0E3BA069B93CB9F0157814A50A5EECE32478B3AA69ED1A935E7B07BB951"
+    AppsAndFeaturesEntries:
+      - DisplayName: LightTable
+        Publisher: Nicholas Reville
+        DisplayVersion: "0.6.1"
+        ProductCode: LightTable
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.locale.en-US.yaml
+++ b/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: NicholasReville.LightTable
+PackageVersion: "0.6.1"
+PackageLocale: en-US
+Publisher: Nicholas Reville
+PublisherUrl: https://github.com/reville
+PackageName: LightTable
+PackageUrl: https://github.com/reville/lighttable-digital-darkroom
+License: "GPL-3.0-only"
+LicenseUrl: "https://github.com/reville/lighttable-digital-darkroom/blob/v0.6.1/LICENSE"
+ShortDescription: Digital darkroom for RAW photography and film simulation
+Moniker: lighttable
+ReleaseNotesUrl: https://github.com/reville/lighttable-digital-darkroom/releases/tag/v0.6.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.yaml
+++ b/manifests/n/NicholasReville/LightTable/0.6.1/NicholasReville.LightTable.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: NicholasReville.LightTable
+PackageVersion: "0.6.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
Adds new package NicholasReville.LightTable at version 0.6.1.
LightTable is a digital darkroom and RAW photo editor for Windows x64.
Release: https://github.com/reville/lighttable-digital-darkroom/releases/tag/v0.6.1

## ✅ Checklist
- [x] Linked to an issue (if applicable)

## 📦 Manifest Checklist
- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the 1.12 schema
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432873)