### PR TITLE
New package: Marbou92.FFXCompatibilityTool version 0.1.0

### DIFF
--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.installer.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.installer.yaml
@@ -1,0 +1,13 @@
+# winget installer manifest — the SHA-256 is of the exact v0.1.0 asset
+# published on the releases page (same value the release notes print)
+PackageIdentifier: Marbou92.FFXCompatibilityTool
+PackageVersion: "0.1.0"
+Installers:
+  - Architecture: x86
+    InstallerType: portable
+    InstallerUrl: https://github.com/marbou92/FFX-Compatibility-Tool/releases/download/v0.1.0/FFXCompatibilityTool-0.1.0.exe
+    InstallerSha256: A56BEE1D822B0C8FEDD23FFCAE3B748B9CC24E194D70CF73BAF38631069BD4D5
+    Commands:
+      - FFXCompatibilityTool
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.installer.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.installer.yaml
@@ -10,4 +10,4 @@ Installers:
     Commands:
       - FFXCompatibilityTool
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.locale.en-US.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# winget defaultLocale manifest
+PackageIdentifier: Marbou92.FFXCompatibilityTool
+PackageVersion: "0.1.0"
+PackageLocale: en-US
+Publisher: marbou92
+PublisherUrl: https://github.com/marbou92
+PublisherSupportUrl: https://github.com/marbou92/FFX-Compatibility-Tool/issues
+PackageName: FFX Compatibility Tool
+PackageUrl: https://github.com/marbou92/FFX-Compatibility-Tool
+License: MIT
+LicenseUrl: https://github.com/marbou92/FFX-Compatibility-Tool/blob/main/LICENSE
+Copyright: Copyright (c) marbou92
+ShortDescription: Converts After Effects .ffx presets for cross-version compatibility and strips effects whose plugins you don't own.
+Description: >-
+  A portable Windows tool for After Effects presets: converts .ffx files
+  for every AE version after CS5.5 — a verified full downgrade to CS5.5's
+  native format, or native-format effect removal for any newer target —
+  strips effects whose plugins you don't own, and shows exactly what is
+  inside a preset. All offline, in one single exe.
+Moniker: ffx-compatibility-tool
+Tags:
+  - after-effects
+  - presets
+  - video
+  - vfx
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.locale.en-US.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.locale.en-US.yaml
@@ -24,4 +24,4 @@ Tags:
   - video
   - vfx
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.yaml
@@ -1,0 +1,6 @@
+# winget version manifest — see README.md in this folder for how to
+# submit a new release to microsoft/winget-pkgs
+PackageIdentifier: Marbou92.FFXCompatibilityTool
+PackageVersion: "0.1.0"
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.yaml
+++ b/manifests/m/Marbou92/FFXCompatibilityTool/0.1.0/Marbou92.FFXCompatibilityTool.yaml
@@ -2,5 +2,6 @@
 # submit a new release to microsoft/winget-pkgs
 PackageIdentifier: Marbou92.FFXCompatibilityTool
 PackageVersion: "0.1.0"
+DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package submission: Marbou92.FFXCompatibilityTool, version 0.1.0.

FFX Compatibility Tool is a free, open-source (MIT) Windows utility for AdobeAfter Effects: it converts .ffx presets so they open in a different AEversion than the one they were saved in — including a verified full downgradeto CS5.5 — strips effects whose plugins the user doesn't own, and shows whatis inside a preset. It is a single portable exe: no installer, nodependencies, fully offline, no telemetry.

Publisher: marbou92 — https://github.com/marbou92
Repository: https://github.com/marbou92/FFX-Compatibility-Tool
Release page: https://github.com/marbou92/FFX-Compatibility-Tool/releases/tag/v0.1.0
Installer: https://github.com/marbou92/FFX-Compatibility-Tool/releases/download/v0.1.0/FFXCompatibilityTool-0.1.0.exe
Installer SHA256: A56BEE1D822B0C8FEDD23FFCAE3B748B9CC24E194D70CF73BAF38631069BD4D5
Installer type: portable (x86) — winget places FFXCompatibilityTool onPATH; portable packages run no installer and are silent by design
License: MIT — https://github.com/marbou92/FFX-Compatibility-Tool/blob/main/LICENSE
Manifest schema: 1.12.0 (validated against the official v1.12.0 JSON schemas)
This PR adds one new package, three manifest files undermanifests/m/Marbou92/FFXCompatibilityTool/0.1.0/:

Marbou92.FFXCompatibilityTool.yaml (version)
Marbou92.FFXCompatibilityTool.installer.yaml (installer)
Marbou92.FFXCompatibilityTool.locale.en-US.yaml (defaultLocale)
✅ Checklist
 Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/)
📦 Manifest Checklist
 Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
 This PR only modifies one (1) manifest
 Validated manifest locally with winget validate --manifest <path> ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
 Tested manifest locally with winget install --manifest <path>
 Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432910)