### PR TITLE
New version: kbirger.WinTabber version 0.2.2

### DIFF
--- a/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.installer.yaml
+++ b/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: kbirger.WinTabber
+PackageVersion: 0.2.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.26100.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: WinTabberUI.exe
+  PortableCommandAlias: wintabber
+ReleaseDate: 2026-09-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/kbirger/wintabber/releases/download/v0.2.2/WinTabber-0.2.2-win-x64.zip
+  InstallerSha256: 5CC80D0C45BB59A894F828FCFEDC984A34AA678E2E70FE3AB9A03AEF0B9BC844
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.locale.en-US.yaml
+++ b/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: kbirger.WinTabber
+PackageVersion: 0.2.2
+PackageLocale: en-US
+Publisher: Kirill Birger
+PublisherUrl: https://github.com/kbirger
+PublisherSupportUrl: https://github.com/kbirger/wintabber/issues
+Author: Kirill Birger
+PackageName: WinTabber
+PackageUrl: https://github.com/kbirger/wintabber
+License: MIT
+LicenseUrl: https://github.com/kbirger/wintabber/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Kirill Birger
+ShortDescription: A Windows desktop utility for window switching and window management.
+Description: |-
+  WinTabber is a Windows desktop utility for window switching and window management. The main
+  feature is a switcher that shows the windows of the application that has focus, not every window
+  on the desktop. It also includes window sleep, floating window thumbnails, a CapsLock hyper key, a
+  desktop dock, and an alpha media and audio control panel.
+Tags:
+- window-manager
+- window-switcher
+- alt-tab
+- task-switcher
+- productivity
+ReleaseNotesUrl: https://github.com/kbirger/wintabber/releases/tag/v0.2.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.yaml
+++ b/manifests/k/kbirger/WinTabber/0.2.2/kbirger.WinTabber.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: kbirger.WinTabber
+PackageVersion: 0.2.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Description

Adds the first manifest for WinTabber, a Windows desktop utility for window switching and window management.

- Package: kbirger.WinTabber
- Version: 0.2.2
- Installer: zip (nested portable exe, x64), self-contained, no admin rights required
- License: MIT
- Source: https://github.com/kbirger/wintabber

## Checklist

- [x] I've verified the exact `PackageIdentifier`, `PackageVersion` and correct manifest type in this PR title/using the correct template.
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does the version of your manifest match the version of the installer it's referencing?
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) previously? (unknown — first submission from this account; the CLA bot will confirm)
- [x] Have you checked the source and destination URLs?