### PR TITLE
New version: StruisICT.ClutterCutter version 0.13.2

### DIFF
--- a/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.installer.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.13.2
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+Commands:
+- cluttercutter
+ReleaseDate: 2026-09-11
+ProductCode: '{FEA80848-6A4E-4569-807C-D5E92A919592}'
+AppsAndFeaturesEntries:
+- ProductCode: '{FEA80848-6A4E-4569-807C-D5E92A919592}'
+  UpgradeCode: '{FADE883B-0102-4A40-A367-3E96BD9692F7}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\ClutterCutter'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/StruisICT/ClutterCutter/releases/download/v0.13.2/ClutterCutter.msi
+  InstallerSha256: 18F0364141D689896E5C7330E0C470C93196C1993506FCAA254F47404F6E0630
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.locale.en-US.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.13.2
+PackageLocale: en-US
+Publisher: Struis ICT
+PublisherUrl: https://struisict.com
+PublisherSupportUrl: https://github.com/StruisICT/ClutterCutter/issues
+PackageName: ClutterCutter
+PackageUrl: https://github.com/StruisICT/ClutterCutter
+License: MIT
+LicenseUrl: https://github.com/StruisICT/ClutterCutter/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Struis ICT
+ShortDescription: Fast disk-usage browser with NTFS MFT scanning.
+Description: |-
+  ClutterCutter is a lightweight Windows disk-usage browser. On NTFS drives it
+  reads the Master File Table directly for very fast full-drive scans (roughly
+  one million files in six seconds), with a parallel FindFirstFileEx walker as
+  a fallback for non-NTFS drives and non-admin runs. Includes a treeview
+  drill-in, a Top-largest-files view, an Oldest-files (by date modified) view,
+  and a safe-to-delete temp/cache files view. Installs per-machine to Program Files with a Start
+  Menu entry; no .NET runtime required.
+Moniker: cluttercutter
+Tags:
+- disk
+- disk-usage
+- ntfs
+- mft
+- treesize
+- utility
+- windows
+ReleaseNotes: |-
+  See the full release notes at https://github.com/StruisICT/ClutterCutter/releases/tag/v0.13.2
+ReleaseNotesUrl: https://github.com/StruisICT/ClutterCutter/releases/tag/v0.13.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.yaml
+++ b/manifests/s/StruisICT/ClutterCutter/0.13.2/StruisICT.ClutterCutter.yaml
@@ -1,0 +1,8 @@
+# Created with: scripts/Update-WingetManifest.ps1
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: StruisICT.ClutterCutter
+PackageVersion: 0.13.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version: StruisICT.ClutterCutter version 0.13.2

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/tools/SandboxTest.md) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Version **0.13.2** for `StruisICT.ClutterCutter` (supersedes the closed 0.13.1 PR).

**Fixes the `Validation-Executable-Error`** from earlier submissions. The moderator's automated run showed `ClutterCutter.exe` exiting with `STATUS_DLL_NOT_FOUND` (0xC0000135) — the exe dynamically linked the MSVC C runtime and had no VCRedist declared, so it couldn't launch on a clean machine. 0.13.2 statically links the CRT (`-C target-feature=+crt-static`), so the binary is now fully self-contained (verified: it imports only core Windows system DLLs — no `vcruntime140`/`ucrtbase`/`msvcp140`). Plain WiX MSI, per-machine, Program Files + Start Menu + ARP. `winget validate` passes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433159)