### PR TITLE
New package: Kevin589981.autossh version 0.2.1

### DIFF
--- a/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.installer.yaml
+++ b/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.installer.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Kevin589981.autossh
+PackageVersion: 0.2.1
+InstallerType: portable
+Commands:
+- autossh
+ReleaseDate: 2026-09-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Kevin589981/autossh-windows/releases/download/v0.2.1/autossh-windows-amd64.exe
+  InstallerSha256: 4728D793C7DC40279B883331AF551EBC18752D385A66FCFFD2F9CD40272BAD5C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.locale.en-US.yaml
+++ b/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Kevin589981.autossh
+PackageVersion: 0.2.1
+PackageLocale: en-US
+Publisher: Kevin589981
+PublisherUrl: https://github.com/Kevin589981
+PublisherSupportUrl: https://github.com/Kevin589981/autossh-windows/issues
+Author: Kevin589981
+PackageName: autossh-windows
+PackageUrl: https://github.com/Kevin589981/autossh-windows
+License: MIT
+LicenseUrl: https://github.com/Kevin589981/autossh-windows/blob/v0.2.1/LICENSE
+ShortDescription: Windows-native SSH connection supervisor with automatic restart and monitoring.
+Description: |-
+  autossh-windows supervises the native Windows OpenSSH client, restarts
+  unexpected SSH exits, and optionally probes SSH port forwarding monitors.
+Moniker: autossh
+Tags:
+- ssh
+- autossh
+- tunnel
+- proxy
+- reconnect
+ReleaseNotesUrl: https://github.com/Kevin589981/autossh-windows/releases/tag/v0.2.1
+Documentations:
+- DocumentLabel: Documentation
+  DocumentUrl: https://github.com/Kevin589981/autossh-windows#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.yaml
+++ b/manifests/k/Kevin589981/autossh/0.2.1/Kevin589981.autossh.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Kevin589981.autossh
+PackageVersion: 0.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Package submission

Adds the Windows-native autossh CLI from https://github.com/Kevin589981/autossh-windows.

- PackageIdentifier: Kevin589981.autossh
- PackageVersion: 0.2.1
- InstallerType: portable
- Architecture: x64
- Version-specific installer URL: https://github.com/Kevin589981/autossh-windows/releases/download/v0.2.1/autossh-windows-amd64.exe
- Installer SHA256: 4728D793C7DC40279B883331AF551EBC18752D385A66FCFFD2F9CD40272BAD5C
- v0.2.0 was superseded because the portable executable validator launched it without arguments; v0.2.1 prints usage and exits successfully for that probe.
- Local validation: winget validate --manifest succeeded

This PR contains one package version and only the three required multi-file manifest files.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433336)