### PR TITLE
New package: relmer.Casso version 1.24.2

### DIFF
--- a/manifests/r/relmer/Casso/1.24.2/relmer.Casso.installer.yaml
+++ b/manifests/r/relmer/Casso/1.24.2/relmer.Casso.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.24.2
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/relmer/Casso/releases/download/v1.24.2/Casso-1.24.2-x64.zip
+  InstallerSha256: 14C1C7A82D0867520D60AA96AA6A867C6F3B6D8FD3ED0AE2E619264696322AA3
+  NestedInstallerFiles:
+  - RelativeFilePath: Casso-x64\Casso.exe
+    PortableCommandAlias: Casso
+  - RelativeFilePath: Casso-x64\CassoCli.exe
+    PortableCommandAlias: CassoCli
+- Architecture: arm64
+  InstallerUrl: https://github.com/relmer/Casso/releases/download/v1.24.2/Casso-1.24.2-ARM64.zip
+  InstallerSha256: A613FAC2BD75DF82B6EA7486CBFDFD606EF9B15E7AC7A315C44ACB7B2C0A6B8D
+  NestedInstallerFiles:
+  - RelativeFilePath: Casso-ARM64\Casso.exe
+    PortableCommandAlias: Casso
+  - RelativeFilePath: Casso-ARM64\CassoCli.exe
+    PortableCommandAlias: CassoCli
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/relmer/Casso/1.24.2/relmer.Casso.locale.en-US.yaml
+++ b/manifests/r/relmer/Casso/1.24.2/relmer.Casso.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.24.2
+PackageLocale: en-US
+Publisher: Robert Elmer
+PublisherUrl: https://github.com/relmer
+PublisherSupportUrl: https://github.com/relmer/Casso/issues
+Author: Robert Elmer
+PackageName: Casso
+PackageUrl: https://github.com/relmer/Casso
+License: MIT
+LicenseUrl: https://github.com/relmer/Casso/blob/master/LICENSE
+Copyright: Copyright (c) 2024-2026 Robert Elmer
+CopyrightUrl: https://github.com/relmer/Casso/blob/master/LICENSE
+ShortDescription: An Apple II family emulator with a built-in, fully AS65-compatible assembler.
+Description: |-
+  Casso is a retro platform emulator, 6502/65C02 assembler, and disk manager,
+  written in C++ with hardware-accelerated DirectX rendering and a multithreaded
+  core. It emulates the Apple ][, ][+, //e, //e Enhanced and //c.
+
+  The bundled CassoCli covers the retro development loop without third-party
+  tools: a from-scratch AS65-compatible assembler that also assembles Merlin,
+  disk management across .woz, .dsk, .do, .po, .nib and .nb2 images, headless
+  6502 execution, and launching the emulator with a machine and disks already
+  selected.
+Moniker: casso
+Tags:
+- 6502
+- 65c02
+- apple-ii
+- apple2
+- apple2c
+- apple2e
+- assembler
+- emulator
+- retro
+ReleaseNotesUrl: https://github.com/relmer/Casso/releases/tag/v1.24.2
+Documentations:
+- DocumentLabel: README
+  DocumentUrl: https://github.com/relmer/Casso/blob/master/README.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/relmer/Casso/1.24.2/relmer.Casso.yaml
+++ b/manifests/r/relmer/Casso/1.24.2/relmer.Casso.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: relmer.Casso
+PackageVersion: 1.24.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
New package submission for relmer.Casso, version 1.24.2.

Supersedes #431697 (1.23.2), which failed Installation Validation with STATUS_DLL_NOT_FOUND: the portable executables needed the Visual C++ runtime installed. As of 1.24.2 the release zips carry the runtime DLLs (vcruntime140, vcruntime140_1, msvcp140, msvcp140_atomic_wait) beside the executables, so they start on a clean Windows.

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the 1.12 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/432996)