### PR TITLE
New version: Psynect.OmniMend version 2.0.9

### DIFF
--- a/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.installer.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.9
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /S
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://crashpro-inference.psynect.workers.dev/releases/v2.0.9/OmniMend-v2.0.9-offline-setup.exe
+  InstallerSha256: 5E13E3BCBC17F269BCD426C52F81A9688500582959F2D654BAF27CDD98C65E31
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.locale.en-US.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.locale.en-US.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.9
+PackageLocale: en-US
+Publisher: Psynect Corp
+PublisherUrl: https://omnimend.com/
+PublisherSupportUrl: https://omnimend.com/contact
+PrivacyUrl: https://omnimend.com/privacy
+Author: Psynect Corp
+PackageName: OmniMend
+PackageUrl: https://omnimend.com/
+License: Proprietary
+LicenseUrl: https://omnimend.com/terms
+Copyright: Copyright (c) 2026 Psynect Corp. All rights reserved.
+ShortDescription: Complete Windows host for OmniMend device diagnostics, approved PC repair, and Security Vitals Beta.
+Description: |-
+  OmniMend is an agentic AI diagnostic system for the devices people and technicians use. This Windows package is its complete host for local PC diagnosis and approved repair plus supported iPhone and iPad, Android, Chromebook, recovery, and professional workflows. The Apple Silicon Mac app is available separately for native local Mac diagnostics.
+
+  Diagnosis stays read-only. If a supported repair fits the evidence, OmniMend explains the action, waits for the user's approval, and checks the relevant result afterward.
+
+  Security Vitals Beta is a separate Windows-only workspace. It filters ordinary activity locally, uses a bounded and redacted cloud AI summary for higher-risk patterns, and works alongside Microsoft Defender or another registered antivirus. It is designed to help investigate unfamiliar behavior, including patterns that can appear in emerging or zero-day attacks. It does not replace antivirus, promise perfect detection, or quarantine anything automatically.
+Moniker: omnimend
+Tags:
+- ai
+- crash
+- diagnostics
+- maintenance
+- repair
+- security
+- system
+- troubleshooting
+- windows
+PurchaseUrl: https://omnimend.com/plans
+ReleaseNotes: |-
+  - Fixed an issue where reports created without custom branding could be missing from Report Studio.
+  - Fixed a layout check that could block saving or printing reports with decorative shapes.
+ReleaseNotesUrl: https://omnimend.com/changelog
+ReleaseDate: 2026-09-10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.yaml
+++ b/manifests/p/Psynect/OmniMend/2.0.9/Psynect.OmniMend.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Psynect.OmniMend
+PackageVersion: 2.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `Psynect.OmniMend` to version 2.0.9.

- Uses the signed x64 installer from OmniMend's official release host.
- Keeps the existing Nullsoft silent-install switches.
- Updates the release notes and current product metadata.

Installer SHA-256: `5E13E3BCBC17F269BCD426C52F81A9688500582959F2D654BAF27CDD98C65E31`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433238)