### PR TITLE
Update: oipoistar.Tinta to 3.7.0

### DIFF
--- a/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.installer.yaml
+++ b/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.7.0
+InstallerType: portable
+Commands:
+- tinta
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/oipoistar/tinta/releases/download/v3.7.0/tinta.exe
+  InstallerSha256: 03D50B72E8D4DD3ECEB1340FB1A0781C2ECDED4D25EB38304F4D4FA9C92E6990
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.locale.en-US.yaml
+++ b/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.locale.en-US.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.7.0
+PackageLocale: en-US
+Publisher: oipoistar
+PublisherUrl: https://github.com/oipoistar
+PublisherSupportUrl: https://github.com/oipoistar/tinta/issues
+PackageName: Tinta
+PackageUrl: https://tinta.cc
+License: MIT
+LicenseUrl: https://github.com/oipoistar/tinta/blob/master/LICENSE
+Copyright: Copyright (c) oipoistar
+ShortDescription: Fast, lightweight markdown and Mermaid viewer for Windows
+Description: |-
+  Tinta is a fast, lightweight markdown viewer and reader for Windows,
+  built with Direct2D and DirectWrite for hardware-accelerated rendering.
+  A single native executable of about 2.4 MB that starts in under 100 ms -
+  no Electron, no web engine, no installer. Features review annotations with a copy-for-agent loop, plain-text file references with mouse back and forward navigation, rendered link previews on hover, export to HTML, DOCX
+  and PDF plus optional Pandoc export to EPUB, ODT, PPTX, RTF and LaTeX, a Win11-style tabbed interface with drag and drop, session
+  restore and a tab context menu, an icon menu for file actions and settings,
+  full file-path copying, configurable frontmatter with opt-in created/updated
+  timestamps, footnotes with HTML/DOCX support, individual H1-H6 and highlight
+  colors, expanded syntax highlighting, resizable Contents through H6 and a
+  resizable file browser, separate inline-code theme colors, native LaTeX
+  math with matrices, cases, aligned equations and equation-local macros, native rendering for
+  twenty-two Mermaid diagram families (flowcharts with subgraphs, sequence,
+  class, state, ER, C4, requirement, architecture, block, sankey, packet,
+  kanban, treemap, radar, pie, git graphs, gantt, mindmaps, timelines,
+  journeys, quadrant and xy charts), custom themes with a built-in editor,
+  shortcut profiles, a UI in seven languages, first-class CJK text layout,
+  glyph-precise text selection, a table of contents and folder browser that
+  can be pinned open beside the document, full-text search, zoom, a start
+  page with recent files, and a unified editor whose rendered page floats
+  beside the source with live diagram preview and click-to-edit tables.
+Moniker: tinta
+Tags:
+- markdown
+- markdown-viewer
+- markdown-reader
+- markdown-editor
+- mermaid
+- latex
+- viewer
+- reader
+- direct2d
+- lightweight
+- portable
+ReleaseNotesUrl: https://github.com/oipoistar/tinta/releases/tag/v3.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.yaml
+++ b/manifests/o/oipoistar/Tinta/3.7.0/oipoistar.Tinta.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: oipoistar.Tinta
+PackageVersion: 3.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update oipoistar.Tinta to 3.7.0, the portable native Windows Markdown viewer.

- [x] Signed the Contributor License Agreement
- [x] Checked for duplicate manifest updates
- [x] This PR updates one package
- [x] Validated locally with `winget validate --manifest`
- [x] Manifest conforms to the 1.12 schema

The release executable was tested with native Markdown rendering and HTML/DOCX exports. Local manifest installation was not run; LocalManifestFiles remains disabled.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432900)