### PR TITLE
New package: Google.Gemini version 1.10.4

### DIFF
--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.installer.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.installer.yaml
@@ -1,0 +1,19 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Google.Gemini
+PackageVersion: 1.10.4
+MinimumOSVersion: 10.0.0.0
+InstallerType: nullsoft
+Scope: user
+ProductCode: Gemini
+ReleaseDate: 2026-09-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.google.com/release2/Google%20DeepMind/ea75szpqyz4qkpxfdxb7gdxkyq_1.10.4/GeminiSetup-1.10.4.exe
+  InstallerSha256: 879E344C088648759B7CAE2C24E8588E79E603343491480066A95B469F5A8680
+- Architecture: arm64
+  InstallerUrl: https://dl.google.com/release2/Google%20DeepMind/p4cb3znx5c4aedwqxxicvfeoz4_1.10.4/GeminiSetup-1.10.4.exe
+  InstallerSha256: F5F58FFE69AA30DCCE008FD259AEFA77050AAF88C34A1033F343F34938285C49
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.installer.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.installer.yaml
@@ -3,7 +3,6 @@
 
 PackageIdentifier: Google.Gemini
 PackageVersion: 1.10.4
-MinimumOSVersion: 10.0.0.0
 InstallerType: nullsoft
 Scope: user
 ProductCode: Gemini

--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.en-US.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Google.Gemini
+PackageVersion: 1.10.4
+PackageLocale: en-US
+Publisher: Google LLC
+PublisherSupportUrl: https://support.google.com/gemini?p=windows_app
+PrivacyUrl: https://policies.google.com/privacy
+PackageName: Gemini
+PackageUrl: https://gemini.google/desktop/
+License: Proprietary
+LicenseUrl: https://policies.google.com/terms
+ShortDescription: Download Gemini for desktop on Windows and macOS.
+Description: Download Gemini for desktop on Windows and macOS. A native AI assistant with global shortcuts and automation to help you research, write and summarise files. From drafting documents to exploring creative ideas, Gemini is always just a shortcut away, ready to help right where you are so you never break your flow.
+Tags:
+- ai
+- ai-assistant
+- artificial-intelligence
+- chatbot
+- gemini
+- google
+- google-gemini
+ReleaseNotesUrl: https://gemini.google/release-notes/
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.en-US.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.en-US.yaml
@@ -5,22 +5,20 @@ PackageIdentifier: Google.Gemini
 PackageVersion: 1.10.4
 PackageLocale: en-US
 Publisher: Google LLC
-PublisherSupportUrl: https://support.google.com/gemini?p=windows_app
+PublisherSupportUrl: https://support.google.com/gemini/answer/18263854
 PrivacyUrl: https://policies.google.com/privacy
 PackageName: Gemini
 PackageUrl: https://gemini.google/desktop/
 License: Proprietary
 LicenseUrl: https://policies.google.com/terms
-ShortDescription: Download Gemini for desktop on Windows and macOS.
-Description: Download Gemini for desktop on Windows and macOS. A native AI assistant with global shortcuts and automation to help you research, write and summarise files. From drafting documents to exploring creative ideas, Gemini is always just a shortcut away, ready to help right where you are so you never break your flow.
+ShortDescription: A native AI assistant with global shortcuts and automation to help you research, write and summarise files
+Description: A native AI assistant with global shortcuts and automation to help you research, write and summarise files. From drafting documents to exploring creative ideas, Gemini is always just a shortcut away, ready to help right where you are so you never break your flow.
 Tags:
 - ai
-- ai-assistant
-- artificial-intelligence
 - chatbot
 - gemini
-- google
-- google-gemini
+- large-language-model
+- llm
 ReleaseNotesUrl: https://gemini.google/release-notes/
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.zh-CN.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.locale.zh-CN.yaml
@@ -1,0 +1,20 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Google.Gemini
+PackageVersion: 1.10.4
+PackageLocale: zh-CN
+PublisherSupportUrl: https://support.google.com/gemini/answer/18263854?hl=zh-Hans
+PrivacyUrl: https://policies.google.com/privacy?hl=zh-CN
+License: 专有软件
+LicenseUrl: https://policies.google.com/terms?hl=zh-CN
+ShortDescription: 一款原生 AI 助手，具备全局快捷键和自动化功能，助你研究、写作及总结文件。
+Description: 一款原生 AI 助手，具备全局快捷键和自动化功能，助你研究、写作及总结文件。从起草文档到探索创意灵感，Gemini 始终触手可及，随时随地为你提供支持，确保你的工作流永不中断。
+Tags:
+- gemini
+- 人工智能
+- 大模型
+- 大语言模型
+- 聊天机器人
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/g/Google/Gemini/1.10.4/Google.Gemini.yaml
+++ b/manifests/g/Google/Gemini/1.10.4/Google.Gemini.yaml
@@ -1,0 +1,8 @@
+# Created with YamlCreate.ps1 Dumplings Mod
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Google.Gemini
+PackageVersion: 1.10.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

Adds the Gemini desktop app for Windows (https://gemini.google/desktop/) as a new package, `Google.Gemini` version 1.10.4.

Installer and version evidence comes from Google's official Omaha update service (`https://update.googleapis.com/service/update2`, appid `{533dd80c-942a-4464-b6a9-2e59428d784e}`, `ap=prod`), which serves the full offline NSIS installers for x64 and arm64. Both installer SHA-256 values were verified against the Omaha response `hash_sha256` and re-verified after download:

- x64: `879E344C088648759B7CAE2C24E8588E79E603343491480066A95B469F5A8680`
- arm64: `F5F58FFE69AA30DCCE008FD259AEFA77050AAF88C34A1033F343F34938285C49`

Static analysis (Dumplings installer analysis) confirms: NSIS, user scope (`%LocalAppData%\Google\Gemini`), HKCU ARP key `Gemini`, signed by Google LLC, silent switch `/S` (NSIS default, so no explicit switches are authored).

Note: #432974 also adds `Google.Gemini`, but its `InstallerUrl` (`https://gemini.google/download/windows/`) is the HTML download page, which 302s to a ~12 MB `GeminiSetup.exe` web stub with PE version 152.0.7933.0 and x86 launcher architecture — hence its `Validation-Unattended-Failed`. This PR instead packages the version-stable full offline installers published by the app's own update service, with the version the app reports (1.10.4).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change (found #432974, see note above)
- [x] This PR only modifies one (1) manifest
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0) (offline schema validation passed with zero errors and warnings)
- [ ] Tested manifest locally with `winget install --manifest <path>` (not run on this host; the Azure pipeline's dynamic validation will exercise the silent install)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433144)