### PR TITLE
New package: makeev.alphai-tui version 0.22.0

### DIFF
--- a/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.installer.yaml
+++ b/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: makeev.alphai-tui
+PackageVersion: 0.22.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: alphai-tui.exe
+  PortableCommandAlias: alphai-tui
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/makeev/alphai-tui/releases/download/v0.22.0/alphai-tui-x86_64-pc-windows-msvc.zip
+  InstallerSha256: 3C765BBA05B9A3575141C2DCE808E3A85A7AAA78F63AFF53E59B854B3A544485
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.locale.en-US.yaml
+++ b/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: makeev.alphai-tui
+PackageVersion: 0.22.0
+PackageLocale: en-US
+Publisher: Mikhail Makeev
+PublisherUrl: https://github.com/makeev
+PublisherSupportUrl: https://github.com/makeev/alphai-tui/issues
+PackageName: alphai-tui
+PackageUrl: https://github.com/makeev/alphai-tui
+License: MIT
+LicenseUrl: https://github.com/makeev/alphai-tui/blob/HEAD/LICENSE
+ShortDescription: Bloomberg-style stock dashboard for the terminal with live quotes, candlestick charts, AI-scored news, SEC Form 4 insider filings and earnings reads
+Moniker: alphai-tui
+Tags:
+- bloomberg-terminal
+- earnings
+- finance
+- insider-trading
+- news
+- ratatui
+- rust
+- sec-edgar
+- stock-market
+- stock-ticker
+- stocks
+- terminal
+- tui
+ReleaseNotesUrl: https://github.com/makeev/alphai-tui/releases/tag/v0.22.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.yaml
+++ b/manifests/m/makeev/alphai-tui/0.22.0/makeev.alphai-tui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: makeev.alphai-tui
+PackageVersion: 0.22.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description
New package: `makeev.alphai-tui` version 0.22.0.

alphai-tui is an open-source (MIT) stock dashboard for the terminal, a single Rust binary built on ratatui: live quotes and candlestick charts next to AI-scored news, SEC Form 4 insider filings and earnings reads. Upstream: https://github.com/makeev/alphai-tui, release https://github.com/makeev/alphai-tui/releases/tag/v0.22.0.

The installer is the upstream `x86_64-pc-windows-msvc.zip` release asset (portable `alphai-tui.exe` at the archive root, alias `alphai-tui`). The SHA256 matches the `.sha256` file published alongside the asset. The manifest follows the shape of `achannarasappa.ticker` (zip / nested portable).

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` (authored on macOS, no Windows machine at hand; relying on the pipeline validation)
- [ ] Tested manifest locally with `winget install --manifest <path>` (same reason)
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433597)