### PR TITLE
New package: Aleckstygit.WayCoder version 0.96.105

### DIFF
--- a/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.installer.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.installer.yaml
@@ -1,0 +1,15 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.105
+InstallerLocale: zh-CN
+InstallerType: portable
+Commands:
+  - waycoder
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.105/waycoder-v0.96.105-win-x64.zip
+    InstallerSha256: b615650a125d9ecaac1a98d2d52b758dcda6814cf2b26bb8327f818f7812d896
+  - Architecture: arm64
+    InstallerUrl: https://github.com/alecksty/waycoder/releases/download/v0.96.105/waycoder-v0.96.105-win-arm64.zip
+    InstallerSha256: 53aac45fd7596ff961c6cf33c5874ba9224d07cc82f480638ffe893c838c000a
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.locale.zh-CN.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.locale.zh-CN.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.105
+PackageLocale: zh-CN
+Publisher: Aleckstygit
+PublisherUrl: https://gitee.com/aleckstygit/way-coder
+PublisherSupportUrl: https://gitee.com/aleckstygit/way-coder/issues
+PackageName: WayCoder
+PackageUrl: https://gitee.com/aleckstygit/way-coder
+License: MIT
+ShortDescription: 中文编程智能体 CLI Coding Agent
+Tags:
+  - coding
+  - agent
+  - ai
+  - cli
+  - programmer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.yaml
+++ b/manifests/a/Aleckstygit/WayCoder/0.96.105/Aleckstygit.WayCoder.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Aleckstygit.WayCoder
+PackageVersion: 0.96.105
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## New package: Aleckstygit.WayCoder version 0.96.105

**WayCoder (道码)** — a Chinese-language CLI coding agent, shipped as a single
NativeAOT executable (no .NET runtime required).

| | |
|---|---|
| Installer type | `portable` |
| Command alias | `waycoder` |
| Architectures | x64, arm64 |
| Upstream | https://gitee.com/aleckstygit/way-coder |
| License | MIT |

### Notes for reviewers
- First submission of this package (`Aleckstygit.WayCoder`); I am the package author.
- Both installer URLs point at the stable release tag; the `InstallerSha256` values were
  computed from the uploaded release assets.

### Test plan
- [x] `InstallerSha256` verified against the downloaded release assets
- [ ] `winget validate` / `winget install --manifest` — not run locally (submitted from macOS)

### CLA
- [ ] I have signed the Microsoft Contributor License Agreement

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433450)