### PR TITLE
New package: Genea.OpenTranscribe version 0.3.7

### DIFF
--- a/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.installer.yaml
+++ b/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Genea.OpenTranscribe
+PackageVersion: 0.3.7
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /S
+  SilentWithProgress: /P
+UpgradeBehavior: install
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.genea.ca/opentranscribe/OpenTranscribe_0.3.7_x64-setup.exe
+  InstallerSha256: BE77825D5DB31319FDC8A83A79752E202B66935DF28C9210948B2E40181A1A78
+  AppsAndFeaturesEntries:
+  - DisplayName: OpenTranscribe
+    Publisher: Genea
+    DisplayVersion: 0.3.7
+    ProductCode: OpenTranscribe
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.locale.en-US.yaml
+++ b/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.locale.en-US.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Genea.OpenTranscribe
+PackageVersion: 0.3.7
+PackageLocale: en-US
+Publisher: Genea
+PublisherUrl: https://genea.ca
+PublisherSupportUrl: https://www.genea.ca/opentranscribe-bug-report/
+PrivacyUrl: https://www.genea.ca/opentranscribe-privacy/
+Author: Genea
+PackageName: OpenTranscribe
+PackageUrl: https://www.genea.ca/opentranscribe-windows/
+License: Proprietary
+Copyright: Copyright (c) Genea
+ShortDescription: AI transcription for historical handwritten documents
+Description: |-
+  OpenTranscribe turns folders of scanned and handwritten documents into searchable text using local and open public AI models. Drag in a folder of images or PDFs, pick a model, and it transcribes the batch.
+
+  Models run either through a provider you bring an API key for (OpenRouter, Google Gemini, OpenAI, Anthropic) or entirely on your own machine against Ollama, LM Studio, llama.cpp, or vLLM. Documents and API keys stay on your computer, and keys are held in the Windows Credential Manager rather than in a file.
+
+  Transcriptions are written to a working folder you choose, as ordinary files you can back up or move. The app includes a side by side editor for correcting results against the original image, keyword search across the whole library, and export to PDF, TXT, CSV, or XML.
+
+  This is the desktop build of the OpenTranscribe browser extension, and it is free to use. Transcription costs, when you use a hosted model, are paid directly to that provider.
+Moniker: opentranscribe
+Tags:
+- ai
+- archives
+- documents
+- genealogy
+- handwriting
+- history
+- htr
+- ocr
+- research
+- transcription
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.yaml
+++ b/manifests/g/Genea/OpenTranscribe/0.3.7/Genea.OpenTranscribe.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Genea.OpenTranscribe
+PackageVersion: 0.3.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

New package: **Genea.OpenTranscribe** version **0.3.7**.

OpenTranscribe transcribes scanned historical and handwritten documents using local
and open public AI models. It is the desktop build of an existing browser extension,
free to use, with models run either through a provider the user brings their own API
key for or entirely locally against Ollama, LM Studio, llama.cpp, or vLLM.

- Homepage / install guide: https://www.genea.ca/opentranscribe-windows/
- Publisher: https://genea.ca
- Installer: Tauri-built NSIS, per-user (`Scope: user`), signed with Azure Artifact
  Signing and RFC 3161 timestamped.

The installer URL is a stable, versioned, redirect-free HTTPS URL on the publisher's
own host.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue (if applicable)
  - N/A, this is a new package submission.

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

### Local test output

```
> winget validate --manifest .
Manifest validation succeeded.

> winget install --manifest .
Found OpenTranscribe [Genea.OpenTranscribe] Version 0.3.7
Downloading https://download.genea.ca/opentranscribe/OpenTranscribe_0.3.7_x64-setup.exe
Successfully verified installer hash
Starting package install...
Successfully installed

> winget list opentranscribe
Name            Id                             Version
OpenTranscribe  ARP\User\Arm64\OpenTranscribe  0.3.7
```

Tested on Windows 11. The `AppsAndFeaturesEntries.ProductCode` value is
`OpenTranscribe`, which is the Add/Remove Programs subkey the Tauri NSIS installer
writes under `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\`, so the
installed version is correlated correctly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433402)