### PR TITLE
New version: Brows3Team.Brows3 version 0.2.45

### DIFF
--- a/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.installer.yaml
+++ b/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.installer.yaml
@@ -1,0 +1,31 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Brows3Team.Brows3
+PackageVersion: 0.2.45
+InstallerLocale: en-US
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerType: nullsoft
+  Scope: user
+  InstallerUrl: https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.45/Brows3_0.2.45_x64-setup.exe
+  InstallerSha256: 7683AF230FC244397EBBDB13071E386577059A4C70983B51DE0C33F96AFA76F1
+  ProductCode: Brows3
+  AppsAndFeaturesEntries:
+  - ProductCode: Brows3
+  InstallationMetadata:
+    DefaultInstallLocation: '%LocalAppData%\Brows3'
+- Architecture: x64
+  InstallerType: wix
+  Scope: machine
+  InstallerUrl: https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.45/Brows3_0.2.45_x64_en-US.msi
+  InstallerSha256: C3A14DE1D2FDAE97BFB36E95772769A14F449DFB0D85171FAF6D0AD7DD9CC7F1
+  ProductCode: '{20929EA8-857B-429E-9E8D-3BDC07184652}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{20929EA8-857B-429E-9E8D-3BDC07184652}'
+    UpgradeCode: '{26EA2ACA-54B4-51EB-A718-0E3D3E90BC2B}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%/Brows3'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.locale.en-US.yaml
+++ b/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Brows3Team.Brows3
+PackageVersion: 0.2.45
+PackageLocale: en-US
+Publisher: Brows3 Team
+PublisherUrl: https://github.com/rgcsekaraa
+PublisherSupportUrl: https://github.com/rgcsekaraa/brows3/issues
+PackageName: Brows3
+PackageUrl: https://github.com/rgcsekaraa/brows3
+License: MIT
+LicenseUrl: https://github.com/rgcsekaraa/brows3/blob/HEAD/LICENSE
+ShortDescription: Fast, open-source desktop client for Amazon S3 and S3-compatible object storage.
+Description: Brows3 is a desktop S3 browser for AWS S3, MinIO, Cloudflare R2, Wasabi, DigitalOcean Spaces, and custom S3-compatible endpoints.
+Tags:
+- amazon-s3
+- aws-s3
+- cloudflare-r2
+- desktop-app
+- minio
+- object-storage
+- rust
+- s3-browser
+- s3-client
+- tauri
+- wasabi
+ReleaseNotes: |-
+  Brows3 0.2.45 release notes
+  Added
+  - Create buckets, edit bucket policies and delete empty buckets from All Buckets. Destructive actions require the bucket name, and profile changes dismiss pending actions. (#27)
+  - Favorite bucket roots from the sidebar or bucket header. Thanks to @EricERodriguez for the contribution. (#30, #31)
+  - Unit and component coverage for core features, production browser smoke tests in Chromium and WebKit, and native CI on Linux, macOS and Windows.
+  Fixed
+  - Keep clipboard, move, search and transfer operations bound to their original profile and bucket.
+  - Reject stale sorted-listing cursors without crashing the application. Keep pagination available through empty pages and prevent overlapping requests. (#28)
+  - Commit downloads without overwriting existing files, reject unsafe paths and symlinks, remove interrupted partial files and retain safe destinations on retry.
+  - Bound stalled transfers and multipart aborts, scale request timeouts for larger uploads and show provider error details in transfer lists. Thanks to @EricERodriguez for the initial timeout and error improvements. (#32)
+  - Send an explicit signed zero content length when creating folders and preserve custom endpoint errors. Added a Garage v1.0.1 integration check. (#29)
+  - Provide working File and Window commands on Linux where predefined native menu items are unsupported. (#33)
+  - Preserve legacy credentials during migration and write credential files atomically with private permissions.
+  - Detect concurrent text edits, preserve object attributes on save and use multipart copy for large objects.
+  - Fix transfer scheduling and listener cleanup, refresh views after cache changes and report incomplete deletions.
+  - Restore narrow-window navigation, keyboard object selection and clipboard shortcuts. Require an explicit permissions change before applying ACLs.
+  - Allow bundled editor fonts and workers, HTTPS media and PDF previews under the desktop content security policy.
+  Changed
+  - Remove unused assets and build leftovers, organize tests and document local verification.
+  - Check desktop packages before uploading release assets, alongside existing updater signature and WinGet manifest validation.
+ReleaseNotesUrl: https://github.com/rgcsekaraa/brows3/releases/tag/app-v0.2.45
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/rgcsekaraa/brows3/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.yaml
+++ b/manifests/b/Brows3Team/Brows3/0.2.45/Brows3Team.Brows3.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Brows3Team.Brows3
+PackageVersion: 0.2.45
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `Brows3Team.Brows3` to 0.2.45 from the [published release](https://github.com/rgcsekaraa/brows3/releases/tag/app-v0.2.45).

Includes the x64 NSIS installer for user scope and the x64 MSI for machine scope. Both installer hashes match the release downloads, and the existing MSI UpgradeCode is preserved.

The release passed Windows native tests, NSIS installation and portable startup checks in [CI](https://github.com/rgcsekaraa/brows3/actions/runs/34626690789).

Manifests generated with [Komac](https://github.com/russellbanks/Komac) v2.16.0.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433323)