### PR TITLE
New package: WebMux.WebMux version 1.3.10

### DIFF
--- a/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.installer.yaml
+++ b/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WebMux.WebMux
+PackageVersion: 1.3.10
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: wix
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- webmux
+- webmux-service
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: OpenJS.NodeJS.LTS
+    MinimumVersion: 24.0.0
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/jordanhubbard/webmux/releases/download/v1.3.10/webmux-1.3.10-windows-x64.msi
+  InstallerSha256: 79483070CDDF7F16ABA2F6FD9C4A7097FEB015A54C23C0D40AC24747263F6698
+  ProductCode: '{D2833997-5C8D-4E40-AB28-45A62B994389}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.locale.en-US.yaml
+++ b/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.locale.en-US.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WebMux.WebMux
+PackageVersion: 1.3.10
+PackageLocale: en-US
+Publisher: WebMux
+PublisherUrl: https://github.com/jordanhubbard/webmux
+PublisherSupportUrl: https://github.com/jordanhubbard/webmux/issues
+Author: Jordan Hubbard
+PackageName: WebMux
+PackageUrl: https://github.com/jordanhubbard/webmux
+License: BSD-2-Clause
+LicenseUrl: https://github.com/jordanhubbard/webmux/blob/v1.3.10/LICENSE
+Copyright: Copyright (c) 2026, Jordan Hubbard
+CopyrightUrl: https://github.com/jordanhubbard/webmux/blob/v1.3.10/LICENSE
+ShortDescription: Browser-based workspace for persistent terminals and remote desktops
+Description: |-
+  WebMux is a browser-based remote workspace for arranging persistent SSH and mosh terminals,
+  VNC and RDP desktops, and optional coding-agent sessions in a shared tiled interface.
+Moniker: webmux
+Tags:
+- browser
+- remote-desktop
+- rdp
+- ssh
+- terminal
+- vnc
+ReleaseNotesUrl: https://github.com/jordanhubbard/webmux/releases/tag/v1.3.10
+InstallationNotes: Microsoft OpenSSH Client (ssh.exe) is required for SSH sessions. Run webmux, then open http://localhost:8080.
+Documentations:
+- DocumentLabel: Windows installation guide
+  DocumentUrl: https://github.com/jordanhubbard/webmux/blob/v1.3.10/README-Windows.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.yaml
+++ b/manifests/w/WebMux/WebMux/1.3.10/WebMux.WebMux.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WebMux.WebMux
+PackageVersion: 1.3.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds WebMux 1.3.10 using the published x64 per-user MSI. WebMux is a browser-based workspace for persistent SSH and mosh terminals, VNC and RDP desktops, and optional coding-agent sessions.

Project tracking: https://github.com/jordanhubbard/webmux/issues/65

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - https://github.com/jordanhubbard/webmux/issues/65

## 📦 Manifest Checklist

- [x] Checked that there are no other open pull requests for WebMux 1.3.10
- [x] This PR only modifies one package
- [ ] Validated locally with `winget validate` (not available on macOS); all three manifests pass their official 1.12 JSON schemas
- [ ] Tested locally with `winget install --manifest` (not available on macOS); the same MSI passed silent install, application health, restart, and uninstall tests on Windows Server 2022 release CI
- [x] Manifest conforms to the 1.12 schema

Installer URL and SHA-256 were verified against the published v1.3.10 GitHub release, and ProductName, Manufacturer, ProductVersion, ProductCode, and UpgradeCode were extracted from the MSI database.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432896)