### PR TITLE
Add CLA signed moderator trigger

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -339,6 +339,14 @@ configuration:
                 then:
                   - addLabel:
                       label: Needs-CLA
+              # CLA-Signed
+              - if:
+                  - commentContains:
+                      pattern: '(?in)\[Policy\]\s+CLA[\s-]Signed'
+                      isRegex: True
+                then:
+                  - removeLabel:
+                      label: Needs-CLA
               # Needs-Manual-Merge
               - if:
                   - commentContains:

--- a/doc/Moderation.md
+++ b/doc/Moderation.md
@@ -131,6 +131,12 @@ Occasionally the automatic validation runs into an issue which is transient, or 
 
 The bots which help keep the repository clean sometimes make mistakes or sometimes a moderator misclicks and accidentally requests changes. This can add the `Needs-Author-Feedback` or `Needs-Attention` labels to pull requests that don't need them. Moderators can remove these labels without re-running the pipelines to allow for the PR to be re-reviewed and merged.
 
+### Marking CLA as Signed
+
+> Trigger: Comment `[Policy] CLA Signed` on a pull request
+
+When the Contributor License Agreement has been signed but the `Needs-CLA` label remains on a pull request, moderators can use this trigger to remove the label.
+
 ### Removing Labels
 
 > Trigger: Comment `[Policy] Reset Labels` on a pull request or issue


### PR DESCRIPTION
## 📖 Description
Adds a moderator trigger for `[Policy] CLA Signed` comments. When matched, the trigger removes the `Needs-CLA` label.

Also updates `doc/Moderation.md` to document the new trigger for moderators.

Copilot assisted with this change.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  - No issue linked per maintainer instruction.

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [ ] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> [!NOTE]
> This is a repository policy and documentation change and does not modify manifests.
