### PR TITLE
New package: julianmb.OpenWinSidecar version 0.1.1

### DIFF
--- a/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.installer.yaml
+++ b/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.installer.yaml
@@ -1,0 +1,16 @@
+PackageIdentifier: julianmb.OpenWinSidecar
+PackageVersion: 0.1.0
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Gyan.FFmpeg
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/julianmb/OpenWinSidecar/releases/download/v0.1/OpenWinSidecar-Setup-0.1.0.exe
+  InstallerSha256: 9a33a345c471a10279b98cc9f54719fa2dbc8079f30e40ea98fcd205a5215941
+  InstallerSwitches:
+    Silent: /SILENT
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.locale.en-US.yaml
+++ b/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.locale.en-US.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: julianmb.OpenWinSidecar
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: julianmb
+PackageName: OpenWinSidecar
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/julianmb/OpenWinSidecar/blob/main/LICENSE
+Copyright: Copyright (c) 2026 OpenWinSidecar Contributors
+ShortDescription: Use your iPad as a wireless second Windows screen over Wi-Fi.
+Description: OpenWinSidecar turns an iPad into a real extra Windows monitor. A virtual
+  display driver extends the desktop, Intel Quick Sync encodes it to HEVC, and Safari
+  shows it with full touch and keyboard input. No client app, no subscription.
+PackageUrl: https://github.com/julianmb/OpenWinSidecar
+Tags:
+- ipad
+- second-monitor
+- virtual-display
+- hevc
+- sidecar
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.yaml
+++ b/manifests/j/julianmb/OpenWinSidecar/0.1.0/julianmb.OpenWinSidecar.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: julianmb.OpenWinSidecar
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement (CLA)](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)? (If not, the cla-bot will prompt after this PR opens.)
- [x] Have you checked that the package doesn't exist in the repository already?
- [x] Have you checked that the latest package version isn't in the repository already?
- [x] Have you validated the manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested that the package installs successfully with the installer's silent switch (`/SILENT`, the switch winget sends)?
- [x] Does your manifest follow the [manifest authoring instructions](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md)?

### Description

New package `julianmb.OpenWinSidecar` version 0.1.1 — an open-source (AGPL-3.0) virtual-monitor server that turns an iPad or any modern browser into a wireless second Windows screen: IddCx virtual display, hardware HEVC end-to-end (Intel Quick Sync → WebCodecs), touch/keyboard input, no client app.

- Inno Setup installer, machine scope, silent switch `/SILENT`
- The HEVC encoder shells out to FFmpeg, so the manifest declares `Gyan.FFmpeg` under `PackageDependencies`; the installer additionally detects and installs FFmpeg via winget when run standalone
- Installer verified with live elevated install/uninstall cycles (driver registration, firewall rule, clean uninstall); `winget validate` passes on all three manifests
- Release asset: https://github.com/julianmb/OpenWinSidecar/releases/download/v0.1.1/OpenWinSidecar-Setup-0.1.1.exe (SHA-256 recorded in the installer manifest)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433549)