### PR TITLE
New package: 9enki.PowerModeTray version 2.2.1

### DIFF
--- a/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.installer.yaml
+++ b/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: 9enki.PowerModeTray
+PackageVersion: 2.2.1
+InstallerType: portable
+Commands:
+- PowerModeTray
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/9enki/power-mode-tray/releases/download/v2.2.1/PowerModeTray.exe
+  InstallerSha256: 1EDF6A46025A95570E024C7608148AC47B5F2909B9F54A69D9F18FBFD70B7690
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.locale.en-US.yaml
+++ b/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: 9enki.PowerModeTray
+PackageVersion: 2.2.1
+PackageLocale: en-US
+Publisher: 9enki
+PublisherUrl: https://github.com/9enki
+PublisherSupportUrl: https://github.com/9enki/power-mode-tray/issues
+PackageName: PowerModeTray
+PackageUrl: https://github.com/9enki/power-mode-tray
+License: MIT
+LicenseUrl: https://github.com/9enki/power-mode-tray/blob/main/LICENSE
+Copyright: Copyright (c) 2026 9enki
+ShortDescription: Cycle Windows 11 power modes (Best power efficiency / Balanced / Best performance) from a tray icon or a hotkey.
+Description: |-
+  A tiny tray app for Windows 11. Left-click the tray icon (or press Ctrl+Alt+P, configurable with --hotkey)
+  to cycle the power mode: Best power efficiency -> Balanced -> Best performance. It calls the same power
+  overlay API as the Settings app, writes nothing to the registry or disk, needs no admin rights and no extra runtime.
+Moniker: powermodetray
+Tags:
+- battery
+- hotkey
+- power
+- power-mode
+- tray
+- windows-11
+ReleaseNotesUrl: https://github.com/9enki/power-mode-tray/releases/tag/v2.2.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.locale.ja-JP.yaml
+++ b/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.locale.ja-JP.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.9.0.schema.json
+PackageIdentifier: 9enki.PowerModeTray
+PackageVersion: 2.2.1
+PackageLocale: ja-JP
+Publisher: 9enki
+PackageName: PowerModeTray
+License: MIT
+ShortDescription: Windows 11 の電源モード（最適な電力効率 / バランス / 最適なパフォーマンス）をトレイアイコンのクリックやホットキーで切り替える最小アプリ。
+Description: |-
+  トレイアイコンの左クリック、または Ctrl+Alt+P（--hotkey で変更可）で電源モードを
+  最適な電力効率 -> バランス -> 最適なパフォーマンス の順に切り替えます。設定アプリと同じ API を呼ぶだけで、
+  レジストリやファイルへの書き込みはなく、管理者権限も追加ランタイムも不要です。
+ManifestType: locale
+ManifestVersion: 1.9.0

--- a/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.yaml
+++ b/manifests/9/9enki/PowerModeTray/2.2.1/9enki.PowerModeTray.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: 9enki.PowerModeTray
+PackageVersion: 2.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
### Checklist

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (will sign when the bot asks)
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

### Notes

New package. PowerModeTray cycles the Windows 11 power mode (Best power efficiency, Balanced, Best performance) from a system tray icon or a global hotkey.

- Single portable executable, about 160 KB, no installer and no runtime dependencies
- Written in Rust against the Win32 API
- Source and releases: https://github.com/9enki/power-mode-tray
- License: MIT
- `InstallerUrl` points at the GitHub release asset for v2.2.1, and `InstallerSha256` matches the `SHA256SUMS.txt` published with that release

On testing, to be precise about what was and was not done: `winget validate --manifest` passes. `winget install --manifest` was not run, because that needs `LocalManifestFiles` enabled from an elevated prompt, which was not available here. The executable itself is the one attached to the v2.2.1 release and has been run and used on Windows 11 24H2 (x64).
