### PR TITLE
New version: RobertoB.SussurroIA version 1.0.1

### DIFF
--- a/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.installer.yaml
+++ b/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RobertoB.SussurroIA
+PackageVersion: 1.0.1
+InstallerLocale: it-IT
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+ReleaseDate: 2026-08-23
+ProductCode: '{495E91FB-11A8-467F-A427-F37739067954}'
+AppsAndFeaturesEntries:
+- DisplayName: Sussurro IA
+  Publisher: sussurroia
+  ProductCode: '{495E91FB-11A8-467F-A427-F37739067954}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/robyberre-code/sussurro-ia/releases/download/v1.0.1/Sussurro.IA_1.0.1_x64_it-IT.msi
+  InstallerSha256: 2F141154F446F92A780DC506C6B1AB9D2FAEC122C6CC01706096996A107C6764
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.locale.en-US.yaml
+++ b/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RobertoB.SussurroIA
+PackageVersion: 1.0.1
+PackageLocale: en-US
+Publisher: RobertoB
+PublisherUrl: https://github.com/robyberre-code
+PublisherSupportUrl: https://github.com/robyberre-code/sussurro-ia/issues
+Author: RobertoB
+PackageName: Sussurro IA
+PackageUrl: https://github.com/robyberre-code/sussurro-ia
+License: Proprietary
+LicenseUrl: https://github.com/robyberre-code/sussurro-ia/blob/main/CONDIZIONI.md
+Copyright: Copyright (c) 2026 RobertoB. All rights reserved.
+ShortDescription: Voice dictation for Windows that types into the field you are already using.
+Description: |-
+  Sussurro IA is a voice dictation tool for Windows. Hold a global shortcut, speak, release, and the transcribed text is inserted directly into whatever field had focus — an email, a search box, a terminal, a comment box in another application. There is no scratchpad to copy from.
+  A second shortcut delivers the same dictation translated into English, Spanish or German, or rewritten as a well-formed prompt for a language model.
+  Dictation is in Italian. Audio is sent only while the shortcut is held, and only to the transcription service you configure with your own API key — Groq by default, or any OpenAI-compatible endpoint. Nothing is sent to the author of the program: there is no telemetry, no usage statistics and no update check.
+  Spoken commands turn words into what they represent: say "a capo" for a line break, "nuovo paragrafo" for a blank line, "emoji sorriso" for an emoji.
+  This is beta software, free to use and not open source. It is not code-signed, so Windows SmartScreen shows a warning on first run.
+Tags:
+- dictation
+- groq
+- italian
+- productivity
+- speech-to-text
+- transcription
+- voice
+- whisper
+ReleaseNotesUrl: https://github.com/robyberre-code/sussurro-ia/releases/tag/v1.0.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.locale.it-IT.yaml
+++ b/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.locale.it-IT.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: RobertoB.SussurroIA
+PackageVersion: 1.0.1
+PackageLocale: it-IT
+Publisher: RobertoB
+PublisherUrl: https://github.com/robyberre-code
+PublisherSupportUrl: https://github.com/robyberre-code/sussurro-ia/issues
+Author: RobertoB
+PackageName: Sussurro IA
+PackageUrl: https://github.com/robyberre-code/sussurro-ia
+License: Proprietario
+LicenseUrl: https://github.com/robyberre-code/sussurro-ia/blob/main/CONDIZIONI.md
+Copyright: Copyright (c) 2026 RobertoB. Tutti i diritti riservati.
+ShortDescription: Dettatura vocale per Windows che scrive nel campo in cui stavi gia' lavorando.
+Description: |-
+  Sussurro IA e' un programma di dettatura vocale per Windows. Tieni premuta una scorciatoia globale, parli, rilasci, e il testo trascritto viene inserito nel campo che aveva il fuoco: la mail che stavi scrivendo, la casella di ricerca, il terminale, il commento in un'altra applicazione. Non c'e' nessun blocco note da cui copiare.
+  Una seconda scorciatoia consegna la stessa dettatura tradotta in inglese, spagnolo o tedesco, oppure riscritta come richiesta ben posta da dare a un modello linguistico.
+  Si detta in italiano. L'audio esce solo mentre tieni premuta la combinazione, e va soltanto al servizio di trascrizione che configuri tu con una chiave API tua — Groq di preimpostazione, o qualunque endpoint compatibile con OpenAI. A chi ha realizzato il programma non arriva niente: nessuna telemetria, nessuna statistica d'uso, nessun controllo degli aggiornamenti.
+  Alcune parole dette diventano quello che rappresentano: «a capo» manda a capo, «nuovo paragrafo» stacca, «emoji sorriso» inserisce un'emoji.
+  E' una versione beta, gratuita e non open source. Non e' firmata con un certificato di code signing, quindi al primo avvio Windows SmartScreen mostra un avviso.
+Tags:
+- dettatura
+- groq
+- italiano
+- produttivita
+- trascrizione
+- voce
+ReleaseNotesUrl: https://github.com/robyberre-code/sussurro-ia/releases/tag/v1.0.1
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.yaml
+++ b/manifests/r/RobertoB/SussurroIA/1.0.1/RobertoB.SussurroIA.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RobertoB.SussurroIA
+PackageVersion: 1.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
### New version of an existing package

`RobertoB.SussurroIA` version **1.0.1** (version 1.0.0 was submitted in #418481).

Release: https://github.com/robyberre-code/sussurro-ia/releases/tag/v1.0.1

Changes from the 1.0.0 manifests, all mechanical:

- `PackageVersion` 1.0.0 -> 1.0.1 in all four files
- `InstallerUrl` points at the v1.0.1 MSI
- `InstallerSha256` recomputed from the published asset
- `ProductCode` / `AppsAndFeaturesEntries.ProductCode` updated: the WiX product code changed with this release (`{7F267FE9-...}` -> `{495E91FB-...}`)
- `ReleaseDate` -> 2026-08-23
- `ReleaseNotesUrl` -> v1.0.1

Descriptions, tags and licence metadata are unchanged.

---

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`? (validation succeeded)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not run - the manifest differs from the already-published 1.0.0 only in the fields listed above, and the installer hash was verified directly against the published asset.
- [x] Does your manifest conform to the [1.x schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433731)