### PR TITLE
Fixed InstallerUrl-s: TerryReese.MarcEdit version 7.8.25

### DIFF
--- a/manifests/t/TerryReese/MarcEdit/7.8.25/TerryReese.MarcEdit.installer.yaml
+++ b/manifests/t/TerryReese/MarcEdit/7.8.25/TerryReese.MarcEdit.installer.yaml
@@ -1,24 +1,19 @@
-# Created with YamlCreate.ps1 Dumplings Mod
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: TerryReese.MarcEdit
 PackageVersion: 7.8.25
+ReleaseDate: 2026-07-04
 InstallerSwitches:
   InstallLocation: APPDIR="<INSTALLPATH>"
 FileExtensions:
 - mrc
 - mrk
-ReleaseDate: 2026-07-04
 Installers:
 - Architecture: x64
   InstallerType: exe
   Scope: user
-  InstallerUrl: https://marcedit.reeset.net/software/marcedit75/MarcEdit_7_7_User_Install_final.exe
-  InstallerSha256: BE42279282BDAC284C01591688A8CA44845DE2C105C600F7ABD88E2EBF7E769F
-  InstallModes:
-  - interactive
-  - silent
-  - silentWithProgress
+  InstallerUrl: https://marcedit.reeset.net/software/marcedit75/MarcEdit_7_8_User_Install.exe
+  InstallerSha256: cf72ba12cb894c0a386ac2028e4ac72938240be2598adee8509ba317b5b5de7d
   InstallerSwitches:
     Silent: /exenoui /quiet /norestart
     SilentWithProgress: /exenoui /passive /norestart
@@ -70,8 +65,8 @@ Installers:
 - Architecture: x64
   InstallerType: msi
   Scope: machine
-  InstallerUrl: https://marcedit.reeset.net/software/marcedit75/MarcEdit_7_7_org_installer.msi
-  InstallerSha256: 9D09FEECB7F3127595F093A88E5358B6C71FEEC6170247940029561046EDB277
+  InstallerUrl: https://marcedit.reeset.net/software/marcedit75/MarcEdit_7_8_org_installer.msi
+  InstallerSha256: 9d09feecb7f3127595f093a88e5358b6c71feec6170247940029561046edb277
   ProductCode: MarcEdit 7.8 7.8.25
   AppsAndFeaturesEntries:
   - InstallerType: exe


### PR DESCRIPTION
<!-- PR Title Format: "New package: Publisher.Name version X.Y.Z" or "Update: Publisher.Name to X.Y.Z" -->

## 📖 Description
Previously, the manifest was incorrectly using the installer URLs of 7.7.x instead of 7.8.x.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue (if applicable)
  <!-- Example: Resolves #328283 -->
  - Resolves #[Issue Number]

## 📦 Manifest Checklist

- [ ] Checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change
- [x] This PR only modifies one (1) manifest
- [ ] Validated manifest locally with `winget validate --manifest <path>` ([validation guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
- [ ] Tested manifest locally with `winget install --manifest <path>`
- [x] Manifest conforms to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)

> **Note:** `<path>` is the directory containing the manifest you're submitting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433817)