### PR TITLE
New version: ProxyKit.ProxyKitCLI version 1.2.0

### DIFF
--- a/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.installer.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.installer.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.2.0
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.17763.0
+Scope: user
+UpgradeBehavior: uninstallPrevious
+ReleaseDate: 2026-09-10
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.2.0/cli/windows-amd64/proxykit-cli-1.2.0-windows-amd64.zip
+    InstallerSha256: 849a08cd2d474f66db06a0a9b20427b601c1254bbbcd1ee3f0e29360a43e3678
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+      - RelativeFilePath: bin\proxykit-mcp.exe
+        PortableCommandAlias: proxykit-mcp
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://release.proxykit.net/v1.2.0/cli/windows-arm64/proxykit-cli-1.2.0-windows-arm64.zip
+    InstallerSha256: 55c692483414ed03d82f08e82853032bde48bd0a548264bfa21806f095b6e17b
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: bin\proxykit.exe
+        PortableCommandAlias: proxykit
+      - RelativeFilePath: bin\proxy-engine.exe
+        PortableCommandAlias: proxy-engine
+      - RelativeFilePath: bin\proxykit-mcp.exe
+        PortableCommandAlias: proxykit-mcp
+    ArchiveBinariesDependOnPath: true
+    InstallModes:
+      - silent
+    Commands:
+      - proxykit
+    Platform:
+      - Windows.Desktop
+
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.locale.en-US.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.2.0
+PackageLocale: en-US
+Publisher: ProxyKit
+PublisherUrl: https://proxykit.net
+PublisherSupportUrl: https://github.com/AA-Box/ProxyKit-issues/issues
+PackageName: ProxyKit CLI
+PackageUrl: https://proxykit.net
+License: Proprietary
+LicenseUrl: https://proxykit.net/terms#license
+ShortDescription: Standalone ProxyKit CLI, headless MITM proxy engine, and MCP server
+Description: |
+  Command-line companion for ProxyKit. Controls a running proxy engine or launches
+  a bundled headless engine for CI and automation. Also ships proxykit-mcp, a Model
+  Context Protocol server that lets MCP-capable IDEs and agents drive the local
+  proxy engine. Separate from ProxyKit.
+Moniker: proxykit
+Tags:
+  - proxy
+  - http
+  - debugging
+  - cli
+  - mcp
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.yaml
+++ b/manifests/p/ProxyKit/ProxyKitCLI/1.2.0/ProxyKit.ProxyKitCLI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: ProxyKit.ProxyKitCLI
+PackageVersion: 1.2.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New version of **ProxyKit CLI** (`ProxyKit.ProxyKitCLI`): **1.2.0**. Version 1.0.0 is already present; this adds 1.2.0 alongside it and does not modify the existing manifest.

ProxyKit CLI is the standalone command-line companion to ProxyKit — it controls a running proxy engine or launches a bundled headless MITM engine for CI and automation. It is distributed independently of the ProxyKit desktop application.

Delivered, as in 1.0.0, as a zip with a nested portable installer, exposing the bundled binaries on PATH for both x64 and arm64. No changes to installer type, scope, or upgrade behaviour.

**One packaging change since 1.0.0:** the archive now ships a third binary, `bin\proxykit-mcp.exe` — a Model Context Protocol (stdio) server that lets MCP-capable IDEs and agents drive the local proxy engine. It is declared as an additional `NestedInstallerFiles` entry with the `proxykit-mcp` alias, alongside the existing `proxykit` and `proxy-engine`. The package description and tags were updated to mention it.

| Architecture | Installer | SHA256 |
|---|---|---|
| x64 | `proxykit-cli-1.2.0-windows-amd64.zip` | `849a08cd2d474f66db06a0a9b20427b601c1254bbbcd1ee3f0e29360a43e3678` |
| arm64 | `proxykit-cli-1.2.0-windows-arm64.zip` | `55c692483414ed03d82f08e82853032bde48bd0a548264bfa21806f095b6e17b` |

Both archives were downloaded in full and hashed directly; the computed digests match the `.sha256` sidecars published beside each archive on `release.proxykit.net`, so the sidecars describe the real bytes rather than only agreeing with themselves. Both archives were extracted and confirmed to contain `bin\proxykit.exe`, `bin\proxy-engine.exe`, and `bin\proxykit-mcp.exe` — the exact `RelativeFilePath` entries this manifest declares — and the bundled `VERSION` file reads `1.2.0`. All installer, publisher, package, and license URLs return 200.

This supersedes #413854 (version 1.0.1), which is being closed in favour of this release.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  <!-- Not applicable: routine version bump, no issue filed. -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>`
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

<sub>On the two unchecked manifest boxes: the submitter works on macOS and cannot run `winget` locally. In place of `winget validate`, all three files were validated against the published 1.12.0 JSON schemas (`aka.ms/winget-manifest.*.1.12.0.schema.json`) and pass. The sandbox install test has not been run — flagging that honestly rather than ticking the box.</sub>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433396)