### PR TITLE
New version: VisorCraft.Mongrel version 5.72.10

### DIFF
--- a/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.installer.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.installer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.10
+InstallerLocale: en-US
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/4e4f39a7-05e2-4f45-8764-9649849669c8
+  InstallerSha256: 52F8A5ECF1AAC3A70ED12031F52C61ABF82ADB3749A3B9445B469959AD98598B
+- Architecture: x64
+  InstallerType: nullsoft
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/5c600896-cc4c-43a4-ab44-464449c916d9
+  InstallerSha256: ECE0E59E8E67E2D19B75F81A72A124F59D97315F141AE4AB8F45024F4518CC6A
+- Architecture: arm64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/9d52ebfc-3c18-4ebb-bd38-8e89db9da02d
+  InstallerSha256: 250298F9BBED672902B35CB6550CD64A32D07C3F13D3F7364ED99FCCE2C1E001
+- Architecture: arm64
+  InstallerType: nullsoft
+  InstallerUrl: https://www.visorcraft.com/api/downloads/mongrel/4d3eed72-3bd7-4e88-ae97-085e6adfe001
+  InstallerSha256: 15C9BC0135512B17E6E7A5A9930F35A375115593A8AFF7A6185A97596E90029E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.locale.en-US.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.locale.en-US.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.10
+PackageLocale: en-US
+Publisher: VisorCraft
+PublisherUrl: https://www.visorcraft.com/
+PackageName: Mongrel
+PackageUrl: https://www.visorcraft.com/
+License: Proprietary
+ShortDescription: Database systems workbench for 30+ engines with terminals, SFTP, Docker, Kubernetes, and an API client
+Description: |-
+  Mongrel is a desktop database systems workbench covering 30+ database engines,
+  including MongoDB, PostgreSQL, MySQL, SQLite, Redis, DuckDB, and many more.
+  It also provides SSH, Mosh, Telnet, and Serial terminals, SFTP and SCP file
+  transfer, Docker, Podman, and Kubernetes integration, and an HTTP, GraphQL,
+  WebSocket, and gRPC API client. Mongrel is proprietary software with an annual
+  license and a 7-day free trial.
+Moniker: mongrel
+Tags:
+- database
+- database-client
+- mongodb
+- sql
+- ssh
+- sftp
+- docker
+- kubernetes
+- api-client
+- terminal
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.yaml
+++ b/manifests/v/VisorCraft/Mongrel/5.72.10/VisorCraft.Mongrel.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: VisorCraft.Mongrel
+PackageVersion: 5.72.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version: **Mongrel** version **5.72.10** by **VisorCraft** (`VisorCraft.Mongrel`).

This is a version update of the existing package. 5.72.10 is the latest VisorCraft-published Windows release (x64 + arm64, MSI and NSIS). Installers are served from the vendor's official downloads API as stable per-file links; each URL responds with the installer, its `Content-Disposition` filename, and an `x-release-sha256` header matching the `InstallerSha256` in the manifest.

This PR is submitted by the vendor (VisorCraft) on its own behalf.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `winget` validation/installation was not run locally because the manifest was authored on a Linux machine without access to `winget`; the schema, URLs, and hashes were verified against the downloads API and HTTP `x-release-sha256` headers instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433069)