### PR TITLE
New package: MockMate.MockMate version 0.0.55

### DIFF
--- a/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.installer.yaml
+++ b/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MockMate.MockMate
+PackageVersion: 0.0.55
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: seeesmm.exe
+  PortableCommandAlias: mockmate
+UpgradeBehavior: install
+ReleaseDate: 2026-09-09
+Installers:
+- Architecture: x64
+  InstallerUrl: https://api.mock-mate.com/api/apps/download/b7ffc0b6-d358-42c9-b732-b07f9994aa4a
+  InstallerSha256: 1BC9D76E44E84ECB694563FCBF57656F18BC8CBAFA362E61AB5CECBFBEF69A92
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.locale.en-US.yaml
+++ b/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MockMate.MockMate
+PackageVersion: 0.0.55
+PackageLocale: en-US
+Publisher: MockMate
+PublisherUrl: https://mock-mate.com
+PublisherSupportUrl: https://mock-mate.com/trust
+PrivacyUrl: https://mock-mate.com/privacy-policy
+Author: MockMate
+PackageName: MockMate
+PackageUrl: https://mock-mate.com
+License: Proprietary
+LicenseUrl: https://mock-mate.com/terms-of-service
+Copyright: Copyright (c) 2026 MockMate
+CopyrightUrl: https://mock-mate.com/terms-of-service
+ShortDescription: AI interview preparation with adaptive practice sessions and reports, plus a Windows companion for authorized live assistance in English, Hindi and Hinglish.
+Description: |-
+  MockMate is an AI interview preparation product with two surfaces: a browser app for practice, and this Windows 10/11 companion for authorized live assistance during interviews and meetings.
+
+  Practice mode runs adaptive interview rounds in the browser. Questions respond to your answers, with interviewer personas and follow-up pressure, and can reflect your resume, target role, seniority and the job description. Technical rounds include a code editor. Each session ends with a report covering question-level answers, response timing, coaching evidence, recurring weaknesses and a recommended next practice.
+
+  The Windows companion adds low-latency transcription of microphone and system audio, with answers grounded in a fixed session snapshot of the resume, job description and notes you attached beforehand. Every answer is labelled with its source: transcript, manual text, screen text or screenshot. Screen context is user-initiated, queued and removable before sending. You choose the AI provider, model and answer depth, and an on-device model option exists for some answers.
+
+  Transcription and answers work in Hinglish (mixed Hindi-English) as well as other configured languages, so a mixed-language interview reads naturally.
+
+  Use live assistance only where the organisation, interviewer or applicable rules permit assistance and disclosure; use Practice mode when permission is unclear. See the Acceptable Use and AI Safety policies at https://mock-mate.com/acceptable-use-policy and https://mock-mate.com/ai-safety-and-usage-policy.
+
+  MockMate at mock-mate.com is a different product from mockmate.com, trymockmate.com and mockmate.althire.ai.
+Moniker: mockmate
+Tags:
+- ai
+- career
+- hinglish
+- interview
+- interview-preparation
+- job-search
+- mock-interview
+- transcription
+ReleaseNotes: 0.0.55 - Renew native login without interrupting active sessions.
+ReleaseNotesUrl: https://mock-mate.com/changelog
+Documentations:
+- DocumentLabel: How it works
+  DocumentUrl: https://mock-mate.com/how-it-works
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.yaml
+++ b/manifests/m/MockMate/MockMate/0.0.55/MockMate.MockMate.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MockMate.MockMate
+PackageVersion: 0.0.55
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `MockMate.MockMate` version `0.0.55`

MockMate is an AI interview preparation product: adaptive practice interviews with an end-of-session report in the browser, plus this Windows 10/11 companion for authorized live assistance during interviews and meetings. It is distributed as a portable zip.

- Publisher: https://mock-mate.com
- Installer: a `zip` containing `seeesmm.exe` at the archive root, submitted as `NestedInstallerType: portable` with `PortableCommandAlias: mockmate`
- The installer URL is the publisher's own versioned endpoint and downloads without a sign-in (302 to a stable per-version URL, `application/zip`, 41,596,717 bytes)
- `winget validate --manifest <dir>` passes with no warnings against schema 1.12.0

I am submitting this as the publisher.

#### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/addition?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

On the install test: `winget install --manifest` needs `LocalManifestFiles` enabled by an administrator on the submitting machine, which I do not have here, so validation is as far as I could take it locally. Happy to fix anything the pipeline's install test reports.

CLA signed on the thread.
