### PR TITLE
New package: MarkPilot.MarkPilot version 2.0.18

### DIFF
--- a/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.installer.yaml
+++ b/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.installer.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarkPilot.MarkPilot
+PackageVersion: 2.0.18
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+  - DisplayName: MarkPilot
+    DisplayVersion: 2.0.18
+ReleaseDate: 2026-09-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ltmroberthk915/markpilot/releases/download/v2.0.18/markpilot-Setup-2.0.18.exe
+    InstallerSha256: 0ADCE6ECF76A51942CF9BDDDC543215E477ED6398C7C6C92078FB4290AAFC4A8
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.locale.en-US.yaml
+++ b/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarkPilot.MarkPilot
+PackageVersion: 2.0.18
+PackageLocale: en-US
+Publisher: MarkPilot
+PublisherUrl: https://github.com/ltmroberthk915/markpilot
+PublisherSupportUrl: https://github.com/ltmroberthk915/markpilot/issues
+PackageName: MarkPilot
+PackageUrl: https://github.com/ltmroberthk915/markpilot
+License: Freeware
+LicenseUrl: https://github.com/ltmroberthk915/markpilot#license
+Copyright: Copyright (c) MarkPilot
+ShortDescription: AI-native Markdown editor for Windows — a free Typora alternative with inline AI completion and live math editing.
+Description: |
+  MarkPilot is a Markdown editor built for people who write Markdown every day: AI inline
+  completion (GLM / DeepSeek presets, bring your own key, plus a local rule engine that keeps
+  working offline), Typora-style live math editing where you can click any symbol and edit the
+  source that produced it, chunked rendering that keeps 200,000-character documents smooth,
+  and print-quality CJK typography with Knuth-Plass line breaking on export.
+
+  Also ships as an editor extension for VS Code and Trae, exports to Word / Excel / PowerPoint
+  with formulas as editable OMML (no Pandoc required), and can be installed as a portable build
+  with no installation at all.
+Moniker: markpilot
+Tags:
+  - markdown
+  - markdown-editor
+  - typora-alternative
+  - ai
+  - writing
+  - notes
+  - latex
+  - math
+  - mermaid
+  - wysiwyg
+ReleaseNotesUrl: https://github.com/ltmroberthk915/markpilot/releases/tag/v2.0.18
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.yaml
+++ b/manifests/m/MarkPilot/MarkPilot/2.0.18/MarkPilot.MarkPilot.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarkPilot.MarkPilot
+PackageVersion: 2.0.18
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: MarkPilot.MarkPilot 2.0.18

- **Publisher:** MarkPilot (independent developer, `ltmroberthk915` on GitHub)
- **Product:** AI-native Markdown editor for Windows — a free Typora alternative with inline AI
  completion, click-to-edit math, large-file performance and print-quality CJK typography.
- **Installer:** `markpilot-Setup-2.0.18.exe` (NSIS, electron-builder), released at
  https://github.com/ltmroberthk915/markpilot/releases/tag/v2.0.18
- **License:** Freeware (app and extension are free; the editing-core source is licensed separately)
- **Validation:** `winget validate --manifest` passes locally; silent install (`/S`) verified.
- **Scope:** user (per-user install, no admin required).

I am the author of the package. Thanks for reviewing!

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433125)