### PR TITLE
New package: NoaSansH.Thermalyn version 1.3.0

### DIFF
--- a/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.installer.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.installer.yaml
@@ -1,0 +1,23 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.3.0
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+  SilentWithProgress: /SILENT /SUPPRESSMSGBOXES /NORESTART
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+UpgradeBehavior: install
+ProductCode: '{8F2C1D74-4E63-4A18-9E2B-5C7A0D3F1B96}_is1'
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NoaSansH/Thermalyn/releases/download/v1.3.0/Thermalyn-Setup-1.3.0.exe
+  InstallerSha256: 2FE5719314DA1955016E1CD279D5491511029AF8B03D76C736EF3CB84BA9CFCD
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.locale.en-US.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.locale.en-US.yaml
@@ -1,0 +1,33 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.3.0
+PackageLocale: en-US
+Publisher: Thermalyn Project
+PublisherUrl: https://github.com/NoaSansH
+PublisherSupportUrl: https://github.com/NoaSansH/Thermalyn/issues
+PackageName: Thermalyn
+PackageUrl: https://github.com/NoaSansH/Thermalyn
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/NoaSansH/Thermalyn/blob/main/LICENSE
+Copyright: Copyright (C) 2026 Thermalyn Project
+ShortDescription: Hardware monitor for Windows 11 with processor, graphics, memory and drive sensors.
+Description: |-
+  Thermalyn reads processor, graphics, memory and drive sensors and keeps a 15-minute history.
+  It offers Mini, Compact, Balanced and Detailed views that adapt to the window size, an English,
+  French, Spanish and German interface, dark and light themes, and per-component warm and critical
+  thresholds with a history of every crossing.
+
+  Sensors are selected by exact name and never inferred, so a reading that cannot be identified is
+  reported as absent rather than approximated.
+
+  It runs entirely offline: no account, no telemetry and no background service.
+Moniker: thermalyn
+Tags:
+- hardware-monitor
+- temperature
+- cpu
+- gpu
+- sensors
+- system-monitor
+ReleaseNotesUrl: https://github.com/NoaSansH/Thermalyn/releases/tag/v1.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.yaml
+++ b/manifests/n/NoaSansH/Thermalyn/1.3.0/NoaSansH.Thermalyn.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: NoaSansH.Thermalyn
+PackageVersion: 1.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description

Thermalyn 1.3.0, a hardware monitor for Windows 11.

This supersedes #432525, which was opened for 1.1.1 and failed unattended installation. The cause
was in the installer: when Microsoft .NET Desktop Runtime 8 is absent it asks for confirmation
before downloading it, so an unattended run has a prompt waiting on it.

`Microsoft.DotNet.DesktopRuntime.8` is now declared as a package dependency. The runtime is
therefore present before the installer runs, the installer detects it and skips that prompt
entirely. #432525 has been closed in favour of this one.

- Installer type: Inno Setup, machine scope
- Silent switches: `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`
- `InstallerSha256` verified against the published asset by downloading it
- Release: https://github.com/NoaSansH/Thermalyn/releases/tag/v1.3.0
- Manifest schema: 1.6.0

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## Manifest checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [ ] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

The last two are unchecked on purpose. The manifest targets schema 1.6.0, the same version that
passed schema validation on #432525. The local install was not run: Windows Sandbox is unavailable
on the machine this was prepared from, and the dependency change is precisely what the pipeline
needs to exercise.
