### PR TITLE
New package: Roethlar.Songr version 1.3.0

### DIFF
--- a/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.installer.yaml
+++ b/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.installer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#
+# AppsAndFeaturesEntries.ProductCode is electron-builder's UUIDv5 of the appId
+# (app.songr.desktop), so it is STABLE across versions. It is also the only
+# usable upgrade key: the installer's ARP DisplayName is "Songr <version>",
+# which carries the version and so cannot match across an upgrade.
+
+PackageIdentifier: Roethlar.Songr
+PackageVersion: "1.3.0"
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+ReleaseDate: 2026-09-05
+AppsAndFeaturesEntries:
+- ProductCode: 5e360a66-1fb2-5b7a-bdf5-7405266bc5ac
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/roethlar/songr/releases/download/v1.3.0/Songr.Setup.1.3.0.exe
+  InstallerSha256: 1E76F8731CDA3489EFABC1AF3A16D220817CF26661B4F588438BC24ED681EEC6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.locale.en-US.yaml
+++ b/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#
+# Publisher deliberately does NOT match the Authenticode subject
+# ("CN=Michael Coelho"). It matches the ARP Publisher value Windows displays
+# and the publisher segment of PackageIdentifier, which is the pair winget's
+# own consistency checks compare.
+
+PackageIdentifier: Roethlar.Songr
+PackageVersion: "1.3.0"
+PackageLocale: en-US
+Publisher: Roethlar
+PublisherUrl: https://github.com/roethlar
+PublisherSupportUrl: https://github.com/roethlar/songr/issues
+PackageName: Songr
+PackageUrl: https://github.com/roethlar/songr
+License: MIT
+LicenseUrl: https://github.com/roethlar/songr/blob/main/LICENSE
+ShortDescription: Multi platform controller for your Roon Core
+Description: |-
+  Multi platform controller for your Roon Core. Linux, macOS, Windows, or
+  browser, your library is at your fingertips.
+Moniker: songr
+Tags:
+- audio
+- controller
+- music
+- roon
+- streaming
+ReleaseNotesUrl: https://github.com/roethlar/songr/releases/tag/v1.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.yaml
+++ b/manifests/r/Roethlar/Songr/1.3.0/Roethlar.Songr.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Roethlar.Songr
+PackageVersion: "1.3.0"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Restores the Songr 1.3.0 manifest that was removed by microsoft/winget-pkgs#432999, using the corrected package identifier and publisher casing: `Roethlar.Songr`.

This PR only adds the restored manifest set under `manifests/r/Roethlar/Songr/1.3.0/`. Copilot assisted with preparing this change.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest manifests\r\Roethlar\Songr\1.3.0` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433017)