### PR TITLE
New version: MSKazemi.YazSes version 2.36.0

### DIFF
--- a/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.installer.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.36.0
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{F3E8B8A4-1B6C-4F24-9BE8-9B7E58E9C4A2}_is1'
+MinimumOSVersion: 10.0.19041.0
+ReleaseDate: 2026-08-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MSKazemi/yazses/releases/download/v2.36.0/YazSes-2.36.0-windows-x64.exe
+    InstallerSha256: 6DE31B891D20BB35E531B0D47CB057B5B561920D9AE8140A95A2F50CF36B1204
+  - Architecture: arm64
+    InstallerUrl: https://github.com/MSKazemi/yazses/releases/download/v2.36.0/YazSes-2.36.0-windows-arm64.exe
+    InstallerSha256: 187A31129F3102C3E06F81526FB19E7A3C804BC55D84D8D74DAF208DA2DF5C02
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.locale.en-US.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.locale.en-US.yaml
@@ -1,0 +1,49 @@
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.36.0
+PackageLocale: en-US
+Publisher: MSKazemi
+PublisherUrl: https://github.com/MSKazemi
+PublisherSupportUrl: https://github.com/MSKazemi/yazses/issues
+Author: Mohsen Seyedkazemi Ardebili
+PackageName: YazSes
+PackageUrl: https://mskazemi.com/yazses/
+License: Apache-2.0
+LicenseUrl: https://github.com/MSKazemi/yazses/blob/main/LICENSE
+Copyright: Copyright 2026 Mohsen Seyedkazemi Ardebili
+ShortDescription: Offline voice dictation — hold a key, speak, release. No cloud, no API key, no subscription.
+Description: |-
+  YazSes is a free, open-source, offline voice dictation and speech-to-text
+  tool. Hold a key, speak, release — your words are transcribed on your own CPU
+  and typed into whatever window has focus.
+
+  Everything runs on-device with faster-whisper. There is no cloud service, no
+  API key, no account and no subscription, and no telemetry of any kind. Use it
+  when audio must not be sent to a third party — a confidential meeting, an
+  air-gapped machine, or simply a preference not to rent your own voice.
+
+  It also transcribes recordings (`yazses transcribe talk.m4a`, with optional
+  speaker labels) and can capture a whole meeting into a speaker-labelled
+  transcript with locally generated minutes.
+Moniker: yazses
+Tags:
+  - voice
+  - dictation
+  - voice-typing
+  - speech-to-text
+  - speech-recognition
+  - whisper
+  - transcription
+  - offline
+  - on-device
+  - privacy
+  - accessibility
+  - productivity
+  - open-source
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://mskazemi.com/yazses/
+  - DocumentLabel: Windows install guide
+    DocumentUrl: https://mskazemi.com/yazses/windows-install.html
+ReleaseNotesUrl: https://github.com/MSKazemi/yazses/releases/tag/v2.36.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.yaml
+++ b/manifests/m/MSKazemi/YazSes/2.36.0/MSKazemi.YazSes.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.36.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Pull request has been created with the following:

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

Version update for `MSKazemi.YazSes`, 2.35.0 → 2.36.0.

I am the maintainer of this project.

Both installers are checksummed against the real release assets. The SHA256 values here were derived by streaming and hashing the published `.exe` files, then cross-checked against the `SHA256SUMS.txt` published by the same release workflow:

| Architecture | Asset | SHA256 |
|---|---|---|
| x64 | `YazSes-2.36.0-windows-x64.exe` | `6DE31B891D20BB35E531B0D47CB057B5B561920D9AE8140A95A2F50CF36B1204` |
| arm64 | `YazSes-2.36.0-windows-arm64.exe` | `187A31129F3102C3E06F81526FB19E7A3C804BC55D84D8D74DAF208DA2DF5C02` |

The manifests are structurally identical to the 2.35.0 predecessor merged in #416963; the only changes are `PackageVersion`, `ReleaseDate`, the two `InstallerUrl`s, the two `InstallerSha256`s, and `ReleaseNotesUrl`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-pkgs/pull/433910)