### PR TITLE
Update version: MarceloLvCabral.BrightScriptEmulator version 2.6.0

### DIFF
--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.installer.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.6.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+ReleaseDate: 2026-09-09
+AppsAndFeaturesEntries:
+- DisplayName: BrightScript Simulator 2.6.0
+  ProductCode: "{E69D4CB2-9611-5C63-AD1A-C28C6ED57B4F}"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lvcabral/brs-desktop/releases/download/v2.6.0/brs-desktop-2.6.0-windows.exe
+  InstallerSha256: 64AF662E346679398B120D7EF7F7A7A004A6F6CC9D9AD14156BE9F60B9C6D32B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.6.0
+PackageLocale: en-US
+Publisher: Marcelo Lv Cabral
+PublisherUrl: https://github.com/lvcabral
+PublisherSupportUrl: https://github.com/lvcabral/brs-desktop/issues
+PackageName: BrightScript Emulator
+PackageUrl: https://github.com/lvcabral/brs-desktop
+License: MIT
+LicenseUrl: https://github.com/lvcabral/brs-desktop/blob/master/LICENSE
+Copyright: Copyright © 2021 Marcelo Lv Cabral
+ShortDescription: Desktop Emulator for Roku 2D API
+Tags:
+- desktop
+- electron-app
+- emulator
+- roku
+- roku-development
+- simulator
+ReleaseNotes: "This release adds a **Registry by App** device setting that segregates `roRegistrySection` data per running sideloaded app, and fixes a bug where some zip/bpk packages had their bytes corrupted while loading over the `executeFile` IPC path, throwing `unknown compression type` on otherwise-valid packages. The Home app also gets a couple of focus/title polish fixes, and console log tag coloring now covers a bracketed tag's full content instead of stopping at the first non-word character. Bumped `brs-engine` to v2.5.4 and `brs-scenegraph` to v0.5.4, fixing a `callFunc` issued onto a SceneGraph `Task` (or a Task-owned `Node`) silently running locally instead of rendezvousing to the owning thread — the root cause of a reported New Relic SDK crash — along with a container-copy fix for an `assocarray`/`array` holding a SceneGraph node, and a `PeekMessage()`/`GetMessage()` fix that stopped a duplicate HTTP request and `roUrlEvent` delivery loop.\r\n\r\nSee the **BrightScript Simulation Engine** v2.5.4 [full changelog](https://github.com/lvcabral/brs-engine/releases/) for all the language and framework features and improvements.\r\n\r\n## New Features\r\n\r\n• Added a \"Registry by App\" device setting that segregates registry data per running sideloaded app, taking effect for the next app started with no device reset or simulator restart needed by @lvcabral in #347\r\n\r\n## Bug Fixes\r\n\r\n• Stopped corrupting zip/bpk package bytes on the `executeFile` IPC path, fixing `unknown compression type` errors sideloading some otherwise-valid packages by @lvcabral in #348\r\n• Fixed the Home app refreshing when focus returns to its left menu, \"Options\" showing in the Overhang menu outside the apps grid, and the main window title showing a duplicated \"BrightScript Simulator\" by @lvcabral in #345\r\n• Fixed bracketed console log tags only coloring up to the first non-word character instead of their full content by @lvcabral in #346\r\n\r\n## Maintenance\r\n\r\n• Set up the macOS signing keychain explicitly in CI instead of letting electron-builder manage it, working around an upstream `set-key-partition-list` unlock bug exposed by a macOS runner point release by [@lvcabral](https://github.com/lvcabral)\r\n• Stubbed `process.uptime()` in the ECP-2 device-info test to remove a rounding-boundary flake by [@lvcabral](https://github.com/lvcabral)\r\n\r\n## Dependency Bumps\r\n\r\n• Bump `brs-engine` from 2.5.2 to 2.5.4 by @lvcabral\r\n• Bump `brs-scenegraph` from 0.5.2 to 0.5.4 by @lvcabral\r\n• Bump `@xmldom/xmldom` from 0.8.13 to 0.8.15 by @lvcabral in #344\r\n• Bump `fast-uri` from 3.1.5 to 3.1.7 by @lvcabral in #343\r\n\r\n**Full Changelog**：https://github.com/lvcabral/brs-desktop/compare/v2.5.2...v2.6.0"
+ReleaseNotesUrl: https://github.com/lvcabral/brs-desktop/releases/tag/v2.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.yaml
+++ b/manifests/m/MarceloLvCabral/BrightScriptEmulator/2.6.0/MarceloLvCabral.BrightScriptEmulator.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: MarceloLvCabral.BrightScriptEmulator
+PackageVersion: 2.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Update MarceloLvCabral.BrightScriptEmulator to version 2.6.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433117)