### PR TITLE
Update metadata: gohide.gohide version 5.2.2

### DIFF
--- a/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
+++ b/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
@@ -13,26 +13,37 @@ PackageUrl: https://gohide.net
 License: Proprietary
 LicenseUrl: https://gohide.net/en/legal/terms
 Copyright: Copyright (c) 2026 Xianwei Zhu
-ShortDescription: Hide app windows, taskbar buttons and tray icons on Windows with one hotkey.
+ShortDescription: Boss key for Windows 11 and 10 - one hotkey hides any app's window, taskbar button and tray icon, one hotkey restores it all.
 Description: |-
-  gohide hides the running applications you choose - their windows, taskbar buttons and even their
-  system-tray icons - with a single global hotkey, then restores everything exactly where it was.
-  Most classic window hiders stopped working on the redesigned Windows 11 notification area; gohide
-  still hides tray icons there. It can also mute an app while hidden, or suspend it entirely so a
-  hidden game stops using CPU and GPU. Everything is fully reversible, works offline, and needs no
-  account and no telemetry. Free for up to 5 managed apps; an optional Pro tier is a one-time
-  perpetual purchase with no subscription.
+  gohide is a boss key for Windows 11 and Windows 10. Press one global hotkey and the apps you
+  choose disappear completely - window, taskbar button and system-tray icon, all at once. Press
+  again and everything comes back exactly where it was.
+  Most "hide window" tools only hide the window: the taskbar button keeps flashing and the tray
+  icon still sits in the corner. gohide removes every trace of the apps you pick, then restores
+  them in place - position, size and stacking order intact - and it still hides tray icons on the
+  current Windows 11 notification area, where many older window hiders quietly stopped working.
+  Use it to hide apps while screen sharing, keep chats private on a shared PC, pause a game in a
+  blink (Pro can suspend the process so it stops using CPU and GPU), or hide a program from the
+  taskbar and Alt+Tab without closing it. Per-app hotkeys, a lock-screen hotkey and mute-while-
+  hidden are included. Everything is reversible, works offline, and needs no account and no
+  telemetry. Free for up to 5 managed apps; Pro is a one-time purchase, never a subscription.
 Moniker: gohide
 Tags:
 - boss-key
-- desktop
 - focus
-- hide
+- hide-app
+- hide-taskbar
+- hide-tray-icon
+- hide-window
 - hotkey
+- panic-button
 - privacy
 - productivity
+- screen-sharing
 - system-tray
 - taskbar
+- tray-icon
+- window-hider
 - window-management
 ReleaseNotesUrl: https://github.com/gohide/GoHide/releases/tag/v5.2.2
 Documentations:

--- a/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
+++ b/manifests/g/gohide/gohide/5.2.2/gohide.gohide.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://gohide.net/en/docs/troubleshooting
 PrivacyUrl: https://gohide.net/en/legal/privacy
 Author: Xianwei Zhu
 PackageName: gohide
-PackageUrl: https://gohide.net
+PackageUrl: https://gohide.net/?utm_source=winget
 License: Proprietary
 LicenseUrl: https://gohide.net/en/legal/terms
 Copyright: Copyright (c) 2026 Xianwei Zhu


### PR DESCRIPTION
Metadata-only update for the existing 5.2.2 manifests (no installer change): rewrites ShortDescription/Description to lead with what the app does (boss key: hide window + taskbar button + tray icon with one hotkey) and expands Tags so `winget search` finds it by intent (boss-key, hide-window, hide-app, hide-taskbar, hide-tray-icon, window-hider, panic-button, screen-sharing). Same text now used on the Microsoft Store listing.

- [x] Have you signed the Contributor License Agreement?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (schema-checked; no installer change)
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? (installer unchanged from the merged 5.2.2 manifest)
- [x] Does your manifest conform to the 1.6 schema?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433492)