### PR TITLE
New version: PLFJY.ContextMenuMgrPlus version 1.7.5

### DIFF
--- a/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.installer.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.installer.yaml
@@ -1,0 +1,26 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus'
+PackageVersion: '1.7.5'
+InstallerType: inno
+Scope: machine
+UpgradeBehavior: install
+InstallModes:
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /VERYSILENT /NORESTART
+  SilentWithProgress: /SILENT /NORESTART
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5/ContextMenuMgrPlus-1.7.5-x64-self-contained-Setup.exe
+  InstallerSha256: 6da0261adab855977af501bd67dcaac5d41505d019db437109c63c26e8cff52d
+- Architecture: x86
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5/ContextMenuMgrPlus-1.7.5-x86-self-contained-Setup.exe
+  InstallerSha256: fd5a33730e7b6344c5bba91fb9e14afc34242471b5340334031d84b8f4689bab
+- Architecture: arm64
+  InstallerUrl: https://github.com/PLFJY/ContextMenuMgr/releases/download/v1.7.5/ContextMenuMgrPlus-1.7.5-arm64-self-contained-Setup.exe
+  InstallerSha256: c0ade569da8f19e5ba9d50eca2e7a9510f6ae08c9367f6646c8e1b2dd2c377f7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.en-US.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus'
+PackageVersion: '1.7.5'
+PackageLocale: en-US
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'A Windows context menu management tool.'
+Description: 'Context Menu Manager Plus manages Windows context menu entries, detects third-party additions, and helps users review unwanted menu items.'
+Tags:
+- 'context-menu'
+- 'windows'
+- 'shell'
+- 'registry'
+- 'wpf'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.zh-CN.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.zh-CN.yaml
@@ -1,0 +1,25 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus'
+PackageVersion: '1.7.5'
+PackageLocale: zh-CN
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'Windows 右键菜单管理工具。'
+Description: 'Context Menu Manager Plus 用于管理 Windows 右键菜单项，检测第三方新增项，并帮助用户审核不需要的菜单项。'
+Tags:
+- '右键菜单'
+- '上下文菜单'
+- 'Windows'
+- 'Shell'
+- '注册表'
+- 'WPF'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.zh-TW.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.locale.zh-TW.yaml
@@ -1,0 +1,25 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus'
+PackageVersion: '1.7.5'
+PackageLocale: zh-TW
+Publisher: PLFJY
+PublisherUrl: https://github.com/PLFJY
+PublisherSupportUrl: https://github.com/PLFJY/ContextMenuMgr/issues
+PackageName: 'Context Menu Manager Plus'
+PackageUrl: https://github.com/PLFJY/ContextMenuMgr
+License: GPL-3.0
+LicenseUrl: https://github.com/PLFJY/ContextMenuMgr/blob/main/LICENSE
+ShortDescription: 'Windows 右鍵選單管理工具。'
+Description: 'Context Menu Manager Plus 用於管理 Windows 右鍵選單項目，偵測第三方新增項目，並協助使用者審核不需要的選單項目。'
+Tags:
+- '右鍵選單'
+- '內容選單'
+- 'Windows'
+- 'Shell'
+- '登錄檔'
+- 'WPF'
+ReleaseNotesUrl: https://github.com/PLFJY/ContextMenuMgr/releases/tag/v1.7.5
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.yaml
+++ b/manifests/p/PLFJY/ContextMenuMgrPlus/1.7.5/PLFJY.ContextMenuMgrPlus.yaml
@@ -1,0 +1,8 @@
+# Created with ContextMenuMgr package manager automation
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 'PLFJY.ContextMenuMgrPlus'
+PackageVersion: '1.7.5'
+DefaultLocale: zh-CN
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Generated from PLFJY/ContextMenuMgr release v1.7.5.

Stable and Beta are mutually exclusive channels and share the same installer AppId and service identity intentionally.

The Beta package-manager channel only tracks GitHub Pre-releases. Stable GitHub Releases do not generate or update this Beta manifest. For Beta prereleases the package version is derived from the GitHub Release publish time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433562)