### PR TITLE
New package: DiscWright.DiscWright version 0.7.1

### DIFF
--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
@@ -1,0 +1,19 @@
+﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: DiscWright.DiscWright
+PackageVersion: 0.7.1
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{20F71A81-9D66-445E-BDC3-394B940F190E}_is1'
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/lazardjokovic/discwright/releases/download/v0.7.1/DiscWright-0.7.1-setup.exe
+  InstallerSha256: 70A4788B2C18306F27B3B599B4EFA7DCA900079153571530D7F338FB1DD87DC3
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
@@ -1,4 +1,5 @@
-﻿PackageIdentifier: DiscWright.DiscWright
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0
@@ -15,4 +16,4 @@ Installers:
   InstallerUrl: https://github.com/lazardjokovic/discwright/releases/download/v0.7.1/DiscWright-0.7.1-setup.exe
   InstallerSha256: 70A4788B2C18306F27B3B599B4EFA7DCA900079153571530D7F338FB1DD87DC3
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.installer.yaml
@@ -1,5 +1,4 @@
-﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
-PackageIdentifier: DiscWright.DiscWright
+﻿PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 InstallerLocale: en-US
 MinimumOSVersion: 10.0.0.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
@@ -1,4 +1,5 @@
-﻿PackageIdentifier: DiscWright.DiscWright
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 PackageLocale: en-US
 Publisher: DiscWright
@@ -35,4 +36,4 @@ Tags:
 - backup
 ReleaseNotesUrl: https://github.com/lazardjokovic/discwright/releases/tag/v0.7.1
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
@@ -1,5 +1,4 @@
-﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
-PackageIdentifier: DiscWright.DiscWright
+﻿PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 PackageLocale: en-US
 Publisher: DiscWright
@@ -22,7 +21,7 @@ Description: |-
   add-ons live under the game they belong to, and a set too big for one disc can
   be split across several.
 
-  Burning is out of scope on purpose - DiscWright writes the ISO and leaves
+  Burning is out of scope on purpose. DiscWright writes the ISO and leaves
   burning to the tools that already do it well.
 Moniker: discwright
 Tags:

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.locale.en-US.yaml
@@ -1,0 +1,39 @@
+﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: DiscWright.DiscWright
+PackageVersion: 0.7.1
+PackageLocale: en-US
+Publisher: DiscWright
+PublisherUrl: https://discwright.com
+PublisherSupportUrl: https://github.com/lazardjokovic/discwright/issues
+PackageName: DiscWright
+PackageUrl: https://discwright.com
+License: MIT
+LicenseUrl: https://github.com/lazardjokovic/discwright/blob/main/LICENSE
+Copyright: Copyright (c) 2026 lazardjokovic
+ShortDescription: Turn a GOG offline installer into a real game disc, with the game's own icon and title in This PC and a menu when you double-click it.
+Description: |-
+  DiscWright turns a folder of GOG offline installers into a burnable ISO that
+  behaves like a game disc from a box: the drive carries the game's own icon and
+  label in This PC, and double-clicking it opens an autorun menu with Play,
+  Install, Manual and Extras.
+
+  It builds the ISO with the disc imaging support already in Windows, so there
+  is nothing bundled and nothing to trust. More than one game fits on a disc,
+  add-ons live under the game they belong to, and a set too big for one disc can
+  be split across several.
+
+  Burning is out of scope on purpose - DiscWright writes the ISO and leaves
+  burning to the tools that already do it well.
+Moniker: discwright
+Tags:
+- gog
+- iso
+- disc
+- burn
+- games
+- autorun
+- retro
+- backup
+ReleaseNotesUrl: https://github.com/lazardjokovic/discwright/releases/tag/v0.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
@@ -1,0 +1,6 @@
+﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: DiscWright.DiscWright
+PackageVersion: 0.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
@@ -1,5 +1,6 @@
-﻿PackageIdentifier: DiscWright.DiscWright
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
+++ b/manifests/d/DiscWright/DiscWright/0.7.1/DiscWright.DiscWright.yaml
@@ -1,5 +1,4 @@
-﻿# Created for DiscWright 0.7.1 - see packaging/winget/New-WingetManifest.ps1
-PackageIdentifier: DiscWright.DiscWright
+﻿PackageIdentifier: DiscWright.DiscWright
 PackageVersion: 0.7.1
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
### Pull request has been created with the following manifest

- Package: `DiscWright.DiscWright`
- Version: `0.7.1`

DiscWright turns a folder of GOG offline installers into a burnable ISO that behaves like a game disc from a box: the drive carries the game's own icon and label in This PC, and double-clicking it opens an autorun menu. It builds the ISO with the disc imaging support already in Windows, so nothing is bundled.

- Homepage: https://discwright.com
- Repository: https://github.com/lazardjokovic/discwright
- Release: https://github.com/lazardjokovic/discwright/releases/tag/v0.7.1
- License: MIT

### Checklist

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/add?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

### Notes

Installer is a per-user Inno Setup package, so it needs no elevation. `Scope: user` and the `ProductCode` reflect that; the ProductCode matches the uninstall key Inno registers.

Validated and installed locally end to end: `winget install --manifest` downloaded from the release URL, verified the hash, installed, and uninstalled cleanly with nothing left behind.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433767)