### PR TITLE
New package: KallistoX.replaycut version 3.7.1

### DIFF
--- a/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.installer.yaml
+++ b/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+# Portable on purpose, and `ArchiveBinariesDependOnPath` because the
+# executable reads its UI from `ui\index.html` next to itself. Both are
+# explained in dist/winget/README.md of the replaycut repository.
+
+PackageIdentifier: KallistoX.replaycut
+PackageVersion: 3.7.1
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: replaycut.exe
+    PortableCommandAlias: replaycut
+ArchiveBinariesDependOnPath: true
+UpgradeBehavior: install
+ReleaseDate: 2026-09-11
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Gyan.FFmpeg
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/KallistoX/replaycut/releases/download/v3.7.1/replaycut-3.7.1-windows-x64.zip
+    InstallerSha256: 3169D6B96C068B62421971E8288880227ED39129B9DA6D7F437B64D433B69DF6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.locale.en-US.yaml
+++ b/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: KallistoX.replaycut
+PackageVersion: 3.7.1
+PackageLocale: en-US
+Publisher: KallistoX
+PublisherUrl: https://github.com/KallistoX
+PublisherSupportUrl: https://github.com/KallistoX/replaycut/issues
+PackageName: replaycut
+PackageUrl: https://replaycut.de
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/KallistoX/replaycut/blob/main/LICENSE
+Copyright: Copyright (c) 2026 KallistoX
+CopyrightUrl: https://github.com/KallistoX/replaycut/blob/main/LICENSE
+ShortDescription: "Clip manager for the OBS replay buffer: trim a replay in the browser, encode it with ffmpeg and post the link."
+Description: |-
+  replaycut is a small self-hosted service next to OBS Studio. It watches the folder the replay buffer writes to and serves one page in the browser: the clip list with thumbnails, a player with in and out marks, the audio tracks and the Share button. The browser is the remote control, so the trimming happens on the phone or the laptop while the gaming PC encodes with ffmpeg and the GPU.
+  A share can stay a local file or go to Nextcloud, OneDrive, S3, WebDAV or YouTube, and the link can be posted to Discord, Telegram or any webhook. Nothing leaves the PC that you did not set up: the service listens on this PC alone until you switch network access on, which asks for a password first, and secrets live in the Windows Credential Manager.
+  ffmpeg and ffprobe have to be on the PATH; the winget package pulls Gyan.FFmpeg in for that. After the install, `replaycut` starts the service and opens the page. `replaycut install` adds the start menu and desktop shortcuts, offers autostart at sign-in and turns on the built-in one-click updater.
+Moniker: replaycut
+Tags:
+  - clips
+  - discord
+  - ffmpeg
+  - gaming
+  - nextcloud
+  - obs
+  - obs-studio
+  - replay-buffer
+  - screen-recording
+  - self-hosted
+  - video
+ReleaseNotesUrl: https://github.com/KallistoX/replaycut/releases/tag/v3.7.1
+Documentations:
+  - DocumentLabel: Settings
+    DocumentUrl: https://github.com/KallistoX/replaycut/blob/main/docs/settings.md
+  - DocumentLabel: HTTP API
+    DocumentUrl: https://github.com/KallistoX/replaycut/blob/main/docs/api.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.yaml
+++ b/manifests/k/KallistoX/replaycut/3.7.1/KallistoX.replaycut.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: KallistoX.replaycut
+PackageVersion: 3.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New package: `KallistoX.replaycut` version 3.7.1

replaycut is a clip manager for the OBS replay buffer: a self-hosted service that watches the folder OBS writes replays to, serves one page in the browser for trimming, encodes the selected range with ffmpeg and can upload it and post the link.

- Homepage: https://replaycut.de
- Repository: https://github.com/KallistoX/replaycut
- Release: https://github.com/KallistoX/replaycut/releases/tag/v3.7.1
- License: AGPL-3.0-only

This replaces #432902, which was for 3.7.1 as well but got closed by the bot while I was replacing the files in it - my mistake, the branch was briefly empty. This one starts clean.

**On the validation error in that PR** (thanks, @stephengillie): that exit code was a real bug, not a packaging problem. `replaycut.exe` imported `VCRUNTIME140.dll`, which is not part of Windows - it arrives with the Visual C++ Redistributable. Every game installs that one, which is why this never showed up on a developer or a gaming machine, and why a clean sandbox is the first thing that caught it. On a fresh Windows the program died before its first line, with no message at all. Fixed by linking the C runtime into the executable (`-C target-feature=+crt-static`); the only imports left are `api-ms-win-crt-*`, the UCRT, which has shipped with Windows since 10. 3.7.1 is that fix.

Notes on the manifest:

- The package is portable. The release ZIP carries `install.cmd`, but it is interactive (it asks about autostart and waits for a key), so it cannot be a nested installer for an unattended install. `winget install` puts `replaycut` on the PATH; users who want shortcuts and autostart run `replaycut install` once.
- `ArchiveBinariesDependOnPath: true` because `replaycut.exe` reads its UI from `ui\index.html` next to itself in the archive.
- `Gyan.FFmpeg` is declared as a dependency: replaycut encodes with ffmpeg and reads clips with ffprobe. Happy to drop the block if you would rather not have it.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433100)