### PR TITLE
New version: TheJonaz.Moraine version 0.3.1

### DIFF
--- a/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.installer.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.1
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: moraine-windows-x86_64\moraine.exe
+    PortableCommandAlias: moraine
+Commands:
+  - moraine
+ReleaseDate: 2026-07-04
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/TheJonaz/moraine-backup/releases/download/v0.3.1/moraine-windows-x86_64.zip
+    InstallerSha256: C4D94F2EE160CDF99FB1E209F197F95098B8C119E64424FB71203CF48E47DD38
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.locale.en-US.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: Jonaz Thern
+PublisherUrl: https://www.thern.io
+PublisherSupportUrl: https://github.com/TheJonaz/moraine-backup/issues
+Author: Jonaz Thern
+PackageName: Moraine
+PackageUrl: https://moraine.thern.io
+License: MIT
+LicenseUrl: https://github.com/TheJonaz/moraine-backup/blob/main/LICENSE
+Copyright: Copyright (c) Jonaz Thern
+ShortDescription: Snapshot-based backup over SSH/rsync and rclone — command-line client.
+Description: |-
+  Moraine is a small, fast backup client written in Rust. Hard-linked snapshots
+  over SSH make every run look like a complete tree while only changed files take
+  new space; restore anything from any snapshot. It also supports an rclone
+  backend for cloud/object storage and FTP.
+
+  This Windows package ships the `moraine` command-line client. The GTK desktop
+  app is Linux-only.
+Moniker: moraine
+Tags:
+  - backup
+  - snapshot
+  - rsync
+  - rclone
+  - ssh
+  - cli
+  - rust
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.yaml
+++ b/manifests/t/TheJonaz/Moraine/0.3.1/TheJonaz.Moraine.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TheJonaz.Moraine
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been manually reviewed

Moraine 0.3.1 — snapshot-based backup over SSH/rsync and rclone (CLI + GTK desktop app).

- Installer: `moraine-windows-x86_64.zip` from the [v0.3.1 release](https://github.com/TheJonaz/moraine-backup/releases/tag/v0.3.1)
- `InstallerSha256` matches the `SHA256SUMS` published with the release.
- Submitted by the upstream maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXstL26NgbYQ9wEZeUxELA
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433405)