### PR TITLE
New package: Gramdown.CLI version 1.0.0

### DIFF
--- a/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.installer.yaml
+++ b/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Gramdown.CLI
+PackageVersion: 1.0.0
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: portable
+Commands:
+  - gramdown
+InstallModes:
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-09-08
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tobysmith568/gramdown/releases/download/v1.0.0/gramdown-windows-x64.exe
+    InstallerSha256: 108B426795C7215FB04D04BD32851B067C76927ED01BFAC50D87BE7E1A148271
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.locale.en-US.yaml
+++ b/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Gramdown.CLI
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Gramdown
+PublisherUrl: https://gramdown.tobythe.dev
+PublisherSupportUrl: https://github.com/tobysmith568/gramdown/issues
+Author: Toby Smith
+PackageName: gramdown
+PackageUrl: https://gramdown.tobythe.dev
+License: ISC
+LicenseUrl: https://github.com/tobysmith568/gramdown/blob/main/LICENSE.md
+ShortDescription: Turn a Grammarly .docx export into clean, GitHub-Flavored Markdown, from the command line.
+Moniker: gramdown
+Tags:
+  - grammarly
+  - docx
+  - markdown
+  - gfm
+  - converter
+  - cli
+ReleaseNotesUrl: https://github.com/tobysmith568/gramdown/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.yaml
+++ b/manifests/g/Gramdown/CLI/1.0.0/Gramdown.CLI.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Gramdown.CLI
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## 📖 Description

Adds the WinGet manifest for `Gramdown.CLI` version `1.0.0` — [gramdown](https://gramdown.tobythe.dev), a CLI that turns a Grammarly `.docx` export into clean, GitHub-Flavored Markdown. Installer type is `portable`, pointing at the `gramdown-windows-x64.exe` asset already published on the project's [GitHub Releases](https://github.com/tobysmith568/gramdown/releases/tag/v1.0.0).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)

## 📦 Manifest Checklist

- [x] Checked that there aren't other open pull requests for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [x] Validated manifest locally with `winget validate --manifest <path>`
- [x] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433798)