### PR TITLE
CryptographicTriangles.TrianglesQt: fix 6.2.6.6 InstallerSha256

### DIFF
--- a/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.installer.yaml
+++ b/manifests/c/CryptographicTriangles/TrianglesQt/6.2.6.6/CryptographicTriangles.TrianglesQt.installer.yaml
@@ -11,6 +11,6 @@ Installers:
   - Architecture: x64
     InstallerType: exe
     InstallerUrl: https://github.com/SamiAhmed7777/triangles_v5/releases/download/v6.2.6.6/Cryptographic-Triangles-6.2.6.6-win-x64-setup.exe
-    InstallerSha256: 758e636b1bf7f78ced5ffcfaa7f28e5eb3bcfcca7ee0484e3280e5bc64dfd0d7
+    InstallerSha256: 9fba566bde69bdfd0d0ac885d59a19b4493b0bb56508d13a431062466bbd760a
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
#### Why: the v6.2.6.6 release asset was replaced on GitHub Releases shortly after #430596 merged, so the cataloged InstallerSha256 no longer matches and installs fail hash validation.

#### What: InstallerSha256 updated to the current asset (`9fba566bde69bdfd…`), verified against the live download from the release URL in the manifest. Single-file change, same pattern as the merged #431290 for 6.2.6.7.

(Replaces the closed #430608, which re-added the existing version.)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433688)