### PR TITLE
New version: EpicMorg.Enodia version 1.2.1

### DIFF
--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.installer.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: enodia.exe
+ReleaseDate: 2026-09-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/EpicMorg/enodia/releases/download/1.2.1%2B0/enodia_windows_amd64.zip
+  InstallerSha256: 95968d5b685741f6c348b23babbe199c076e81edbae733f1f250ddf963b69b75
+- Architecture: x86
+  InstallerUrl: https://github.com/EpicMorg/enodia/releases/download/1.2.1%2B0/enodia_windows_386.zip
+  InstallerSha256: 5ee8f01a36ca9e70eeee5226a1689aa06154a47f15aa0c9235b179b0e3f4b319
+- Architecture: arm64
+  InstallerUrl: https://github.com/EpicMorg/enodia/releases/download/1.2.1%2B0/enodia_windows_arm64.zip
+  InstallerSha256: 44c6b71e42012de8d512c154d05267ae32f606017620a9740265646bda44ea3a
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.be-BY.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.be-BY.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+PackageLocale: be-BY
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/enodia/issues
+Author: EpicMorg
+PackageName: Enodia
+PackageUrl: https://enodia.sh
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/EpicMorg/enodia/blob/master/LICENSE
+Copyright: Copyright (c) EpicMorg
+ShortDescription: Апытвае вашы разгорнутыя сэрвісы пра іх версію, звярае яе з календарамі жыццёвага цыклу вендараў і паказвае, што ўжо мёртва, што памірае і дзе ваш парк сістэм разышоўся па версіях.
+Description: |-
+  Enodia апытвае вашы разгорнутыя сэрвісы пра іх версію, потым звярае гэтыя версіі з календарамі жыццёвага цыклу вендараў і паказвае, што ўжо мёртва, што памірае і дзе ваш парк сістэм разышоўся па версіях.
+
+  Вы апісваеце свае сэрвісы адзін раз. Астатняе робіць Enodia.
+
+  Збор і ацэнка — дзве асобныя фазы, звязаныя толькі звычайным файлам інвентарызацыі ў фармаце JSONL, таму ў ізаляваных (air-gapped) асяроддзях можна збіраць дадзеныя ўнутры закрытай сеткі, а ацэньваць іх дзе заўгодна, дзе ёсць доступ у інтэрнэт. Справаздачы фарміруюцца ў выглядзе інтэрактыўнай табліцы ў тэрмінале, статычнага або CDN-афармленага HTML, JSON ці метрык Prometheus.
+Tags:
+- eol
+- end-of-life
+- checker
+- cli
+- inventory
+- lifecycle
+- monitoring
+- devops
+- sre
+- go
+- golang
+- reporter
+Documentations:
+- DocumentLabel: Introduction
+  DocumentUrl: https://docs.enodia.sh
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/enodia
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.en-US.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+PackageLocale: en-US
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/enodia/issues
+Author: EpicMorg
+PackageName: Enodia
+PackageUrl: https://enodia.sh
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/EpicMorg/enodia/blob/master/LICENSE
+Copyright: Copyright (c) EpicMorg
+ShortDescription: Asks your deployed services what version they are running, checks it against vendor lifecycle calendars, and reports what is already dead, what is dying, and where your fleet has drifted apart.
+Description: |-
+  Enodia asks your deployed services what version they are running, then checks those versions against vendor lifecycle calendars and tells you what is already dead, what is dying, and where your fleet has drifted apart.
+
+  You describe your services once. Enodia handles the rest.
+
+  Collection and evaluation are two separate phases connected only by a plain JSONL inventory file, so air-gapped environments can collect inside a closed network and evaluate anywhere else with internet access. Reports render as an interactive terminal table, static or CDN-themed HTML, JSON, or Prometheus metrics.
+Moniker: enodia
+Tags:
+- eol
+- end-of-life
+- checker
+- cli
+- inventory
+- lifecycle
+- monitoring
+- devops
+- sre
+- go
+- golang
+- reporter
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://docs.enodia.sh
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/enodia
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.ru-RU.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.ru-RU.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+PackageLocale: ru-RU
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/enodia/issues
+Author: EpicMorg
+PackageName: Enodia
+PackageUrl: https://enodia.sh
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/EpicMorg/enodia/blob/master/LICENSE
+Copyright: Copyright (c) EpicMorg
+ShortDescription: Опрашивает ваши развёрнутые сервисы об их версии, сверяет её с календарями жизненного цикла вендоров и показывает, что уже мертво, что умирает и где ваш парк систем разошёлся по версиям.
+Description: |-
+  Enodia опрашивает ваши развёрнутые сервисы об их версии, затем сверяет эти версии с календарями жизненного цикла вендоров и показывает, что уже мертво, что умирает и где ваш парк систем разошёлся по версиям.
+
+  Вы описываете свои сервисы один раз. Остальное делает Enodia.
+
+  Сбор и оценка — две отдельные фазы, связанные только обычным файлом инвентаризации в формате JSONL, поэтому в изолированных (air-gapped) средах можно собирать данные внутри закрытой сети, а оценивать их где угодно, где есть доступ в интернет. Отчёты формируются в виде интерактивной таблицы в терминале, статического или CDN-оформленного HTML, JSON или метрик Prometheus.
+Tags:
+- eol
+- end-of-life
+- checker
+- cli
+- inventory
+- lifecycle
+- monitoring
+- devops
+- sre
+- go
+- golang
+- reporter
+Documentations:
+- DocumentLabel: Introduction
+  DocumentUrl: https://docs.enodia.sh
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/enodia
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.sr-RS.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.sr-RS.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+PackageLocale: sr-RS
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/enodia/issues
+Author: EpicMorg
+PackageName: Enodia
+PackageUrl: https://enodia.sh
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/EpicMorg/enodia/blob/master/LICENSE
+Copyright: Copyright (c) EpicMorg
+ShortDescription: Пита ваше покренуте сервисе коју верзију користе, упоређује је са календарима животног циклуса произвођача и приказује шта је већ мртво, шта умире и где се ваш парк система разишао по верзијама.
+Description: |-
+  Enodia пита ваше покренуте сервисе коју верзију користе, затим упоређује те верзије са календарима животног циклуса произвођача и приказује шта је већ мртво, шта умире и где се ваш парк система разишао по верзијама.
+
+  Ви описујете своје сервисе једном. Остало ради Enodia.
+
+  Прикупљање и процена су две одвојене фазе повезане само обичном JSONL датотеком инвентара, тако да се у изолованим (air-gapped) окружењима прикупљање може обавити унутар затворене мреже, а процена било где са приступом интернету. Извештаји се приказују као интерактивна табела у терминалу, статички или CDN-стилизовани HTML, JSON или Prometheus метрике.
+Tags:
+- eol
+- end-of-life
+- checker
+- cli
+- inventory
+- lifecycle
+- monitoring
+- devops
+- sre
+- go
+- golang
+- reporter
+Documentations:
+- DocumentLabel: Introduction
+  DocumentUrl: https://docs.enodia.sh
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/enodia
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.uk-UA.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.locale.uk-UA.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+PackageLocale: uk-UA
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/enodia/issues
+Author: EpicMorg
+PackageName: Enodia
+PackageUrl: https://enodia.sh
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/EpicMorg/enodia/blob/master/LICENSE
+Copyright: Copyright (c) EpicMorg
+ShortDescription: Опитує ваші розгорнуті сервіси про їхню версію, звіряє її з календарями життєвого циклу вендорів і показує, що вже мертве, що вмирає і де ваш парк систем розійшовся за версіями.
+Description: |-
+  Enodia опитує ваші розгорнуті сервіси про їхню версію, потім звіряє ці версії з календарями життєвого циклу вендорів і показує, що вже мертве, що вмирає і де ваш парк систем розійшовся за версіями.
+
+  Ви описуєте свої сервіси один раз. Усе інше робить Enodia.
+
+  Збір і оцінка — це дві окремі фази, пов'язані лише звичайним файлом інвентаризації у форматі JSONL, тому в ізольованих (air-gapped) середовищах можна збирати дані всередині закритої мережі, а оцінювати їх будь-де, де є доступ до інтернету. Звіти формуються у вигляді інтерактивної таблиці в терміналі, статичного або CDN-оформленого HTML, JSON чи метрик Prometheus.
+Tags:
+- eol
+- end-of-life
+- checker
+- cli
+- inventory
+- lifecycle
+- monitoring
+- devops
+- sre
+- go
+- golang
+- reporter
+Documentations:
+- DocumentLabel: Introduction
+  DocumentUrl: https://docs.enodia.sh
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/enodia
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.yaml
+++ b/manifests/e/EpicMorg/Enodia/1.2.1/EpicMorg.Enodia.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.Enodia
+PackageVersion: '1.2.1'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds version 1.2.1 of the [Enodia](https://github.com/EpicMorg/enodia) manifest — EpicMorg's AGPL-3.0-or-later-licensed service inventory and lifecycle (EOL) monitoring CLI. Same manifest shape as the already-open 1.2-series submissions, just this version's own installer URLs/checksums.

## Summary
- Portable zip installers for windows/x64, x86 and arm64, published as part of the `1.2.1+0` GitHub release
- Locales: en-US (default), ru-RU, uk-UA, be-BY, sr-RS
- InstallerSha256 values confirmed against the release's own `checksums.txt`; `NestedInstallerFiles` confirmed by downloading and inspecting the actual archive contents

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (pending, will sign if the CLA bot flags this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.10.0/manifest.singleton.1.10.0.json)?

## Manifest Version Compatibility
- [ ] Should this manifest target a specific installer behavior? (no, standard portable zip)
- [ ] Do you want to target a Windows Feature update as a min version? (no)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432895)