### PR TITLE
New package: aleksandrreva-eng.llama-monitor version 0.1.0

### DIFF
--- a/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.installer.yaml
+++ b/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: aleksandrreva-eng.llama-monitor
+PackageVersion: 0.1.0
+InstallerType: wix
+Scope: machine
+ReleaseDate: 2026-09-12
+ProductCode: '{CBF7825E-5DEE-4868-A245-A5331F773DA2}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/aleksandrreva-eng/llama-monitor/releases/download/v0.1.0/llama-monitor_0.1.0_x64_en-US.msi
+  InstallerSha256: B56CA7CA476B110F4A8B82BC87FAA5ADC2464D9167FEB24C7DE9AFA50CE9D9DA
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.locale.en-US.yaml
+++ b/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: aleksandrreva-eng.llama-monitor
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: aleksandrreva-eng
+PublisherUrl: https://github.com/aleksandrreva-eng
+PackageName: llama-monitor
+PackageUrl: https://github.com/aleksandrreva-eng/llama-monitor
+License: MIT
+LicenseUrl: https://github.com/aleksandrreva-eng/llama-monitor/blob/main/LICENSE
+ShortDescription: Always-on-top desktop widget showing llama.cpp server context usage and inference speed
+Description: A borderless always-on-top widget for Windows 11 that shows the state of a local or remote llama.cpp server — context used and remaining with a progress bar, prefill and generation speed in tokens per second with a 30 second rolling average, and the loaded model with quantization, context size and build version. Supports multiple server profiles including llama.cpp, vLLM, Ollama and OpenAI-compatible cloud endpoints, plus LAN scanning to discover servers. Built with Tauri 2 and Svelte 4.
+Moniker: llama-monitor
+Tags:
+- llama-cpp
+- llm
+- local-llm
+- inference
+- monitoring
+- tauri
+- windows
+ReleaseNotesUrl: https://github.com/aleksandrreva-eng/llama-monitor/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.yaml
+++ b/manifests/a/aleksandrreva-eng/llama-monitor/0.1.0/aleksandrreva-eng.llama-monitor.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: aleksandrreva-eng.llama-monitor
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description

New package: `aleksandrreva-eng.llama-monitor` version `0.1.0`.

A borderless always-on-top desktop widget for Windows 11 that monitors a local or remote
llama.cpp server: context used and remaining with a progress bar, prefill and generation
speed in tokens per second with a 30 second rolling average, and the loaded model with
quantization, context size and build version. Also supports vLLM, Ollama and
OpenAI-compatible cloud endpoints as separate server profiles, plus LAN scanning to
discover servers without typing addresses.

- Upstream: https://github.com/aleksandrreva-eng/llama-monitor
- License: MIT
- Installer: WiX MSI, machine scope. Not code-signed, so SmartScreen shows a warning on
  first run.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #<!-- Issue Number -->

## 📦 Manifest Checklist

- [x] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.

---

`winget validate` passed with no errors. `winget install` was deliberately not run on the
submission machine — the installer is machine-scope and would require an elevated install;
the manifest was written from the actual MSI metadata instead (ProductCode
`{CBF7825E-5DEE-4868-A245-A5331F773DA2}`, `ALLUSERS=1`, so `Scope: machine`), and the
installer SHA256 was taken from the released artifact.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433748)