### PR TITLE
New package: tau625.ShudaoLe version 1.5.0

### DIFF
--- a/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.installer.yaml
+++ b/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: tau625.ShudaoLe
+PackageVersion: 1.5.0
+InstallerType: inno
+# installer.iss 是 PrivilegesRequired=admin + {autopf}：装到 Program Files，
+# Scope 与 ElevationRequirement 两个语义都要声明（缺 Scope 时
+# winget install --scope machine/user 无法按范围过滤到这个包）
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+# 显式写全（与 winget 对 inno 的默认值一致）：一旦清单里给了 Silent，
+# winget 就不再叠加自己的默认参数，缺 /SUPPRESSMSGBOXES 会漏掉对话框抑制
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART /SP-
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/tau625/ShudaoLe/releases/download/v1.5.0/ShudaoLe-1.5.0-setup.exe
+  InstallerSha256: 1a624ba77caf1fe554df7d62d35bf9518f1fd6209f64ed42999b529b64fbe815
+  ElevationRequirement: elevationRequired
+  AppsAndFeaturesEntries:
+  - DisplayName: 书到了（ShudaoLe）
+    Publisher: tau625
+    DisplayVersion: 1.5.0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.locale.en-US.yaml
+++ b/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: tau625.ShudaoLe
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: tau625
+PublisherUrl: https://github.com/tau625
+PublisherSupportUrl: https://github.com/tau625/ShudaoLe/issues
+PackageName: ShudaoLe (Book Arrived)
+PackageUrl: https://github.com/tau625/ShudaoLe
+License: PolyForm-Noncommercial-1.0.0
+LicenseUrl: https://github.com/tau625/ShudaoLe/blob/main/LICENSE
+Copyright: Copyright (c) 2026 tau625
+ShortDescription: One-click official textbook PDF downloader for China's Smart Education platform
+Description: >-
+  ShudaoLe (Book Arrived) is a free desktop tool for teachers, students and
+  parents to browse and batch-download official K-12 textbook PDFs from
+  China's national Smart Education of Primary and Secondary School platform.
+  It filters by education stage, grade, subject and publisher, and serves a
+  local web UI in your browser — no browser extension, no account, no
+  third-party mirrors.
+Moniker: shudaole
+Tags:
+- education
+- textbook
+- pdf
+- downloader
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.yaml
+++ b/manifests/t/tau625/ShudaoLe/1.5.0/tau625.ShudaoLe.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: tau625.ShudaoLe
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Adds **书到了 (ShudaoLe)** — a desktop tool that downloads textbook PDFs from China's National Smart Education Platform (国家中小学智慧教育平台).

- Publisher: `tau625`
- Homepage: https://github.com/tau625/ShudaoLe
- Installer: Inno Setup (`ShudaoLe-1.5.0-setup.exe`) from GitHub Releases
- Silent install supported (`/VERYSILENT`), per-machine (`{autopf}`, requires elevation)

###### Microsoft CLA
By submitting this pull request, I confirm I have read and agree to the Microsoft CLA.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433105)