### PR TITLE
New version: MarcoSburlino.Koinkat version 0.1.3

### DIFF
--- a/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.installer.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.3
+InstallerLocale: en-US
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17134.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+- interactive
+- silent
+UpgradeBehavior: install
+ReleaseDate: 2026-09-12
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/MarcoSburlino/Koinkat/releases/download/v0.1.3/Koinkat_0.1.3_x64-setup.exe
+  InstallerSha256: 44A3F301FD92E4BCD590EAAD982919BE9AAA4330A282FCDD3B672FCCB4E2C011
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.locale.en-US.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: Marco Sburlino
+PublisherUrl: https://github.com/MarcoSburlino
+PublisherSupportUrl: https://github.com/MarcoSburlino/Koinkat/issues
+PrivacyUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/docs/privacy-policy.md
+PackageName: Koinkat
+PackageUrl: https://github.com/MarcoSburlino/Koinkat
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/MarcoSburlino/Koinkat/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Marco Sburlino
+ShortDescription: Local-first multi-currency personal finance manager.
+Description: Koinkat is a local-first desktop app for tracking personal finances across multiple currencies and bank accounts. Your data lives on your device. There is no Koinkat server, no cloud sync, no telemetry and no account system. Connect European banks via PSD2 through Enable Banking, or use it manually.
+Moniker: koinkat
+Tags:
+- desktop
+- local-first
+- open-banking
+- personal-finance
+- privacy
+- psd2
+- react
+- rust
+- sqlite
+- tauri
+- typescript
+ReleaseNotesUrl: https://github.com/MarcoSburlino/Koinkat/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.yaml
+++ b/manifests/m/MarcoSburlino/Koinkat/0.1.3/MarcoSburlino.Koinkat.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MarcoSburlino.Koinkat
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
New version of an existing package: **MarcoSburlino.Koinkat 0.1.3**

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

This supersedes #426131 (0.1.2), which I am closing alongside this PR. 0.1.3
fixes a startup bug where the app could show the first-run "create your user"
screen while the user's database was sitting intact on disk, inviting them to
start over on top of their real data. Nothing was ever deleted, but 0.1.2 is
not the version users should be installing.

On Policy-Test-1.8, should it flag again: this package received a waiver for
0.1.0 in #410828, and the analysis on #426131 recommended a waiver on the same
grounds. Nothing relevant has changed - no purchases, no billing, no payment
capture, read-only PSD2 account information access only. `PrivacyUrl` is
present in this manifest.

Installer URL and SHA256 verified against the published release asset.

Upstream release: https://github.com/MarcoSburlino/Koinkat/releases/tag/v0.1.3

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433666)