### PR TITLE
New version: vsDizzy.GitCompletion version 0.1.1

### DIFF
--- a/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.installer.yaml
+++ b/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.installer.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: vsDizzy.GitCompletion
+PackageVersion: 0.1.1
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    Scope: user
+    InstallerUrl: https://github.com/vsDizzy/git-completion/releases/download/v0.1.1/GitCompletion.msi
+    InstallerSha256: 93060E2E8C53A179E3830BACF2E944EF890E81B6F9CC842E984B583379CC40ED
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.locale.en-US.yaml
+++ b/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: vsDizzy.GitCompletion
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: vsDizzy
+PackageName: GitCompletion
+Moniker: git-completion
+PackageUrl: https://github.com/vsDizzy/git-completion
+License: MIT
+ShortDescription: Git completion for Windows PowerShell
+Description: Git command, branch, and option completion for Windows PowerShell.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.yaml
+++ b/manifests/v/vsDizzy/GitCompletion/0.1.1/vsDizzy.GitCompletion.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: vsDizzy.GitCompletion
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

New release of `vsDizzy.GitCompletion` version `0.1.1`.

- Package: `vsDizzy.GitCompletion`
- Version: `0.1.1`
- Installer: `GitCompletion.msi`
- Scope: `user`
- Moniker: `git-completion`
- SHA256: `93060E2E8C53A179E3830BACF2E944EF890E81B6F9CC842E984B583379CC40ED`
- Release: https://github.com/vsDizzy/git-completion/releases/tag/v0.1.1

Generated and validated by the GitHub Actions release workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433739)