### PR TITLE
New version: kayapater.VideoDownloader version 2.0.0

### DIFF
--- a/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.installer.yaml
+++ b/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.installer.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: kayapater.VideoDownloader
+PackageVersion: 2.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.19041.0
+InstallerType: wix
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-11
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8
+      MinimumVersion: 8.0.0
+    - PackageIdentifier: Microsoft.EdgeWebView2Runtime
+ProductCode: '{32BBBB78-C4EC-4ED4-BBED-87E675920550}'
+AppsAndFeaturesEntries:
+  - DisplayName: Video Downloader
+    Publisher: kayapater
+    DisplayVersion: 2.0.0
+    ProductCode: '{32BBBB78-C4EC-4ED4-BBED-87E675920550}'
+    UpgradeCode: '{A6A7B2F7-8B1D-4A07-9E20-C3AB1DBBC0A4}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Blackswan-Yazilim/video-downloader/releases/download/v2.0.0/VideoDownloader-2.0.0-Setup.msi
+    InstallerSha256: 75AF98446B8321543732CE73BCD5F8A914F60C3798167F541A3E2E1BA580ED6E
+    ProductCode: '{32BBBB78-C4EC-4ED4-BBED-87E675920550}'
+    AppsAndFeaturesEntries:
+      - DisplayName: Video Downloader
+        Publisher: kayapater
+        DisplayVersion: 2.0.0
+        ProductCode: '{32BBBB78-C4EC-4ED4-BBED-87E675920550}'
+        UpgradeCode: '{A6A7B2F7-8B1D-4A07-9E20-C3AB1DBBC0A4}'
+ManifestType: installer
+ManifestVersion: 1.6.0
+

--- a/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.locale.en-US.yaml
+++ b/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: kayapater.VideoDownloader
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: kayapater
+PublisherUrl: https://kayapater.dev
+PublisherSupportUrl: https://github.com/Blackswan-Yazilim/video-downloader/issues
+PackageName: Video Downloader
+PackageUrl: https://github.com/Blackswan-Yazilim/video-downloader
+License: MIT
+LicenseUrl: https://github.com/Blackswan-Yazilim/video-downloader/blob/main/LICENSE
+ShortDescription: Download video and audio from supported platforms.
+Description: Video Downloader is a Windows desktop application powered by yt-dlp and FFmpeg with a modern WebView2 interface.
+ReleaseNotesUrl: https://github.com/Blackswan-Yazilim/video-downloader/releases/tag/v2.0.0
+Tags:
+  - video
+  - downloader
+  - youtube
+  - yt-dlp
+  - ffmpeg
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+

--- a/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.locale.tr-TR.yaml
+++ b/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.locale.tr-TR.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.6.0.schema.json
+
+PackageIdentifier: kayapater.VideoDownloader
+PackageVersion: 2.0.0
+PackageLocale: tr-TR
+Publisher: kayapater
+PublisherUrl: https://kayapater.dev
+PublisherSupportUrl: https://github.com/Blackswan-Yazilim/video-downloader/issues
+PackageName: Video İndirici
+PackageUrl: https://github.com/Blackswan-Yazilim/video-downloader
+License: MIT
+LicenseUrl: https://github.com/Blackswan-Yazilim/video-downloader/blob/main/LICENSE
+Copyright: Telif Hakkı (c) 2026 kayapater
+CopyrightUrl: https://github.com/Blackswan-Yazilim/video-downloader/blob/main/LICENSE
+ShortDescription: Desteklenen platformlardan video ve ses indirme uygulaması.
+Description: Video İndirici, yt-dlp ve FFmpeg altyapısıyla güçlendirilmiş, modern WebView2 arayüzüne sahip bir Windows masaüstü uygulamasıdır.
+ReleaseNotesUrl: https://github.com/Blackswan-Yazilim/video-downloader/releases/tag/v2.0.0
+Tags:
+  - video
+  - downloader
+  - indirici
+  - youtube
+  - yt-dlp
+  - ffmpeg
+ManifestType: locale
+ManifestVersion: 1.6.0

--- a/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.yaml
+++ b/manifests/k/kayapater/VideoDownloader/2.0.0/kayapater.VideoDownloader.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: kayapater.VideoDownloader
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Description
New version: kayapater.VideoDownloader version 2.0.0

## Changes
- Upgraded to version 2.0.0
- Switched to WiX-based MSI installer
- Updated SHA256 checksum and ProductCode
- Updated dependencies to include Microsoft.DotNet.DesktopRuntime.8 and Microsoft.EdgeWebView2Runtime
- Added Turkish (tr-TR) and English (en-US) localization manifests

## Validation
- Validated via winget validate --manifest packaging/winget
- Manifest validation succeeded

Installer URL:
https://github.com/Blackswan-Yazilim/video-downloader/releases/download/v2.0.0/VideoDownloader-2.0.0-Setup.msi
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433393)