### PR TITLE
New package: EpicMorg.AtlassianDownloader version 2.0.0.9

### DIFF
--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.installer.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: atlassian-downloader.exe
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/EpicMorg/atlassian-downloader/releases/download/2.0.0.9/atlassian-downloader-dotnet10.0-win-x64.zip
+  InstallerSha256: 39d06e09cfee7a9c68b5515b97e6b2adb5917a19502fe4cf9229803a369da39b
+- Architecture: x86
+  InstallerUrl: https://github.com/EpicMorg/atlassian-downloader/releases/download/2.0.0.9/atlassian-downloader-dotnet10.0-win-x86.zip
+  InstallerSha256: 03fe25ecee20a454ede42780196261635f39b49341f8f271e0ed565a5b225a10
+- Architecture: arm64
+  InstallerUrl: https://github.com/EpicMorg/atlassian-downloader/releases/download/2.0.0.9/atlassian-downloader-dotnet10.0-win-arm64.zip
+  InstallerSha256: 6b2a9d62ac5487b53a2fbcd243ce957857a59ba6f131d46272cdbaeecdff1dd1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.be-BY.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.be-BY.yaml
@@ -1,0 +1,40 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+PackageLocale: be-BY
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/atlassian-downloader/issues
+Author: EpicMorg
+PackageName: Atlassian Downloader
+PackageUrl: https://github.com/EpicMorg/atlassian-downloader
+License: MIT
+LicenseUrl: https://github.com/EpicMorg/atlassian-downloader/blob/master/LICENSE.md
+Copyright: Copyright (c) 2009 EpicMorg
+ShortDescription: Кансольны дадатак для спампоўкі ўсіх публічна даступных інсталятараў прадуктаў Atlassian з іх уласных стужак рэлізаў.
+Description: |-
+  Atlassian Downloader — кансольны дадатак для спампоўкі афіцыйна апублікаваных інсталятараў і архіваў прадуктаў Atlassian (Jira, Confluence, Bitbucket, Bamboo і іншых) непасрэдна са стужак рэлізаў Atlassian.
+
+  Акрамя звычайнай масавай спампоўкі, ён умее выводзіць спіс спасылак на спампоўку або знойдзеныя нумары версій без самой спампоўкі, выгружаць сыры JSON стужкі як ёсць, або архіваваць усе версіі аднаго плагіна з Marketplace па яго ключы. Стужка, якую не ўдалося атрымаць або разабраць, лагуецца і прапускаецца — астатнія стужкі пры гэтым працягваюць апрацоўвацца.
+
+  Логіка спампоўкі таксама пастаўляецца асобным NuGet-пакетам (EpicMorg.Atlassian.Downloader), каб яе можна было выкарыстоўваць з уласнага .NET-кода, а не толькі праз CLI.
+Tags:
+- atlassian
+- jira
+- confluence
+- bitbucket
+- bamboo
+- downloader
+- mirror
+- archive
+- cli
+- dotnet
+Documentations:
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/atlassian-downloader
+- DocumentLabel: NuGet Package
+  DocumentUrl: https://www.nuget.org/packages/EpicMorg.Atlassian.Downloader
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.en-US.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+PackageLocale: en-US
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/atlassian-downloader/issues
+Author: EpicMorg
+PackageName: Atlassian Downloader
+PackageUrl: https://github.com/EpicMorg/atlassian-downloader
+License: MIT
+LicenseUrl: https://github.com/EpicMorg/atlassian-downloader/blob/master/LICENSE.md
+Copyright: Copyright (c) 2009 EpicMorg
+ShortDescription: Console app for downloading every publicly available Atlassian product installer from Atlassian's own release feeds.
+Description: |-
+  Atlassian Downloader is a console app for downloading Atlassian's own publicly released product installers and archives (Jira, Confluence, Bitbucket, Bamboo and more) straight from Atlassian's release feeds.
+
+  Beyond a plain bulk download, it can list the download URLs or version numbers it found without downloading anything, dump a feed's raw JSON as fetched, or archive every version of a single Marketplace plugin by its key. A feed that cannot be fetched or parsed is reported and skipped, and the run continues with the remaining feeds.
+
+  The downloading logic also ships as a standalone NuGet package (EpicMorg.Atlassian.Downloader) for driving from your own .NET code instead of the CLI.
+Moniker: atlassian-downloader
+Tags:
+- atlassian
+- jira
+- confluence
+- bitbucket
+- bamboo
+- downloader
+- mirror
+- archive
+- cli
+- dotnet
+Documentations:
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/atlassian-downloader
+- DocumentLabel: NuGet Package
+  DocumentUrl: https://www.nuget.org/packages/EpicMorg.Atlassian.Downloader
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.ru-RU.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.ru-RU.yaml
@@ -1,0 +1,40 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+PackageLocale: ru-RU
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/atlassian-downloader/issues
+Author: EpicMorg
+PackageName: Atlassian Downloader
+PackageUrl: https://github.com/EpicMorg/atlassian-downloader
+License: MIT
+LicenseUrl: https://github.com/EpicMorg/atlassian-downloader/blob/master/LICENSE.md
+Copyright: Copyright (c) 2009 EpicMorg
+ShortDescription: Консольное приложение для скачивания всех публично доступных инсталляторов продуктов Atlassian из их собственных лент релизов.
+Description: |-
+  Atlassian Downloader — консольное приложение для скачивания официально опубликованных инсталляторов и архивов продуктов Atlassian (Jira, Confluence, Bitbucket, Bamboo и других) напрямую из лент релизов Atlassian.
+
+  Помимо обычной массовой загрузки, оно умеет выводить список ссылок на скачивание или найденные номера версий без самой загрузки, выгружать сырой JSON ленты как есть, или архивировать все версии одного плагина из Marketplace по его ключу. Лента, которую не удалось получить или разобрать, логируется и пропускается — остальные ленты при этом продолжают обрабатываться.
+
+  Логика загрузки также поставляется отдельным NuGet-пакетом (EpicMorg.Atlassian.Downloader), чтобы её можно было использовать из своего .NET-кода, а не только через CLI.
+Tags:
+- atlassian
+- jira
+- confluence
+- bitbucket
+- bamboo
+- downloader
+- mirror
+- archive
+- cli
+- dotnet
+Documentations:
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/atlassian-downloader
+- DocumentLabel: NuGet Package
+  DocumentUrl: https://www.nuget.org/packages/EpicMorg.Atlassian.Downloader
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.sr-RS.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.sr-RS.yaml
@@ -1,0 +1,40 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+PackageLocale: sr-RS
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/atlassian-downloader/issues
+Author: EpicMorg
+PackageName: Atlassian Downloader
+PackageUrl: https://github.com/EpicMorg/atlassian-downloader
+License: MIT
+LicenseUrl: https://github.com/EpicMorg/atlassian-downloader/blob/master/LICENSE.md
+Copyright: Copyright (c) 2009 EpicMorg
+ShortDescription: Конзолна апликација за преузимање свих јавно доступних инсталера производа Atlassian из њихових сопствених фидова издања.
+Description: |-
+  Atlassian Downloader је конзолна апликација за преузимање званично објављених инсталера и архива производа Atlassian (Jira, Confluence, Bitbucket, Bamboo и других) директно из Atlassian-ових фидова издања.
+
+  Осим обичног масовног преузимања, може да испише листу URL адреса за преузимање или пронађене бројеве верзија без самог преузимања, да прикаже сирови JSON фида онако како је преузет, или да архивира све верзије једног Marketplace додатка по његовом кључу. Фид који не може да се преузме или рашчлани се пријављује и прескаче, док се остали фидови настављају обрађивати.
+
+  Логика преузимања се такође испоручује као засебан NuGet пакет (EpicMorg.Atlassian.Downloader), тако да се може користити из сопственог .NET кода, а не само преко CLI-ја.
+Tags:
+- atlassian
+- jira
+- confluence
+- bitbucket
+- bamboo
+- downloader
+- mirror
+- archive
+- cli
+- dotnet
+Documentations:
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/atlassian-downloader
+- DocumentLabel: NuGet Package
+  DocumentUrl: https://www.nuget.org/packages/EpicMorg.Atlassian.Downloader
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.uk-UA.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.locale.uk-UA.yaml
@@ -1,0 +1,40 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+PackageLocale: uk-UA
+Publisher: EpicMorg
+PublisherUrl: https://epicm.org/
+PublisherSupportUrl: https://github.com/EpicMorg/atlassian-downloader/issues
+Author: EpicMorg
+PackageName: Atlassian Downloader
+PackageUrl: https://github.com/EpicMorg/atlassian-downloader
+License: MIT
+LicenseUrl: https://github.com/EpicMorg/atlassian-downloader/blob/master/LICENSE.md
+Copyright: Copyright (c) 2009 EpicMorg
+ShortDescription: Консольний застосунок для завантаження всіх публічно доступних інсталяторів продуктів Atlassian з їхніх власних стрічок релізів.
+Description: |-
+  Atlassian Downloader — консольний застосунок для завантаження офіційно опублікованих інсталяторів і архівів продуктів Atlassian (Jira, Confluence, Bitbucket, Bamboo та інших) безпосередньо зі стрічок релізів Atlassian.
+
+  Окрім звичайного масового завантаження, він уміє виводити список посилань для завантаження або знайдені номери версій без самого завантаження, вивантажувати сирий JSON стрічки як є, або архівувати всі версії одного плагіна з Marketplace за його ключем. Стрічка, яку не вдалося отримати або розібрати, логується і пропускається — інші стрічки при цьому продовжують оброблятися.
+
+  Логіка завантаження також постачається окремим NuGet-пакетом (EpicMorg.Atlassian.Downloader), щоб її можна було використовувати з власного .NET-коду, а не лише через CLI.
+Tags:
+- atlassian
+- jira
+- confluence
+- bitbucket
+- bamboo
+- downloader
+- mirror
+- archive
+- cli
+- dotnet
+Documentations:
+- DocumentLabel: GitHub Repository
+  DocumentUrl: https://github.com/EpicMorg/atlassian-downloader
+- DocumentLabel: NuGet Package
+  DocumentUrl: https://www.nuget.org/packages/EpicMorg.Atlassian.Downloader
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.yaml
+++ b/manifests/e/EpicMorg/AtlassianDownloader/2.0.0.9/EpicMorg.AtlassianDownloader.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EpicMorg.AtlassianDownloader
+PackageVersion: '2.0.0.9'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds the initial winget manifest for [Atlassian Downloader](https://github.com/EpicMorg/atlassian-downloader), EpicMorg's MIT-licensed console app for downloading Atlassian's own publicly released product installers and archives (Jira, Confluence, Bitbucket, Bamboo and more) from Atlassian's release feeds.

## Summary
- Portable, self-contained zip installers for windows/x64, x86 and arm64 (.NET 10), published as part of the `2.0.0.9` GitHub release
- Locales: en-US (default), ru-RU, uk-UA, be-BY, sr-RS
- InstallerSha256 values computed directly from the downloaded release archives (no checksums file is published); `NestedInstallerFiles` confirmed by inspecting the actual archive contents

## Checklist
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (pending, will sign if the CLA bot flags this PR)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.10.0/manifest.singleton.1.10.0.json)?

## Manifest Version Compatibility
- [ ] Should this manifest target a specific installer behavior? (no, standard portable zip)
- [ ] Do you want to target a Windows Feature update as a min version? (no)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432897)