### PR TITLE
New package: XGo.LLGo.MinGW version 1.0.3

### DIFF
--- a/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.installer.yaml
+++ b/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: XGo.LLGo.MinGW
+PackageVersion: "1.0.3"
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+NestedInstallerFiles:
+- RelativeFilePath: bin/llgo.exe
+  PortableCommandAlias: llgo
+UpgradeBehavior: uninstallPrevious
+Commands:
+- llgo
+Installers:
+- Architecture: x64
+  InstallerUrl: "https://github.com/xgo-dev/llgo/releases/download/v1.0.3/llgo1.0.3.windows-amd64-mingw.zip"
+  InstallerSha256: ab8b66b7b468bbbb7595ed9833c4066fbb633d1e9b4cf86c4f3ab21861b3f79a
+- Architecture: arm64
+  InstallerUrl: "https://github.com/xgo-dev/llgo/releases/download/v1.0.3/llgo1.0.3.windows-arm64-mingw.zip"
+  InstallerSha256: ddbe3fe1c481064a3f5c15b88cde0cbc349f4f687bde256cbbd8d3b47c2b2f67
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.locale.en-US.yaml
+++ b/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: XGo.LLGo.MinGW
+PackageVersion: "1.0.3"
+PackageLocale: en-US
+Publisher: XGo
+PackageName: "LLGo (MinGW)"
+PackageUrl: https://github.com/xgo-dev/llgo
+License: Apache-2.0
+LicenseUrl: https://github.com/xgo-dev/llgo/blob/v1.0.3/LICENSE
+ShortDescription: Go compiler based on LLVM.
+InstallationNotes: "Native compilation requires Go, native Clang, SDK/CRT, pkg-config, and libraries for the MinGW ABI. See WINDOWS.md in the package. The bundled crosscompile/clang is the ESP toolchain. Use one LLGo ABI profile on PATH at a time."
+Documentations:
+- DocumentLabel: Windows dependencies
+  DocumentUrl: https://github.com/xgo-dev/llgo/blob/v1.0.3/WINDOWS.md
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.yaml
+++ b/manifests/x/XGo/LLGo/MinGW/1.0.3/XGo.LLGo.MinGW.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: XGo.LLGo.MinGW
+PackageVersion: "1.0.3"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Add LLGo 1.0.3 (MinGW) for Windows x64 and ARM64 using the official release ZIPs. The package exposes `llgo` as a portable command and includes the runtime sources and ESP toolchain. Native development dependencies are documented in the installation notes and the bundled WINDOWS.md.

All four public release ZIPs were checked against the published SHA-256 file and their release metadata. The manifests passed `winget validate`, installation from the public URLs, `llgo version`, and uninstallation on architecture-matched Windows CI runners. This is the first package version; no cross-version upgrade is claimed.

- Release: https://github.com/xgo-dev/llgo/releases/tag/v1.0.3
- Successful Windows validation: https://github.com/xgo-dev/llgo/actions/runs/34689502689
- Duplicate open PR search: none found before submission.
- This PR contains only the three manifest files for XGo.LLGo.MinGW 1.0.3, using validated schema 1.9.0.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433693)