### PR TITLE
New version: GRCSAC.NetVane version 1.4.0

### DIFF
--- a/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.installer.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.4.0
+# Matches the published requirement ("Windows 10 or 11, 64-bit"). Deliberately not stricter: this
+# field makes winget REFUSE to install below it, so it must not promise less than the website does.
+MinimumOSVersion: 10.0.10240.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-11
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://netvane.doorvane.com/downloads/NetVane-Setup-1.4.0.exe
+    InstallerSha256: C97CC5AD4612C08F53886BFD686302BA0161F338B956951F7F7DAEBCE012A6CA
+    # Inno's uninstall key is "{AppId}_is1"; AppId is pinned in installer/netvane.iss and must
+    # never change between versions, since it drives upgrade and uninstall detection.
+    ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+    AppsAndFeaturesEntries:
+      # UninstallDisplayName in the .iss is "NetVane {version}", so the ARP name is NOT the
+      # package name and changes every release. Without this, winget cannot correlate an
+      # existing install and would offer an upgrade that is already applied.
+      - DisplayName: NetVane 1.4.0
+        Publisher: GRCSAC
+        ProductCode: '{7B2E9D4C-3A1F-4E58-9C2A-1D6B0F3E9A21}_is1'
+        # No UpgradeCode: that is an MSI concept and this is an Inno installer. Putting the Inno
+        # AppId there would look right and mean nothing.
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.locale.en-US.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.locale.en-US.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.4.0
+PackageLocale: en-US
+# Publisher matches the Authenticode certificate subject (CN=GRCSAC), which is what Windows
+# displays. GRCSAC LLC is the legal entity and appears in Copyright and the EULA. Keeping these
+# distinct is deliberate - see the note in installer/netvane.iss.
+Publisher: GRCSAC
+PublisherUrl: https://netvane.doorvane.com
+PublisherSupportUrl: https://netvane.doorvane.com/support/
+PrivacyUrl: https://netvane.doorvane.com/privacy/
+Author: GRCSAC
+PackageName: NetVane
+PackageUrl: https://netvane.doorvane.com
+License: Proprietary
+LicenseUrl: https://netvane.doorvane.com/eula/
+Copyright: Copyright (c) 2026 GRCSAC LLC
+CopyrightUrl: https://netvane.doorvane.com/eula/
+ShortDescription: Maps the devices on your network and shows what they are exposing, entirely on your own machine
+Description: |-
+  NetVane finds the devices on your network - phones, laptops, cameras, smart-home gadgets -
+  and draws them as a live map: what each device is, how it connects, and what it is exposing,
+  with plain-language fixes.
+
+  Discovered service versions are matched against an NVD and CISA-KEV vulnerability database
+  bundled with the app, so exposure checks work with no internet connection. There is no cloud
+  service, no account and no agent: the app opens a local dashboard at 127.0.0.1:8787 and keeps
+  everything in a local database on the machine it runs on.
+
+  The free edition is not a trial. Discovery, the topology map, device identification, port
+  fingerprinting, CVE and KEV matching, report export and local backups are all perpetual, with
+  no account required, and vulnerability and fingerprint data updates stay free. Optional Pro and
+  Business licences add scheduled and background scanning, multiple subnets, credentialed
+  validation, extended retention, remote alerts, and compliance reporting for teams.
+
+  Installs per-user and needs no administrator rights. A portable build is also available from
+  the website for use without installing.
+Moniker: netvane
+Tags:
+  - cve
+  - device-discovery
+  - inventory
+  - lan
+  - network
+  - network-map
+  - network-monitor
+  - network-scanner
+  - offline
+  - port-scanner
+  - privacy
+  - security
+  - sysadmin
+  - topology
+  - vulnerability-scanner
+ReleaseNotes: |-
+  Phones and laptops change their Wi-Fi address on a schedule, and NetVane was counting each
+  change as a brand-new device. It now spots when two records look like the same physical device,
+  shows you why it thinks so, and asks - it never merges on its own. How hard it looks is now one
+  choice rather than seven switches, and every scan says plainly how much of your network it
+  actually reached, without estimating what it did not see. You can seal the devices you expect
+  and be told about anything else that turns up, see what software is listening rather than only
+  which devices exist, and read why NetVane believes a device is what it says - and overrule it.
+ReleaseNotesUrl: https://netvane.doorvane.com/changelog/
+Documentations:
+  - DocumentLabel: User guide
+    DocumentUrl: https://netvane.doorvane.com/docs/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.yaml
+++ b/manifests/g/GRCSAC/NetVane/1.4.0/GRCSAC.NetVane.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: GRCSAC.NetVane
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Update for GRCSAC.NetVane to 1.4.0. Installer URL and SHA-256 verified live; ARP entry verified on a real install (NetVane 1.4.0 / GRCSAC). Manifest validated with winget validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433734)