### PR TITLE
New version: ChristofMueller.DeviceShelf version 1.9.30

### DIFF
--- a/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.installer.yaml
+++ b/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: ChristofMueller.DeviceShelf
+PackageVersion: 1.9.30
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-10
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.deviceshelf.app/DeviceShelf-1.9.30-setup.exe
+    InstallerSha256: 4741C1AAD4F058939CAE5A3311E46D9C9F4E3BFAC7BC03F56F582F18C6B5029E
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.locale.en-US.yaml
+++ b/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.locale.en-US.yaml
@@ -1,0 +1,43 @@
+PackageIdentifier: ChristofMueller.DeviceShelf
+PackageVersion: 1.9.30
+PackageLocale: en-US
+Publisher: Christof Müller
+PublisherUrl: https://deviceshelf.app
+PublisherSupportUrl: https://deviceshelf.app
+PackageName: DeviceShelf
+PackageUrl: https://deviceshelf.app
+License: Proprietary
+LicenseUrl: https://deviceshelf.app
+Copyright: Copyright (c) 2026 Christof Müller
+ShortDescription: Local-first network scanner that finds and identifies every device on your LAN.
+Description: |-
+  DeviceShelf scans your local network and tells you what every device on it
+  actually is: vendor, type, operating system, open ports. It runs on your own
+  machine, and nothing about your network leaves it unless you turn that on.
+
+  Npcap is required on Windows and is not bundled: the x64 build links wpcap.dll
+  at load time, so the app will not start without it. Install it from
+  https://npcap.com/#download first. The interactive installer says so as well,
+  but `winget install` runs silently and skips that prompt.
+
+  Beyond discovery there is a per-device security report covering TLS, SSH, SMB
+  and HTTP checks, presence monitoring that alerts you when an unknown device
+  joins or a known one drops off, per-device bandwidth and a topology map.
+  AI-assisted identification is optional and uses your own API key; none is
+  bundled or required.
+
+  A headless server edition covers 24/7 monitoring as a Docker image, a .deb
+  install or a Windows service, and it is part of the same one-time licence.
+Moniker: deviceshelf
+Tags:
+  - network
+  - network-scanner
+  - ip-scanner
+  - lan
+  - monitoring
+  - security
+  - device-discovery
+  - inventory
+ReleaseNotesUrl: https://deviceshelf.app/blog
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.yaml
+++ b/manifests/c/ChristofMueller/DeviceShelf/1.9.30/ChristofMueller.DeviceShelf.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: ChristofMueller.DeviceShelf
+PackageVersion: 1.9.30
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## 📖 Description

DeviceShelf 1.9.30, a version update for `ChristofMueller.DeviceShelf` (currently at 1.9.6). Installer URL and SHA256 point at the published NSIS setup on our own download host; the digest is taken from the bytes at that URL and matches the `.sha256` published beside it.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` — "Manifest validation succeeded."
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the schema (ManifestVersion 1.6.0, as in the merged 1.9.6 manifest)

On the install test: `winget install --manifest` verifies the hash and then stalls on our test machine, which is driven over SSH and runs the installer in a non-interactive session-0 context. Rather than tick a box I could not honestly tick, here is what was verified instead: `winget validate` passes, the installer hash in the manifest matches the published artefact, and the same NSIS installer from the same URL installs and runs from an interactive desktop session.

Note for anyone reading the description: DeviceShelf needs Npcap on Windows and does not bundle it. That is stated in the locale manifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433240)