### PR TITLE
New package: RunTheWall.Constly version 4.7.1

### DIFF
--- a/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.installer.yaml
+++ b/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.installer.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: RunTheWall.Constly
+PackageVersion: 4.7.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-09-06"
+# Windows 10 1803.
+MinimumOSVersion: 10.0.17134.0
+FileExtensions:
+- markdown
+- md
+- mdx
+# The installer's actual Add/Remove Programs values, so winget can correlate an
+# installed copy. Publisher here is the registry value and differs from the
+# locale manifest's Publisher by design.
+AppsAndFeaturesEntries:
+- DisplayName: Constly
+  Publisher: constly
+  ProductCode: Constly
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.constly.com/v4.7.1/Constly_4.7.1_x64-setup.exe
+  InstallerSha256: ABCB7820A6811417DD81E98447D0F7D603EABDB5C825CABB29878D9B0F613D69
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.locale.en-US.yaml
+++ b/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: RunTheWall.Constly
+PackageVersion: 4.7.1
+PackageLocale: en-US
+Publisher: Run The Wall
+PublisherUrl: https://constly.com
+PublisherSupportUrl: https://github.com/RunTheWall/constly-app/issues
+PrivacyUrl: https://constly.com/privacy/
+Author: Run The Wall
+PackageName: Constly
+PackageUrl: https://constly.com
+License: Proprietary
+LicenseUrl: https://constly.com/eula/
+Copyright: Copyright (c) 2026 RUN THE WALL PTY LTD
+ShortDescription: A WYSIWYG Markdown editor that renders as you type and never rewrites a byte you didn't touch.
+Description: |-
+  Constly renders Markdown in place as you type. Headings, bold, lists, tables, KaTeX math and Mermaid diagrams read as finished text, and the raw marks show only on the line your cursor is on.
+
+  Plain text is the document. The rendered view is a projection over it, so saving touches only the bytes you changed: Constly never re-wraps, reorders or normalises Markdown you left alone. Your line endings, byte-order mark and trailing spaces all survive. Every release is checked against a corpus of real files.
+
+  Tables are an editable grid. Click a cell and type, Tab across, Enter for the next row, and the source reflows to aligned pipes when you leave. There is a command palette, quick-open, workspace search, tabs, session restore, a document outline, focus and typewriter modes, real modal Vim with a status bar, and a git gutter diff against HEAD.
+
+  Nothing phones home. No account, no telemetry, no server to reach. Remote images stay unloaded until you allow them, and Constly never needs the network to open, edit or save a file. Local version history is off by default; turn it on and it snapshots each document as you save, on your disk.
+
+  Export to PDF, self-contained HTML, Word, ODT, RTF, LaTeX or EPUB. Import from Word and HTML. Opens .md, .markdown and .mdx.
+
+  The installer is 17.6 MB and installs per user, so it needs no administrator rights. Constly is free to use with nothing gated: no expiry, no watermark, no locked exports. After two weeks a weekly reminder appears, and a one-time licence for up to three devices retires it. Pricing is on constly.com.
+Moniker: constly
+Tags:
+- editor
+- markdown
+- md
+- mermaid
+- notes
+- offline
+- privacy
+- text-editor
+- wysiwyg
+- writing
+PurchaseUrl: https://constly.com/#pricing
+ReleaseNotesUrl: https://github.com/RunTheWall/constly-app/blob/main/CHANGELOG.md#471-2026-09-06
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.yaml
+++ b/manifests/r/RunTheWall/Constly/4.7.1/RunTheWall.Constly.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: RunTheWall.Constly
+PackageVersion: 4.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Constly 4.7.1**, a WYSIWYG Markdown editor for Windows.

Per-user NSIS installer, x64, 17.6 MB, no administrator rights needed. `Scope: user` and `AppsAndFeaturesEntries` reflect what the installer actually writes.

One thing worth flagging for review: Constly is also in the Microsoft Store as `XP8KCJ492XV21J`, so a search will return two entries for the same application. That is expected and not an accident. The Store build has to embed the WebView2 runtime offline to satisfy Partner Center, which puts it at 279.6 MB against 17.6 MB for the installer submitted here.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433048)